### PR TITLE
fix: show stats for companions, exalted weapons, and companion weapons

### DIFF
--- a/src/components/build-editor/item-sidebar.tsx
+++ b/src/components/build-editor/item-sidebar.tsx
@@ -18,6 +18,9 @@ import {
   isWeaponCategory,
   isGunCategory,
   isMeleeCategory,
+  isCompanionCategory,
+  isExaltedWeaponCategory,
+  isCompanionWeaponCategory,
   isArchwingCategory,
 } from "@/lib/warframe/categories"
 import { getImageUrl } from "@/lib/warframe/images"
@@ -97,14 +100,22 @@ export function ItemSidebar({
   const isArchwingGun = isArchwing && item?.category === "Arch-Gun"
 
   const isWarframeOrNecramech = isWarframeCategory(buildState.itemCategory)
+  const isCompanion = isCompanionCategory(buildState.itemCategory)
+  const isExaltedWeapon = isExaltedWeaponCategory(buildState.itemCategory)
+  const isCompanionWeapon = isCompanionWeaponCategory(buildState.itemCategory)
   const isWeapon = isWeaponCategory(buildState.itemCategory)
   const isMelee = isMeleeCategory(buildState.itemCategory)
   const isGun = isGunCategory(buildState.itemCategory)
 
-  // Combined flags that include archwing sub-types
-  const showWarframeStats = isWarframeOrNecramech || isArchwingFrame
-  const showWeaponStats = isWeapon || isArchwingWeapon
-  const showGunStats = isGun || isArchwingGun
+  // Exalted weapons can be ranged (has trigger field) or melee
+  const isExaltedGun = isExaltedWeapon && !!(item as { trigger?: string })?.trigger
+  const isExaltedMelee = isExaltedWeapon && !isExaltedGun
+
+  // Combined flags that include archwing sub-types and new categories
+  const showWarframeStats = isWarframeOrNecramech || isArchwingFrame || isCompanion
+  const showWeaponStats = isWeapon || isArchwingWeapon || isExaltedWeapon || isCompanionWeapon
+  const showGunStats = isGun || isArchwingGun || isCompanionWeapon || isExaltedGun
+  const showMeleeStats = isMelee || isExaltedMelee
 
   // Reactor for warframes/necramechs, Catalyst for weapons
   const capacityBoosterLabel = isWarframeOrNecramech ? "Reactor" : "Catalyst"
@@ -381,7 +392,7 @@ export function ItemSidebar({
                   unit="s"
                 />
               )}
-              {weaponStats.attackModes[0].range && isMelee && (
+              {weaponStats.attackModes[0].range && showMeleeStats && (
                 <CalculatedStatRow
                   label="Range"
                   stat={weaponStats.attackModes[0].range}
@@ -448,7 +459,7 @@ export function ItemSidebar({
                       unit="s"
                     />
                   )}
-                  {mode.range && isMelee && (
+                  {mode.range && showMeleeStats && (
                     <CalculatedStatRow
                       label="Range"
                       stat={mode.range}
@@ -530,7 +541,7 @@ export function ItemSidebar({
               />
             </>
           )}
-          {isMelee && (
+          {showMeleeStats && (
             <>
               <SimpleStatRow
                 label="Range"
@@ -553,8 +564,8 @@ export function ItemSidebar({
         </div>
       )}
 
-      {/* Ability Stats - Calculated */}
-      {showWarframeStats && warframeStats && (
+      {/* Ability Stats - Calculated (not shown for companions) */}
+      {showWarframeStats && !isCompanion && warframeStats && (
         <>
           <Separator />
           <div className="flex flex-col gap-2 p-3">
@@ -582,8 +593,8 @@ export function ItemSidebar({
         </>
       )}
 
-      {/* Ability Stats - Fallback to static display */}
-      {showWarframeStats && !warframeStats && (
+      {/* Ability Stats - Fallback to static display (not shown for companions) */}
+      {showWarframeStats && !isCompanion && !warframeStats && (
         <>
           <Separator />
           <div className="flex flex-col gap-2 p-3">

--- a/src/lib/warframe/categories.ts
+++ b/src/lib/warframe/categories.ts
@@ -98,6 +98,8 @@ const VALID_CATEGORY_IDS = new Set<string>(
 const WARFRAME_CATEGORIES_SET = new Set<BrowseCategory>(["warframes", "necramechs"])
 const WEAPON_CATEGORIES_SET = new Set<BrowseCategory>(["primary", "secondary", "melee"])
 const GUN_CATEGORIES_SET = new Set<BrowseCategory>(["primary", "secondary"])
+const EXALTED_WEAPON_CATEGORIES_SET = new Set<BrowseCategory>(["exalted-weapons"])
+const COMPANION_WEAPON_CATEGORIES_SET = new Set<BrowseCategory>(["companion-weapons"])
 
 /**
  * Get category config by ID
@@ -187,6 +189,20 @@ export function isMeleeCategory(category: BrowseCategory): boolean {
  */
 export function isCompanionCategory(category: BrowseCategory): boolean {
   return category === "companions"
+}
+
+/**
+ * Check if a category represents an exalted weapon
+ */
+export function isExaltedWeaponCategory(category: BrowseCategory): boolean {
+  return EXALTED_WEAPON_CATEGORIES_SET.has(category)
+}
+
+/**
+ * Check if a category represents a companion weapon
+ */
+export function isCompanionWeaponCategory(category: BrowseCategory): boolean {
+  return COMPANION_WEAPON_CATEGORIES_SET.has(category)
 }
 
 /**

--- a/src/lib/warframe/stats/index.ts
+++ b/src/lib/warframe/stats/index.ts
@@ -1,7 +1,7 @@
 // Stats calculation module — entry point and re-exports
 
 import type { CalculatedStats } from "../stat-types"
-import type { BrowseableItem, BuildState, Warframe, Gun, Melee } from "../types"
+import type { BrowseableItem, BuildState, Warframe, Companion, Gun, Melee } from "../types"
 import { calculateWarframeStats } from "./warframe-stats"
 import { calculateWeaponStats } from "./weapon-stats"
 
@@ -66,6 +66,29 @@ export function calculateStats(
       }
     }
     // Arch-Gun and Arch-Melee have weapon-like stats
+    return {
+      weapon: calculateWeaponStats(
+        item as Gun | Melee,
+        buildState,
+        showMaxStacks,
+      ),
+    }
+  }
+
+  // Companions (Kubrows, Kavats, Sentinels) have warframe-like survivability stats
+  if (category === "companions") {
+    return {
+      warframe: calculateWarframeStats(
+        item as Companion as Warframe,
+        buildState,
+        showMaxStacks,
+        { skipRankUpBonus: true },
+      ),
+    }
+  }
+
+  // Exalted weapons and companion weapons have weapon-like stats
+  if (category === "exalted-weapons" || category === "companion-weapons") {
     return {
       weapon: calculateWeaponStats(
         item as Gun | Melee,


### PR DESCRIPTION
## Summary
- Companions (Kubrows, Kavats, Sentinels) now display health/shield/armor stats (without ability stats)
- Exalted weapons now display weapon stats with correct melee/gun sub-stats based on trigger field
- Companion weapons now display weapon stats with gun-specific stats (magazine/reload)

Closes #19

## Test plan
- [x] Open a Kubrow build — verify health/shield/armor stats appear, no ability stats shown
- [x] Open a Sentinel build — same check
- [x] Open Exalted Blade (melee exalted) — verify weapon stats with range
- [x] Open Regulators (ranged exalted) — verify weapon stats with magazine/reload
- [x] Open a companion weapon — verify weapon stats with magazine/reload
- [x] Verify existing categories (warframes, primary, secondary, melee, archwing) still display correctly