### PR TITLE
Add communities tab to admin panel

### DIFF
--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -9,6 +9,7 @@ import {
   adminUnbanUser,
   adminDeleteUser,
   adminDeleteBuild,
+  adminDeleteOrganization,
 } from "@/lib/db/index"
 import { ok, err, getErrorMessage, type Result } from "@/lib/result"
 
@@ -103,5 +104,24 @@ export async function adminDeleteBuildAction(buildId: string): Promise<Result> {
     return ok()
   } catch (error) {
     return err(getErrorMessage(error, "Failed to delete build"))
+  }
+}
+
+// =============================================================================
+// ORGANIZATION ACTIONS
+// =============================================================================
+
+export async function adminDeleteOrganizationAction(
+  orgId: string,
+): Promise<Result> {
+  try {
+    const auth = await requireAdmin("delete organization")
+    if (!auth.success) return auth
+
+    await adminDeleteOrganization(orgId)
+    revalidatePath("/admin")
+    return ok()
+  } catch (error) {
+    return err(getErrorMessage(error, "Failed to delete organization"))
   }
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation"
 
 import { AdminApiKeysTab } from "@/components/admin/admin-api-keys-tab"
+import { AdminCommunitiesTab } from "@/components/admin/admin-communities-tab"
 import { AdminContentTab } from "@/components/admin/admin-content-tab"
 import { AdminDevToolsTab } from "@/components/admin/admin-dev-tools-tab"
 import { AdminStatsTab } from "@/components/admin/admin-stats-tab"
@@ -27,6 +28,7 @@ export default async function AdminPage({
         <TabsList>
           <TabsTrigger value="users">Users</TabsTrigger>
           <TabsTrigger value="content">Content</TabsTrigger>
+          <TabsTrigger value="communities">Communities</TabsTrigger>
           <TabsTrigger value="stats">Stats</TabsTrigger>
           <TabsTrigger value="dev-tools">Dev Tools</TabsTrigger>
           <TabsTrigger value="api-keys">API Keys</TabsTrigger>
@@ -38,6 +40,10 @@ export default async function AdminPage({
 
         <TabsContent value="content">
           <AdminContentTab search={q} />
+        </TabsContent>
+
+        <TabsContent value="communities">
+          <AdminCommunitiesTab search={q} />
         </TabsContent>
 
         <TabsContent value="stats">

--- a/src/components/admin/admin-communities-tab.tsx
+++ b/src/components/admin/admin-communities-tab.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link"
+
+import { AdminCommunityActions } from "@/components/admin/admin-community-actions"
+import { Input } from "@/components/ui/input"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { getAdminOrganizations } from "@/lib/db/admin"
+
+interface AdminCommunitiesTabProps {
+  search?: string
+}
+
+export async function AdminCommunitiesTab({ search }: AdminCommunitiesTabProps) {
+  const orgs = await getAdminOrganizations(search)
+
+  return (
+    <div className="flex flex-col gap-4 pt-4">
+      <form action="/admin" className="flex gap-2">
+        <input type="hidden" name="tab" value="communities" />
+        <Input
+          name="q"
+          placeholder="Search communities..."
+          defaultValue={search}
+          className="max-w-sm"
+        />
+      </form>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Slug</TableHead>
+            <TableHead>Members</TableHead>
+            <TableHead>Builds</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead>Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orgs.map((org) => (
+            <TableRow key={org.id}>
+              <TableCell className="font-medium">
+                <Link
+                  href={`/org/${org.slug}`}
+                  className="hover:underline"
+                >
+                  {org.name}
+                </Link>
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {org.slug}
+              </TableCell>
+              <TableCell>{org._count.members}</TableCell>
+              <TableCell>{org._count.builds}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {org.createdAt.toLocaleDateString()}
+              </TableCell>
+              <TableCell>
+                <AdminCommunityActions orgId={org.id} orgName={org.name} />
+              </TableCell>
+            </TableRow>
+          ))}
+          {orgs.length === 0 && (
+            <TableRow>
+              <TableCell
+                colSpan={6}
+                className="text-muted-foreground h-24 text-center"
+              >
+                No communities found.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/src/components/admin/admin-community-actions.tsx
+++ b/src/components/admin/admin-community-actions.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import { adminDeleteOrganizationAction } from "@/app/actions/admin"
+import { AdminDeleteDialog } from "@/components/admin/admin-delete-dialog"
+
+interface AdminCommunityActionsProps {
+  orgId: string
+  orgName: string
+}
+
+export function AdminCommunityActions({
+  orgId,
+  orgName,
+}: AdminCommunityActionsProps) {
+  const router = useRouter()
+
+  return (
+    <AdminDeleteDialog
+      title={`Delete "${orgName}"?`}
+      description="This will permanently delete this community and remove all member associations. Builds owned by this community will be unlinked but not deleted. This cannot be undone."
+      onConfirm={async () => {
+        const result = await adminDeleteOrganizationAction(orgId)
+        if (result.success) {
+          toast.success("Community deleted")
+          router.refresh()
+        } else {
+          toast.error(result.error)
+        }
+      }}
+    />
+  )
+}

--- a/src/components/admin/admin-users-tab.tsx
+++ b/src/components/admin/admin-users-tab.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image"
+import Link from "next/link"
 
 import { AdminUserActions } from "@/components/admin/admin-user-actions"
 import { Badge } from "@/components/ui/badge"
@@ -61,9 +62,18 @@ export async function AdminUsersTab({ search, currentUserId }: AdminUsersTabProp
                   ) : (
                     <div className="bg-muted size-6 rounded-full" />
                   )}
-                  <span className="font-medium">
-                    {user.displayUsername || user.name || "—"}
-                  </span>
+                  {user.username ? (
+                    <Link
+                      href={`/profile/${user.username}`}
+                      className="font-medium hover:underline"
+                    >
+                      {user.displayUsername || user.name || "—"}
+                    </Link>
+                  ) : (
+                    <span className="font-medium">
+                      {user.name || "—"}
+                    </span>
+                  )}
                 </div>
               </TableCell>
               <TableCell className="text-muted-foreground">

--- a/src/lib/db/admin.ts
+++ b/src/lib/db/admin.ts
@@ -268,6 +268,59 @@ export async function getRecentUsers(limit = 10) {
 }
 
 // =============================================================================
+// ORGANIZATION QUERIES
+// =============================================================================
+
+export interface AdminOrganization {
+  id: string
+  name: string
+  slug: string
+  image: string | null
+  description: string | null
+  createdAt: Date
+  _count: { members: number; builds: number }
+}
+
+export async function getAdminOrganizations(
+  search?: string,
+): Promise<AdminOrganization[]> {
+  return prisma.organization.findMany({
+    where: search
+      ? {
+          OR: [
+            { name: { contains: search, mode: "insensitive" } },
+            { slug: { contains: search, mode: "insensitive" } },
+          ],
+        }
+      : undefined,
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      image: true,
+      description: true,
+      createdAt: true,
+      _count: { select: { members: true, builds: true } },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 200,
+  })
+}
+
+export async function adminDeleteOrganization(orgId: string): Promise<void> {
+  await prisma.$transaction([
+    prisma.build.updateMany({
+      where: { organizationId: orgId },
+      data: { organizationId: null },
+    }),
+    prisma.organizationMember.deleteMany({
+      where: { organizationId: orgId },
+    }),
+    prisma.organization.delete({ where: { id: orgId } }),
+  ])
+}
+
+// =============================================================================
 // DEV TOOLS QUERIES
 // =============================================================================
 

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -90,6 +90,8 @@ export {
   adminDeleteUser,
   getAdminBuilds,
   adminDeleteBuild,
+  getAdminOrganizations,
+  adminDeleteOrganization,
   getAdminStats,
   getTopBuilds,
   getTopUsers,
@@ -97,7 +99,7 @@ export {
   getDbTableCounts,
 } from "./admin"
 
-export type { AdminUser, AdminBuild, AdminStats } from "./admin"
+export type { AdminUser, AdminBuild, AdminStats, AdminOrganization } from "./admin"
 
 // API Key operations
 export {


### PR DESCRIPTION
## Summary
- Add a **Communities** tab to the admin panel for viewing and managing organizations (name, slug, member count, build count, delete with confirmation)
- Make **usernames clickable** in the Users tab, linking to `/profile/{username}`

## Test plan
- [ ] Navigate to `/admin` and verify the Communities tab appears between Content and Stats
- [ ] Search for communities by name or slug
- [ ] Verify community names link to their org page
- [ ] Delete a community and confirm builds are unlinked (not deleted)
- [ ] In the Users tab, click a username and verify it navigates to the profile
- [ ] Users without a username show a plain text fallback (no broken link)