### PR TITLE
feat: add format option to screenshot API, default to webp

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "satori": "^0.26.0",
         "server-only": "^0.0.1",
         "shadcn": "^4.1.0",
+        "sharp": "^0.34.5",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "vaul": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "satori": "^0.26.0",
     "server-only": "^0.0.1",
     "shadcn": "^4.1.0",
+    "sharp": "^0.34.5",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "vaul": "^1.1.2",

--- a/src/app/api/builds/[slug]/screenshot/route.ts
+++ b/src/app/api/builds/[slug]/screenshot/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { requireApiKey } from "@/lib/auth/api-keys"
 import { getBuildBySlug } from "@/lib/db/index"
 import { screenshotLimiter, RateLimitError } from "@/lib/rate-limit"
-import { screenshotBuild } from "@/lib/screenshot"
+import { screenshotBuild, type ImageFormat } from "@/lib/screenshot"
 
 export const runtime = "nodejs"
 export const maxDuration = 30
@@ -71,10 +71,15 @@ export async function GET(
   // 2. Validate query params
   const { searchParams } = request.nextUrl
   const bg = searchParams.get("bg") ?? DEFAULT_BG
+  const format = (searchParams.get("format") ?? "webp") as ImageFormat
   const refresh = searchParams.get("refresh") === "true"
 
   if (!HEX_COLOR_RE.test(bg)) {
     return NextResponse.json({ error: "Invalid bg color" }, { status: 400 })
+  }
+
+  if (!["webp", "png", "jpeg"].includes(format)) {
+    return NextResponse.json({ error: "Invalid format. Use: webp, png, jpeg" }, { status: 400 })
   }
 
   // 3. Fetch build
@@ -100,21 +105,23 @@ export async function GET(
       : "http://localhost:3000")
 
   try {
-    const png = await screenshotBuild({
+    const image = await screenshotBuild({
       url: `${baseUrl}/builds/${slug}`,
       bgColor: bg,
+      format,
     })
 
+    const contentType = format === "jpeg" ? "image/jpeg" : `image/${format}`
     const cacheControl = refresh
       ? "no-store"
       : "public, max-age=3600, stale-while-revalidate=86400"
 
-    return new NextResponse(new Uint8Array(png), {
+    return new NextResponse(new Uint8Array(image), {
       status: 200,
       headers: {
-        "Content-Type": "image/png",
+        "Content-Type": contentType,
         "Cache-Control": cacheControl,
-        "Content-Disposition": `inline; filename="${slug}-screenshot.png"`,
+        "Content-Disposition": `inline; filename="${slug}-screenshot.${format === "jpeg" ? "jpg" : format}"`,
       },
     })
   } catch (err) {

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,10 +1,16 @@
 import "server-only"
 
+import sharp from "sharp"
+
+export type ImageFormat = "webp" | "png" | "jpeg"
+
 export interface ScreenshotOptions {
   /** Full URL of the build page to screenshot */
   url: string
   /** Hex background color without '#' (e.g. "111111") */
   bgColor: string
+  /** Output format (default: webp) */
+  format?: ImageFormat
 }
 
 export async function screenshotBuild(
@@ -86,8 +92,11 @@ export async function screenshotBuild(
     }, color)
 
     const png = await target!.screenshot({ type: "png" })
+    const format = options.format ?? "webp"
 
-    return Buffer.from(png)
+    if (format === "png") return Buffer.from(png)
+
+    return sharp(png)[format]({ quality: 95 }).toBuffer()
   } finally {
     await browser.close()
   }


### PR DESCRIPTION
## Summary
- Add `sharp` for server-side image conversion
- Add `format` query param to screenshot endpoint (`webp`, `png`, `jpeg`) — defaults to `webp` at 95% quality
- Significantly reduces response size (~1MB PNG → ~100-300KB WebP)

## Test plan
- [x] Request screenshot with no `format` param → returns WebP
- [x] Request with `?format=png` → returns PNG
- [x] Request with `?format=jpeg` → returns JPEG
- [x] Request with `?format=bmp` → returns 400 error