### PR TITLE
feat: switch community builds from card grid to list layout

### DIFF
--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -7,6 +7,7 @@ import { z } from "zod"
 import { auth, getServerSession } from "@/lib/auth"
 import { requireAuth } from "@/lib/auth-helpers"
 import {
+  getPublicBuilds,
   getUserBuilds,
   getUserForSettings,
   isUsernameTaken,
@@ -132,6 +133,36 @@ export async function getProfileBuildsAction(
       viewerId,
       buildOptions,
     )
+    const hasMore = total > page * limit
+
+    return ok({ builds, hasMore })
+  } catch (error) {
+    return err(getErrorMessage(error, "Failed to load builds"))
+  }
+}
+
+// =============================================================================
+// ORGANIZATION BUILDS
+// =============================================================================
+
+export async function getOrgBuildsAction(
+  orgId: string,
+  options: { query?: string; category?: string; page?: number },
+): Promise<Result<ProfileBuildsResult>> {
+  try {
+    const limit = 12
+    const page = options.page ?? 1
+    const buildOptions: GetBuildsOptions = {
+      page,
+      limit,
+      sortBy: "votes",
+      organizationId: orgId,
+      ...(options.query && { query: options.query }),
+      ...(options.category &&
+        options.category !== "all" && { category: options.category }),
+    }
+
+    const { builds, total } = await getPublicBuilds(buildOptions)
     const hasMore = total > page * limit
 
     return ok({ builds, hasMore })

--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -433,7 +433,7 @@ async function CommunityBuildsSection({
                   </p>
                 ) : (
                   <p className="text-muted-foreground line-clamp-1 text-xs">
-                    by {build.user.username || build.user.name || "Anonymous"}
+                    by {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
                   </p>
                 )
               }

--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -412,7 +412,7 @@ async function CommunityBuildsSection({
           </CardContent>
         </Card>
       ) : (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        <div className="flex flex-col gap-2.5">
           {builds.map((build) => (
             <BuildCardLink
               key={build.id}

--- a/src/app/builds/[slug]/page.tsx
+++ b/src/app/builds/[slug]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({
   const description =
     build.description ||
     `${build.item.name} build by ${
-      build.user.username || build.user.name || "Anonymous"
+      build.user.displayUsername || build.user.username || build.user.name || "Anonymous"
     }`
 
   return {
@@ -188,10 +188,10 @@ export default async function BuildPage({ params }: BuildPageProps) {
                         href={`/profile/${build.user.username}`}
                         className="hover:text-foreground transition-colors hover:underline"
                       >
-                        {build.user.username}
+                        {build.user.displayUsername || build.user.username}
                       </Link>
                     ) : (
-                      build.user.name || "Anonymous"
+                      build.user.displayUsername || build.user.name || "Anonymous"
                     )}
                   </span>
                 )}

--- a/src/app/builds/mine/page.tsx
+++ b/src/app/builds/mine/page.tsx
@@ -123,7 +123,7 @@ export default async function MyBuildsPage({
             </div>
           ) : (
             <>
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              <div className="flex flex-col gap-2.5">
                 {builds.map((build) => (
                   <BuildCardLink
                     key={build.id}

--- a/src/app/builds/page.tsx
+++ b/src/app/builds/page.tsx
@@ -81,7 +81,7 @@ function BuildCard({ build }: { build: BuildListItem }) {
     getCategoryConfig(build.item.browseCategory as BrowseCategory)?.label ??
     build.item.browseCategory
   const authorName =
-    build.user.username || build.user.name || "Anonymous"
+    build.user.displayUsername || build.user.username || build.user.name || "Anonymous"
 
   return (
     <div className="bg-card hover:bg-card/80 relative flex items-center gap-4 rounded-lg border p-4 transition-colors">

--- a/src/app/builds/page.tsx
+++ b/src/app/builds/page.tsx
@@ -84,10 +84,14 @@ function BuildCard({ build }: { build: BuildListItem }) {
     build.user.username || build.user.name || "Anonymous"
 
   return (
-    <Link
-      href={`/builds/${build.slug}`}
-      className="bg-card hover:bg-card/80 flex items-center gap-4 rounded-lg border p-4 transition-colors"
-    >
+    <div className="bg-card hover:bg-card/80 relative flex items-center gap-4 rounded-lg border p-4 transition-colors">
+      {/* Full-card link */}
+      <Link
+        href={`/builds/${build.slug}`}
+        className="absolute inset-0 rounded-lg"
+        aria-label={build.name}
+      />
+
       {/* Item Image */}
       <div className="bg-muted/20 relative size-20 shrink-0 overflow-hidden rounded-lg">
         <Image
@@ -106,9 +110,19 @@ function BuildCard({ build }: { build: BuildListItem }) {
         <p className="text-muted-foreground text-sm">
           {build.item.name} build by{" "}
           {build.organization ? (
-            <span className="text-[#a78bfa]">{build.organization.name}</span>
+            <Link
+              href={`/org/${build.organization.slug}`}
+              className="relative z-10 text-[#a78bfa] underline decoration-[#a78bfa]/40 hover:decoration-[#a78bfa]"
+            >
+              {build.organization.name}
+            </Link>
           ) : (
-            <span>{authorName}</span>
+            <Link
+              href={`/profile/${build.user.username || ""}`}
+              className="relative z-10 underline decoration-current/40 hover:decoration-current"
+            >
+              {authorName}
+            </Link>
           )}
         </p>
         <div className="flex gap-2 pt-1">
@@ -125,7 +139,7 @@ function BuildCard({ build }: { build: BuildListItem }) {
       <div className="shrink-0 pl-4">
         <BuildStats voteCount={build.voteCount} viewCount={build.viewCount} />
       </div>
-    </Link>
+    </div>
   )
 }
 

--- a/src/app/builds/page.tsx
+++ b/src/app/builds/page.tsx
@@ -9,11 +9,11 @@ import { BuildStats } from "@/components/build/build-card-link"
 import { BuildsFilterDropdown, BuildsSortDropdown } from "@/components/builds"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
-import { OrgBadge } from "@/components/org"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { getPublicBuilds, type BuildListItem } from "@/lib/db/index"
 import { getImageUrl } from "@/lib/warframe/images"
+import { getCategoryConfig } from "@/lib/warframe/categories"
 import type { BrowseCategory } from "@/lib/warframe/types"
 
 export const metadata: Metadata = {
@@ -77,56 +77,53 @@ function buildFilterUrl(
 
 function BuildCard({ build }: { build: BuildListItem }) {
   const timeAgo = getRelativeTime(new Date(build.createdAt))
+  const categoryLabel =
+    getCategoryConfig(build.item.browseCategory as BrowseCategory)?.label ??
+    build.item.browseCategory
+  const authorName =
+    build.user.username || build.user.name || "Anonymous"
 
   return (
     <Link
       href={`/builds/${build.slug}`}
-      className="bg-card block overflow-hidden rounded-lg border"
+      className="bg-card hover:bg-card/80 flex items-center gap-4 rounded-lg border p-4 transition-colors"
     >
       {/* Item Image */}
-      <div className="bg-muted/20 relative aspect-video">
+      <div className="bg-muted/20 relative size-20 shrink-0 overflow-hidden rounded-lg">
         <Image
           src={getImageUrl(build.item.imageName ?? undefined)}
           alt={build.item.name}
           fill
           unoptimized
-          sizes="(max-width: 768px) 100vw, 300px"
+          sizes="80px"
           className="object-cover"
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
-        <div className="absolute right-2 bottom-2 left-2">
+      </div>
+
+      {/* Build Info */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <h3 className="truncate text-base font-semibold">{build.name}</h3>
+        <p className="text-muted-foreground text-sm">
+          {build.item.name} build by{" "}
+          {build.organization ? (
+            <span className="text-[#a78bfa]">{build.organization.name}</span>
+          ) : (
+            <span>{authorName}</span>
+          )}
+        </p>
+        <div className="flex gap-2 pt-1">
           <Badge variant="secondary" className="text-xs">
-            {build.item.browseCategory}
+            {timeAgo}
+          </Badge>
+          <Badge variant="secondary" className="text-xs">
+            {categoryLabel}
           </Badge>
         </div>
       </div>
 
-      {/* Build Info */}
-      <div className="flex flex-col gap-2 p-3">
-        <div>
-          <h3 className="line-clamp-1 text-sm font-semibold">{build.name}</h3>
-          <p className="text-muted-foreground line-clamp-1 text-xs">
-            {build.item.name}
-          </p>
-        </div>
-
-        {/* Author and Stats */}
-        <div className="text-muted-foreground flex items-center justify-between text-xs">
-          <span className="line-clamp-1">
-            {build.organization ? (
-              <OrgBadge
-                name={build.organization.name}
-                slug={build.organization.slug}
-                linked={false}
-              />
-            ) : (
-              <>by {build.user.username || build.user.name || "Anonymous"}</>
-            )}
-          </span>
-          <BuildStats voteCount={build.voteCount} viewCount={build.viewCount} />
-        </div>
-
-        <p className="text-muted-foreground text-xs">{timeAgo}</p>
+      {/* Stats */}
+      <div className="shrink-0 pl-4">
+        <BuildStats voteCount={build.voteCount} viewCount={build.viewCount} />
       </div>
     </Link>
   )
@@ -228,7 +225,7 @@ export default async function BuildsPage({ searchParams }: BuildsPageProps) {
             </div>
           ) : (
             <>
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              <div className="flex flex-col gap-2.5">
                 {builds.map((build) => (
                   <BuildCard key={build.id} build={build} />
                 ))}

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -77,7 +77,7 @@ export default async function FavoritesPage({
                     subtitle={
                       <p className="text-muted-foreground line-clamp-1 text-xs">
                         {build.item.name} by{" "}
-                        {build.user.username || build.user.name || "Anonymous"}
+                        {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
                       </p>
                     }
                   />

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -64,7 +64,7 @@ export default async function FavoritesPage({
             </div>
           ) : (
             <>
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              <div className="flex flex-col gap-2.5">
                 {builds.map((build) => (
                   <BuildCardLink
                     key={build.id}

--- a/src/app/org/[slug]/page.tsx
+++ b/src/app/org/[slug]/page.tsx
@@ -3,13 +3,13 @@ import type { Metadata } from "next"
 import Link from "next/link"
 import { notFound } from "next/navigation"
 
-import { BuildCardLink } from "@/components/build/build-card-link"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
+import { ProfileBuilds } from "@/components/profile"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { getServerSession } from "@/lib/auth"
-import { prisma } from "@/lib/db"
+import { getPublicBuilds } from "@/lib/db/index"
 import { getOrganizationBySlug } from "@/lib/db/organizations"
 
 export const revalidate = 3600 // 1 hour
@@ -51,25 +51,12 @@ export default async function OrgProfilePage({ params }: OrgProfilePageProps) {
     ? org.members.some((m) => m.userId === viewerUserId)
     : false
 
-  const [builds, totalBuilds] = await Promise.all([
-    prisma.build.findMany({
-      where: { organizationId: org.id, visibility: "PUBLIC" },
-      orderBy: { voteCount: "desc" },
-      take: 12,
-      select: {
-        id: true,
-        slug: true,
-        name: true,
-        itemName: true,
-        itemImageName: true,
-        voteCount: true,
-        viewCount: true,
-      },
-    }),
-    prisma.build.count({
-      where: { organizationId: org.id, visibility: "PUBLIC" },
-    }),
-  ])
+  const { builds, total: totalBuilds } = await getPublicBuilds({
+    organizationId: org.id,
+    sortBy: "votes",
+    limit: 12,
+  })
+  const hasMore = totalBuilds > 12
 
   const createdDate = new Date(org.createdAt).toLocaleDateString("en-US", {
     month: "long",
@@ -182,23 +169,12 @@ export default async function OrgProfilePage({ params }: OrgProfilePageProps) {
           {/* Builds */}
           <section className="flex flex-col gap-4">
             <h2 className="text-xl font-semibold">Builds</h2>
-            {builds.length === 0 ? (
-              <p className="text-muted-foreground">No builds published yet.</p>
-            ) : (
-              <div className="flex flex-col gap-2.5">
-                {builds.map((build) => (
-                  <BuildCardLink
-                    key={build.id}
-                    slug={build.slug}
-                    name={build.name}
-                    itemName={build.itemName}
-                    itemImageName={build.itemImageName}
-                    voteCount={build.voteCount}
-                    viewCount={build.viewCount}
-                  />
-                ))}
-              </div>
-            )}
+            <ProfileBuilds
+              orgId={org.id}
+              initialBuilds={builds}
+              initialHasMore={hasMore}
+              emptyMessage="No builds published yet"
+            />
           </section>
         </div>
       </main>

--- a/src/app/org/[slug]/page.tsx
+++ b/src/app/org/[slug]/page.tsx
@@ -185,7 +185,7 @@ export default async function OrgProfilePage({ params }: OrgProfilePageProps) {
             {builds.length === 0 ? (
               <p className="text-muted-foreground">No builds published yet.</p>
             ) : (
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              <div className="flex flex-col gap-2.5">
                 {builds.map((build) => (
                   <BuildCardLink
                     key={build.id}

--- a/src/components/build/build-card-link.tsx
+++ b/src/components/build/build-card-link.tsx
@@ -34,26 +34,28 @@ export function BuildCardLink({
   return (
     <Link
       href={`/builds/${slug}`}
-      className="bg-card hover:border-primary block overflow-hidden rounded-lg border transition-colors"
+      className="bg-card hover:bg-card/80 flex items-center gap-4 rounded-lg border p-4 transition-colors"
     >
-      <div className="bg-muted/20 relative aspect-video">
+      <div className="bg-muted/20 relative size-20 shrink-0 overflow-hidden rounded-lg">
         <Image
           src={getImageUrl(itemImageName ?? undefined)}
           alt={itemName}
           fill
           unoptimized
-          sizes="(max-width: 768px) 100vw, 300px"
+          sizes="80px"
           className="object-cover"
         />
         {imageOverlay}
       </div>
-      <div className="flex flex-col gap-1 p-2">
-        <h3 className="line-clamp-1 text-sm font-medium">{name}</h3>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <h3 className="truncate text-base font-semibold">{name}</h3>
         {subtitle ?? (
-          <p className="text-muted-foreground text-xs">{itemName}</p>
+          <p className="text-muted-foreground text-sm">{itemName}</p>
         )}
-        <BuildStats voteCount={voteCount} viewCount={viewCount} />
         {footer}
+      </div>
+      <div className="shrink-0 pl-4">
+        <BuildStats voteCount={voteCount} viewCount={viewCount} />
       </div>
     </Link>
   )

--- a/src/components/org/org-badge.tsx
+++ b/src/components/org/org-badge.tsx
@@ -8,11 +8,11 @@ interface OrgBadgeProps {
 
 export function OrgBadge({ name, slug, linked = true }: OrgBadgeProps) {
   const content = (
-    <span className="inline-flex items-center gap-1">
-      <span className="rounded bg-[#7c3aed] px-[5px] py-[1px] text-[9px] font-semibold text-white">
+    <span className="inline-flex min-w-0 items-center gap-1">
+      <span className="shrink-0 rounded bg-[#7c3aed] px-[5px] py-[1px] text-[9px] font-semibold text-white">
         ORG
       </span>
-      <span className="text-[#a78bfa]">{name}</span>
+      <span className="truncate text-[#a78bfa]">{name}</span>
     </span>
   )
 

--- a/src/components/profile/profile-builds.tsx
+++ b/src/components/profile/profile-builds.tsx
@@ -2,7 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react"
 
-import { getProfileBuildsAction } from "@/app/actions/profile"
+import {
+  getOrgBuildsAction,
+  getProfileBuildsAction,
+} from "@/app/actions/profile"
 import { BuildCardLink } from "@/components/build/build-card-link"
 import { Button } from "@/components/ui/button"
 import {
@@ -18,15 +21,19 @@ import type { BuildListItem } from "@/lib/db/index"
 import { ProfileBuildsFilters } from "./profile-builds-filters"
 
 interface ProfileBuildsProps {
-  userId: string
+  userId?: string
+  orgId?: string
   initialBuilds: BuildListItem[]
   initialHasMore: boolean
+  emptyMessage?: string
 }
 
 export function ProfileBuilds({
   userId,
+  orgId,
   initialBuilds,
   initialHasMore,
+  emptyMessage = "This user hasn't created any builds yet",
 }: ProfileBuildsProps) {
   const [builds, setBuilds] = useState(initialBuilds)
   const [hasMore, setHasMore] = useState(initialHasMore)
@@ -48,11 +55,14 @@ export function ProfileBuilds({
         setIsLoadingMore(true)
       }
       startTransition(async () => {
-        const result = await getProfileBuildsAction(userId, {
+        const fetchOptions = {
           query: newSearch || undefined,
           category: newCategory !== "all" ? newCategory : undefined,
           page: newPage,
-        })
+        }
+        const result = orgId
+          ? await getOrgBuildsAction(orgId, fetchOptions)
+          : await getProfileBuildsAction(userId!, fetchOptions)
 
         if (result.success) {
           if (append) {
@@ -66,7 +76,7 @@ export function ProfileBuilds({
         setIsLoadingMore(false)
       })
     },
-    [userId],
+    [userId, orgId],
   )
 
   // Debounced search — skip initial mount
@@ -107,7 +117,7 @@ export function ProfileBuilds({
             <EmptyDescription>
               {search || category !== "all"
                 ? "Try adjusting your search or filters"
-                : "This user hasn't created any builds yet"}
+                : emptyMessage}
             </EmptyDescription>
           </EmptyHeader>
         </Empty>

--- a/src/components/profile/profile-builds.tsx
+++ b/src/components/profile/profile-builds.tsx
@@ -95,9 +95,9 @@ export function ProfileBuilds({
       />
 
       {isPending && !isLoadingMore ? (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        <div className="flex flex-col gap-2.5">
           {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="aspect-video rounded-lg" />
+            <Skeleton key={i} className="h-24 rounded-lg" />
           ))}
         </div>
       ) : builds.length === 0 ? (
@@ -113,7 +113,7 @@ export function ProfileBuilds({
         </Empty>
       ) : (
         <>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+          <div className="flex flex-col gap-2.5">
             {builds.map((build) => (
               <BuildCardLink
                 key={build.id}

--- a/src/lib/db/builds.ts
+++ b/src/lib/db/builds.ts
@@ -60,6 +60,7 @@ export interface BuildWithUser {
     id: string
     name: string | null
     username: string | null
+    displayUsername: string | null
     image: string | null
   }
   organization: {
@@ -101,6 +102,7 @@ export interface GetBuildsOptions {
   category?: string
   query?: string
   author?: string
+  organizationId?: string
   hasGuide?: boolean
   hasShards?: boolean
 }
@@ -118,6 +120,7 @@ export interface BuildListItem {
   user: {
     name: string | null
     username: string | null
+    displayUsername: string | null
   }
   organization: {
     id: string
@@ -221,6 +224,7 @@ const buildInclude = {
       id: true,
       name: true,
       username: true,
+      displayUsername: true,
       image: true,
     },
   },
@@ -265,6 +269,7 @@ const buildListSelect = {
     select: {
       name: true,
       username: true,
+      displayUsername: true,
     },
   },
   itemUniqueName: true,
@@ -569,6 +574,7 @@ export async function getPublicBuilds(
     category,
     query,
     author,
+    organizationId,
     hasGuide,
     hasShards,
   } = options
@@ -584,6 +590,7 @@ export async function getPublicBuilds(
         username: { equals: author, mode: "insensitive" },
       },
     }),
+    ...(organizationId && { organizationId }),
     ...(hasGuide === true && { hasGuide: true }),
     ...(hasShards === true && { hasShards: true }),
   }

--- a/src/lib/db/favorites.ts
+++ b/src/lib/db/favorites.ts
@@ -37,6 +37,7 @@ export interface FavoriteBuildWithDetails {
     id: string
     name: string | null
     username: string | null
+    displayUsername: string | null
     image: string | null
   }
   item: {
@@ -129,6 +130,7 @@ export async function getUserFavoriteBuilds(
                 id: true,
                 name: true,
                 username: true,
+                displayUsername: true,
                 image: true,
               },
             },


### PR DESCRIPTION
## Summary
- Replace 6-column card grid with horizontal list rows on the Community Builds page
- Each build card now shows: 80px thumbnail, full title, item name + author, date/category badges, and vote/view stats
- Fix category labels to display proper names (e.g. "Exalted Weapon" instead of "exalted-weapons")
- Add truncation support to OrgBadge component
- Org names shown in purple text inline (no ORG pill) on the builds list

## Test plan
- [ ] Verify builds page renders correctly with list layout on prod
- [ ] Check long build titles are no longer truncated
- [ ] Verify org names display in purple without wrapping
- [ ] Confirm category badges show proper labels
- [ ] Test hover state on build cards
- [ ] Verify vote/view stats display correctly