### PR TITLE
refactor: deduplicate auth logic and ItemStats type

### DIFF
--- a/src/components/build-editor/hooks/use-build-state.ts
+++ b/src/components/build-editor/hooks/use-build-state.ts
@@ -20,6 +20,7 @@ import type {
   Mod,
   Arcane,
   HelminthAbility,
+  ItemStats,
 } from "@/lib/warframe/types"
 
 // ---------------------------------------------------------------------------
@@ -58,24 +59,6 @@ export interface BuildContainerProps {
     }
     buildData: { formaCount: number }
   }[]
-}
-
-export interface ItemStats {
-  health?: number
-  shield?: number
-  armor?: number
-  energy?: number
-  sprintSpeed?: number
-  abilities?: Array<{ name: string; imageName?: string; description: string }>
-  fireRate?: number
-  criticalChance?: number
-  criticalMultiplier?: number
-  procChance?: number
-  totalDamage?: number
-  magazineSize?: number
-  reloadTime?: number
-  range?: number
-  comboDuration?: number
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/build-editor/item-sidebar.tsx
+++ b/src/components/build-editor/item-sidebar.tsx
@@ -24,6 +24,7 @@ import { getImageUrl } from "@/lib/warframe/images"
 import type {
   BuildState,
   HelminthAbility,
+  ItemStats,
   PlacedShard,
   BrowseableItem,
 } from "@/lib/warframe/types"
@@ -33,28 +34,6 @@ import { DamageBreakdownSection } from "./damage-breakdown"
 import { HelminthAbilityDialog } from "./helminth-ability-dialog"
 import { ShardsPanel } from "./shards-panel"
 import { CalculatedStatRow, SimpleStatRow } from "./stat-row"
-
-interface ItemStats {
-  // Warframe stats
-  health?: number
-  shield?: number
-  armor?: number
-  energy?: number
-  sprintSpeed?: number
-  abilities?: Array<{ name: string; imageName?: string; description: string }>
-  // Weapon stats (all)
-  fireRate?: number
-  criticalChance?: number
-  criticalMultiplier?: number
-  procChance?: number // status chance
-  totalDamage?: number
-  // Gun stats (primary/secondary)
-  magazineSize?: number
-  reloadTime?: number
-  // Melee stats
-  range?: number
-  comboDuration?: number
-}
 
 interface ItemSidebarProps {
   buildState: BuildState

--- a/src/lib/db/builds.ts
+++ b/src/lib/db/builds.ts
@@ -590,22 +590,7 @@ export async function updateBuild(
   userId: string,
   input: UpdateBuildInput,
 ): Promise<BuildWithUser> {
-  // First verify ownership
-  const existing = await prisma.build.findUnique({
-    where: { id: buildId },
-    select: { userId: true, organizationId: true },
-  })
-  if (!existing) throw new Error("Build not found")
-
-  const isOwner = existing.userId === userId
-  let isOrgMemberAllowed = false
-  if (!isOwner && existing.organizationId) {
-    const { isOrgMember } = await import("./organizations")
-    isOrgMemberAllowed = await isOrgMember(existing.organizationId, userId)
-  }
-  if (!isOwner && !isOrgMemberAllowed) {
-    throw new Error("Not authorized to update this build")
-  }
+  await assertBuildAccess(buildId, userId)
 
   const updateData: Prisma.BuildUpdateInput = {}
 
@@ -760,22 +745,7 @@ export async function deleteBuild(
   buildId: string,
   userId: string,
 ): Promise<void> {
-  // First verify ownership
-  const existing = await prisma.build.findUnique({
-    where: { id: buildId },
-    select: { userId: true, organizationId: true },
-  })
-  if (!existing) throw new Error("Build not found")
-
-  const isOwner = existing.userId === userId
-  let isOrgMemberAllowed = false
-  if (!isOwner && existing.organizationId) {
-    const { isOrgMember } = await import("./organizations")
-    isOrgMemberAllowed = await isOrgMember(existing.organizationId, userId)
-  }
-  if (!isOwner && !isOrgMemberAllowed) {
-    throw new Error("Not authorized to delete this build")
-  }
+  await assertBuildAccess(buildId, userId)
 
   await prisma.build.delete({
     where: { id: buildId },
@@ -838,6 +808,31 @@ async function searchBuildsWithFilters(
 // =============================================================================
 // HELPERS
 // =============================================================================
+
+/**
+ * Assert that a user has write access to a build (owner or org member).
+ * Throws if the build doesn't exist or the user isn't authorized.
+ */
+async function assertBuildAccess(
+  buildId: string,
+  userId: string,
+): Promise<void> {
+  const existing = await prisma.build.findUnique({
+    where: { id: buildId },
+    select: { userId: true, organizationId: true },
+  })
+  if (!existing) throw new Error("Build not found")
+
+  const isOwner = existing.userId === userId
+  if (isOwner) return
+
+  if (existing.organizationId) {
+    const { isOrgMember } = await import("./organizations")
+    if (await isOrgMember(existing.organizationId, userId)) return
+  }
+
+  throw new Error("Not authorized")
+}
 
 /**
  * Check if a user can view a build based on visibility

--- a/src/lib/warframe/types.ts
+++ b/src/lib/warframe/types.ts
@@ -385,3 +385,25 @@ export interface PlacedShard {
   stat: string // Stat name key
   tauforged: boolean
 }
+
+// ---------------------------------------------------------------------------
+// Item Stats (extracted from browseable item data for display)
+// ---------------------------------------------------------------------------
+
+export interface ItemStats {
+  health?: number
+  shield?: number
+  armor?: number
+  energy?: number
+  sprintSpeed?: number
+  abilities?: Array<{ name: string; imageName?: string; description: string }>
+  fireRate?: number
+  criticalChance?: number
+  criticalMultiplier?: number
+  procChance?: number
+  totalDamage?: number
+  magazineSize?: number
+  reloadTime?: number
+  range?: number
+  comboDuration?: number
+}


### PR DESCRIPTION
## Summary
- Extract duplicated authorization check from `updateBuild`/`deleteBuild` into a shared `assertBuildAccess()` helper in `builds.ts` — prevents auth logic drift between the two functions
- Move `ItemStats` interface to `types.ts` as single source of truth, removing duplicate definitions from `use-build-state.ts` and `item-sidebar.tsx`

## Test plan
- [x] `bun run build` passes (confirmed locally — only pre-existing Prisma client staleness issue, resolved with `bunx prisma generate`)
- [x] Load a build page, confirm editor works (mods, arcanes, shards)
- [x] Save/delete a build as owner and as org member