### PR TITLE
fix: set username from GitHub profile on OAuth sign-in

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,6 +19,10 @@ export const auth = betterAuth({
           github: {
             clientId: githubId,
             clientSecret: githubSecret,
+            mapProfileToUser: (profile) => ({
+              username: profile.login.toLowerCase(),
+              displayUsername: profile.login,
+            }),
           },
         }
       : {},


### PR DESCRIPTION
## Changes

- Add profile mapping for GitHub OAuth provider to automatically populate user fields
- Map GitHub `login` field to `username` (lowercase) and `displayUsername`
- Ensures username is set during GitHub OAuth sign-in flow

## Files Changed

- `src/lib/auth.ts`: Added `mapProfileToUser` configuration for GitHub OAuth provider