### PR TITLE
Add Archgun support and fix browse tabs wrapping

### DIFF
--- a/src/app/builds/[slug]/page.tsx
+++ b/src/app/builds/[slug]/page.tsx
@@ -124,6 +124,11 @@ export default async function BuildPage({ params }: BuildPageProps) {
   let compatibleArcanes: Arcane[] = []
   if (isWarframeCategory) {
     compatibleArcanes = getArcanesForSlot("warframe")
+  } else if (category === "archwing") {
+    compatibleArcanes = [
+      ...getArcanesForSlot("primary"),
+      ...getArcanesForSlot("secondary"),
+    ]
   } else if (category === "primary") {
     compatibleArcanes = getArcanesForSlot("primary")
   } else if (category === "secondary") {

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -84,6 +84,11 @@ export default async function CreatePage({ searchParams }: CreatePageProps) {
         let compatibleArcanes: Arcane[] = []
         if (["warframes", "necramechs"].includes(category)) {
           compatibleArcanes = getArcanesForSlot("warframe")
+        } else if (category === "archwing") {
+          compatibleArcanes = [
+            ...getArcanesForSlot("primary"),
+            ...getArcanesForSlot("secondary"),
+          ]
         } else if (["primary", "secondary", "melee"].includes(category)) {
           compatibleArcanes = getArcanesForSlot(
             category as "primary" | "secondary" | "melee",
@@ -135,6 +140,11 @@ export default async function CreatePage({ searchParams }: CreatePageProps) {
     let compatibleArcanes: Arcane[] = []
     if (["warframes", "necramechs"].includes(category)) {
       compatibleArcanes = getArcanesForSlot("warframe")
+    } else if (category === "archwing") {
+      compatibleArcanes = [
+        ...getArcanesForSlot("primary"),
+        ...getArcanesForSlot("secondary"),
+      ]
     } else if (["primary", "secondary", "melee"].includes(category)) {
       compatibleArcanes = getArcanesForSlot(
         category as "primary" | "secondary" | "melee",
@@ -201,6 +211,11 @@ export default async function CreatePage({ searchParams }: CreatePageProps) {
     let compatibleArcanes: Arcane[] = []
     if (["warframes", "necramechs"].includes(category)) {
       compatibleArcanes = getArcanesForSlot("warframe")
+    } else if (category === "archwing") {
+      compatibleArcanes = [
+        ...getArcanesForSlot("primary"),
+        ...getArcanesForSlot("secondary"),
+      ]
     } else if (["primary", "secondary", "melee"].includes(category)) {
       compatibleArcanes = getArcanesForSlot(
         category as "primary" | "secondary" | "melee",

--- a/src/components/browse/category-tabs.tsx
+++ b/src/components/browse/category-tabs.tsx
@@ -71,7 +71,7 @@ export function CategoryTabs({
       onValueChange={linkNavigation ? undefined : handleCategoryChange}
       className={className}
     >
-      <TabsList className="bg-muted/50 h-auto flex-wrap justify-start p-1">
+      <TabsList className="bg-muted/50 !h-auto w-full flex-wrap justify-start p-1">
         {tabs.map((category, index) => {
           const value = category.id
           return (

--- a/src/components/build-editor/build-container.tsx
+++ b/src/components/build-editor/build-container.tsx
@@ -202,6 +202,29 @@ export function BuildContainer({
     [activeSlotId, placeArcaneInSlot, setActiveSlotId],
   )
 
+  // --- Per-slot arcane filtering for Archguns ---
+  // Archguns have 2 arcane slots: slot 0 = primary arcanes, slot 1 = secondary arcanes
+  const filteredArcanes = useMemo(() => {
+    if (category !== "archwing") return compatibleArcanes
+    if (!activeSlotId?.startsWith("arcane-")) return compatibleArcanes
+
+    const slotIndex = parseInt(activeSlotId.replace("arcane-", ""))
+    if (slotIndex === 0) {
+      // Primary arcanes only
+      return compatibleArcanes.filter((a) =>
+        a.type?.toLowerCase().includes("primary"),
+      )
+    }
+    if (slotIndex === 1) {
+      // Secondary arcanes only
+      return compatibleArcanes.filter((a) => {
+        const t = a.type?.toLowerCase() ?? ""
+        return t.includes("secondary") || t.includes("pax")
+      })
+    }
+    return compatibleArcanes
+  }, [category, compatibleArcanes, activeSlotId])
+
   // --- Keyboard navigation ---
 
   const isWarframeOrNecramech = isWarframeCategory(category)
@@ -320,7 +343,7 @@ export function BuildContainer({
             <BuildEditorSearchPanel
               activeSlotId={activeSlotId}
               activeDragItem={activeDragItem}
-              compatibleArcanes={compatibleArcanes}
+              compatibleArcanes={filteredArcanes}
               compatibleMods={compatibleMods}
               usedArcaneNames={usedArcaneNames}
               usedModNames={usedModNames}

--- a/src/components/build-editor/hooks/use-build-state.ts
+++ b/src/components/build-editor/hooks/use-build-state.ts
@@ -179,6 +179,12 @@ export function createInitialBuildState(
     }
     baseState.shardSlots = [null, null, null, null, null]
     baseState.arcaneSlots = [null, null]
+  } else if (
+    category === "archwing" &&
+    (item as { type?: string }).type === "Arch-Gun"
+  ) {
+    // Archguns get 2 arcane slots: 1 primary + 1 secondary arcane
+    baseState.arcaneSlots = [null, null]
   } else if (isWeaponCategory(category)) {
     baseState.arcaneSlots = [null]
   }

--- a/src/lib/warframe/mods.ts
+++ b/src/lib/warframe/mods.ts
@@ -167,6 +167,14 @@ export function getModsByCompatibility(compatibility: ModCompatibility): Mod[] {
         )
       case "Necramech":
         return modType.includes("necramech")
+      case "Archgun":
+        return compatName === "archgun" || modType.includes("arch-gun")
+      case "Archmelee":
+        return compatName === "archmelee" || modType.includes("arch-melee")
+      case "Archwing":
+        return (
+          compatName === "archwing" || modType.includes("archwing")
+        )
       default:
         return false
     }
@@ -188,6 +196,7 @@ export function getModsForCategory(category: string): Mod[] {
     "exalted-weapons": ["Rifle", "Pistol", "Melee"],
     necramechs: ["Necramech"],
     companions: ["Companion"],
+    archwing: ["Archwing", "Archgun", "Archmelee"],
   }
 
   const compatibilities = categoryMap[category]
@@ -257,6 +266,7 @@ export function getModsForItem(item: {
     if (category === "warframes") return getModsForCategory("warframes")
     if (category === "necramechs") return getModsForCategory("necramechs")
     if (category === "companions") return getModsForCategory("companions")
+    if (category === "archwing") return getModsForCategory("archwing")
     return []
   }
 
@@ -281,6 +291,21 @@ export function getModsForItem(item: {
     // Melee weapons
     if (itemTypeLower === "melee") {
       return isMeleeMod(compatName, modType)
+    }
+
+    // Arch-Gun
+    if (itemTypeLower === "arch-gun") {
+      return compatName === "archgun" || modType.includes("arch-gun")
+    }
+
+    // Arch-Melee
+    if (itemTypeLower === "arch-melee") {
+      return compatName === "archmelee" || modType.includes("arch-melee")
+    }
+
+    // Archwing
+    if (itemTypeLower === "archwing") {
+      return compatName === "archwing" || modType.includes("archwing")
     }
 
     // Exalted weapons — WFCD data uses type "Exalted Weapon" for all.


### PR DESCRIPTION
## Changes

- **Archgun arcane support**: Add arcane slot filtering for Archguns with 2 slots (primary + secondary arcanes)
  - Updated `BuildContainer` with `filteredArcanes` logic
  - Modified `use-build-state.ts` to initialize 2 arcane slots for Arch-Gun items
  - Added arcane filtering in create and build pages

- **Mod compatibility**: Extended `getModsForCategory()` and `getModsForItem()` to support Archgun, Archmelee, and Archwing mod types in `src/lib/warframe/mods.ts`

- **UI fixes**: Added `!h-auto w-full` to CategoryTabs to prevent height constraint and allow proper wrapping of tabs