### PR TITLE
Add Archwing and Arch-Gun support with stat calculations

### DIFF
--- a/src/components/build-editor/item-sidebar.tsx
+++ b/src/components/build-editor/item-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   isWeaponCategory,
   isGunCategory,
   isMeleeCategory,
+  isArchwingCategory,
 } from "@/lib/warframe/categories"
 import { getImageUrl } from "@/lib/warframe/images"
 import type {
@@ -111,10 +112,20 @@ export function ItemSidebar({
   // Only use calculated stats if item was provided
   const calculatedStats = item ? calculatedStatsResult : null
 
+  const isArchwing = isArchwingCategory(buildState.itemCategory)
+  const isArchwingFrame = isArchwing && item?.category === "Archwing"
+  const isArchwingWeapon = isArchwing && !isArchwingFrame
+  const isArchwingGun = isArchwing && item?.category === "Arch-Gun"
+
   const isWarframeOrNecramech = isWarframeCategory(buildState.itemCategory)
   const isWeapon = isWeaponCategory(buildState.itemCategory)
   const isMelee = isMeleeCategory(buildState.itemCategory)
   const isGun = isGunCategory(buildState.itemCategory)
+
+  // Combined flags that include archwing sub-types
+  const showWarframeStats = isWarframeOrNecramech || isArchwingFrame
+  const showWeaponStats = isWeapon || isArchwingWeapon
+  const showGunStats = isGun || isArchwingGun
 
   // Reactor for warframes/necramechs, Catalyst for weapons
   const capacityBoosterLabel = isWarframeOrNecramech ? "Reactor" : "Catalyst"
@@ -165,7 +176,7 @@ export function ItemSidebar({
   return (
     <div className="flex h-full flex-col">
       {/* Abilities */}
-      {isWarframeOrNecramech && abilities.length > 0 && (
+      {showWarframeStats && abilities.length > 0 && (
         <div className="flex justify-around p-3">
           {abilities.slice(0, 4).map((originalAbility, i) => {
             const displayAbility = getDisplayAbility(i, originalAbility)
@@ -256,7 +267,7 @@ export function ItemSidebar({
         )}
 
       {/* Separator after abilities/shards, before capacity - only if there's content above */}
-      {isWarframeOrNecramech && <Separator />}
+      {showWarframeStats && <Separator />}
 
       {/* Capacity */}
       <div className="flex flex-col gap-3 p-3">
@@ -311,7 +322,7 @@ export function ItemSidebar({
       <Separator />
 
       {/* Warframe Base Stats - Calculated */}
-      {isWarframeOrNecramech && warframeStats && (
+      {showWarframeStats && warframeStats && (
         <div className="flex flex-col gap-2 p-3">
           <CalculatedStatRow label="Energy" stat={warframeStats.energy} />
           <CalculatedStatRow label="Health" stat={warframeStats.health} />
@@ -326,7 +337,7 @@ export function ItemSidebar({
       )}
 
       {/* Warframe Base Stats - Fallback to static display */}
-      {isWarframeOrNecramech && !warframeStats && (
+      {showWarframeStats && !warframeStats && (
         <div className="flex flex-col gap-2 p-3">
           <SimpleStatRow
             label="Energy"
@@ -352,7 +363,7 @@ export function ItemSidebar({
       )}
 
       {/* Weapon Stats - Calculated */}
-      {isWeapon && weaponStats && weaponStats.attackModes.length > 0 && (
+      {showWeaponStats && weaponStats && weaponStats.attackModes.length > 0 && (
         <div className="flex flex-col gap-2 p-3">
           {/* For multiple attack modes, show shared stats first */}
           {weaponStats.attackModes.length > 1 && (
@@ -377,13 +388,13 @@ export function ItemSidebar({
                 stat={weaponStats.attackModes[0].fireRate}
                 format="decimal"
               />
-              {weaponStats.attackModes[0].magazineSize && isGun && (
+              {weaponStats.attackModes[0].magazineSize && showGunStats && (
                 <CalculatedStatRow
                   label="Magazine"
                   stat={weaponStats.attackModes[0].magazineSize}
                 />
               )}
-              {weaponStats.attackModes[0].reloadTime && isGun && (
+              {weaponStats.attackModes[0].reloadTime && showGunStats && (
                 <CalculatedStatRow
                   label="Reload Time"
                   stat={weaponStats.attackModes[0].reloadTime}
@@ -444,13 +455,13 @@ export function ItemSidebar({
                     stat={mode.fireRate}
                     format="decimal"
                   />
-                  {mode.magazineSize && isGun && (
+                  {mode.magazineSize && showGunStats && (
                     <CalculatedStatRow
                       label="Magazine"
                       stat={mode.magazineSize}
                     />
                   )}
-                  {mode.reloadTime && isGun && (
+                  {mode.reloadTime && showGunStats && (
                     <CalculatedStatRow
                       label="Reload Time"
                       stat={mode.reloadTime}
@@ -490,7 +501,7 @@ export function ItemSidebar({
       )}
 
       {/* Weapon Stats - Fallback to static display */}
-      {isWeapon && !weaponStats && (
+      {showWeaponStats && !weaponStats && (
         <div className="flex flex-col gap-2 p-3">
           <SimpleStatRow
             label="Total Damage"
@@ -524,7 +535,7 @@ export function ItemSidebar({
             label="Fire Rate"
             value={itemStats?.fireRate?.toFixed(2) ?? "—"}
           />
-          {isGun && (
+          {showGunStats && (
             <>
               <SimpleStatRow
                 label="Magazine"
@@ -564,7 +575,7 @@ export function ItemSidebar({
       )}
 
       {/* Ability Stats - Calculated */}
-      {isWarframeOrNecramech && warframeStats && (
+      {showWarframeStats && warframeStats && (
         <>
           <Separator />
           <div className="flex flex-col gap-2 p-3">
@@ -593,7 +604,7 @@ export function ItemSidebar({
       )}
 
       {/* Ability Stats - Fallback to static display */}
-      {isWarframeOrNecramech && !warframeStats && (
+      {showWarframeStats && !warframeStats && (
         <>
           <Separator />
           <div className="flex flex-col gap-2 p-3">

--- a/src/lib/warframe/categories.ts
+++ b/src/lib/warframe/categories.ts
@@ -184,3 +184,10 @@ export function isMeleeCategory(category: BrowseCategory): boolean {
 export function isCompanionCategory(category: BrowseCategory): boolean {
   return category === "companions"
 }
+
+/**
+ * Check if a category is the archwing category
+ */
+export function isArchwingCategory(category: BrowseCategory): boolean {
+  return category === "archwing"
+}

--- a/src/lib/warframe/stats/index.ts
+++ b/src/lib/warframe/stats/index.ts
@@ -10,6 +10,14 @@ export { calculateWeaponStats } from "./weapon-stats"
 export { buildHasConditionalMods } from "./stat-engine"
 
 /**
+ * Check if an archwing-category item is a frame (vs a weapon)
+ * WFCD category "Archwing" = the vehicle, "Arch-Gun"/"Arch-Melee" = weapons
+ */
+function isArchwingFrame(item: BrowseableItem): boolean {
+  return item.category === "Archwing"
+}
+
+/**
  * Main entry point - calculate all stats for a build
  */
 export function calculateStats(
@@ -34,6 +42,30 @@ export function calculateStats(
     category === "secondary" ||
     category === "melee"
   ) {
+    return {
+      weapon: calculateWeaponStats(
+        item as Gun | Melee,
+        buildState,
+        showMaxStacks,
+      ),
+    }
+  }
+
+  // Archwing category includes Archwing frames + Arch-Gun/Arch-Melee weapons
+  if (category === "archwing") {
+    if (isArchwingFrame(item)) {
+      // Archwing frames have warframe-like stats (health, shield, armor, energy)
+      // WFCD data already includes rank-30 values, so skip rank-up bonuses
+      return {
+        warframe: calculateWarframeStats(
+          item as Warframe,
+          buildState,
+          showMaxStacks,
+          { skipRankUpBonus: true },
+        ),
+      }
+    }
+    // Arch-Gun and Arch-Melee have weapon-like stats
     return {
       weapon: calculateWeaponStats(
         item as Gun | Melee,

--- a/src/lib/warframe/stats/warframe-stats.ts
+++ b/src/lib/warframe/stats/warframe-stats.ts
@@ -83,6 +83,11 @@ function getWarframeRank30BaseStats(warframe: Warframe) {
   }
 }
 
+interface WarframeStatsOptions {
+  /** Skip rank-up bonus calculation (for Archwings where WFCD data is already rank-30) */
+  skipRankUpBonus?: boolean
+}
+
 /**
  * Calculate warframe stats including health, shields, armor, energy, and ability stats
  */
@@ -90,12 +95,20 @@ export function calculateWarframeStats(
   warframe: Warframe,
   buildState: BuildState,
   showMaxStacks = false,
+  options?: WarframeStatsOptions,
 ): WarframeStats {
   const mods = getAllPlacedMods(buildState)
   const shards = buildState.shardSlots ?? []
   const umbralCount = countUmbralMods(mods)
 
-  const rank30 = getWarframeRank30BaseStats(warframe)
+  const rank30 = options?.skipRankUpBonus
+    ? {
+        health: warframe.health,
+        shield: warframe.shield,
+        armor: warframe.armor,
+        energy: warframe.power,
+      }
+    : getWarframeRank30BaseStats(warframe)
 
   return {
     health: calculateSingleStat(


### PR DESCRIPTION
## Changes

- **Archwing category support**: Added Archwing frames and Arch-Gun/Arch-Melee weapons to the build editor
- **Stat calculations**: Implemented stat calculations for Archwing frames (warframe-like stats) and Arch-Gun/Arch-Melee weapons (weapon-like stats)
- **Arcane filtering**: Added per-slot arcane filtering for Archguns (primary in slot 0, secondary in slot 1)
- **Arcane compatibility**: Configured Archwings to use primary and secondary arcanes
- **Mod compatibility**: Extended mod system to support Archwing, Arch-Gun, and Arch-Melee mod types
- **UI fixes**: Fixed category tabs wrapping issue and improved item sidebar stat display for archwing sub-types
- **Build state**: Added arcane slot initialization for Arch-Gun builds

## Files Modified

- `src/lib/warframe/categories.ts` - Added `isArchwingCategory()` helper
- `src/lib/warframe/mods.ts` - Added Archwing/Arch-Gun/Arch-Melee mod compatibility
- `src/lib/warframe/stats/index.ts` - Implemented stat calculations for archwing items
- `src/lib/warframe/stats/warframe-stats.ts` - Added option to skip rank-up bonus for Archwings
- `src/components/build-editor/build-container.tsx` - Added arcane filtering by slot
- `src/components/build-editor/item-sidebar.tsx` - Updated to display stats for archwing sub-types
- `src/app/builds/[slug]/page.tsx` & `src/app/create/page.tsx` - Added Archwing arcane compatibility
- `src/components/browse/category-tabs.tsx` - Fixed tab list height issue