### PR TITLE
fix: improve mod card name readability

### DIFF
--- a/src/components/mod-card/mod-card.tsx
+++ b/src/components/mod-card/mod-card.tsx
@@ -173,7 +173,7 @@ function CompactModCard({
           alt={mod.name}
           className="object-cover object-top"
           style={{
-            filter: "grayscale(0.7) brightness(0.5)",
+            filter: "grayscale(0.7) brightness(0.35)",
           }}
         />
         <div
@@ -192,7 +192,7 @@ function CompactModCard({
           fontFamily: "Roboto, sans-serif",
           color: getRarityColor(rarity),
           textShadow:
-            "-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000",
+            "-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000, 0 0 6px #000, 0 0 12px #000",
         }}
       >
         {mod.name}


### PR DESCRIPTION
## Summary
- Darkened mod card background image (brightness 0.5 → 0.35) for better contrast
- Added blurred text shadow layers to mod name for improved readability over artwork

## Test plan
- [ ] Verify mod names are readable across all rarities (common, uncommon, rare, legendary, primed)
- [ ] Check mod cards in both the build editor grid and the mod search picker