### PR TITLE
feat: build list layout, view toggle, and UX improvements

### DIFF
--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -4,12 +4,10 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 
-import { BuildCardLink } from "@/components/build/build-card-link"
-import { BuildsResults } from "@/components/builds/builds-results"
+import { BrowseItemBuilds } from "@/components/build/browse-item-builds"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Icons } from "@/components/icons"
-import { OrgBadge } from "@/components/org"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -413,39 +411,7 @@ async function CommunityBuildsSection({
           </CardContent>
         </Card>
       ) : (
-        <BuildsResults
-          renderCard={(layout) =>
-            builds.map((build) => (
-              <BuildCardLink
-                key={build.id}
-                slug={build.slug}
-                name={build.name}
-                itemName={build.item.name}
-                itemImageName={build.item.imageName}
-                voteCount={build.voteCount}
-                viewCount={build.viewCount}
-                layout={layout}
-                subtitle={
-                  layout === "list"
-                    ? build.organization ? (
-                        <p className="line-clamp-1 text-sm">
-                          <OrgBadge
-                            name={build.organization.name}
-                            slug={build.organization.slug}
-                            linked={false}
-                          />
-                        </p>
-                      ) : (
-                        <p className="text-muted-foreground line-clamp-1 text-sm">
-                          by {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
-                        </p>
-                      )
-                    : undefined
-                }
-              />
-            ))
-          }
-        />
+        <BrowseItemBuilds builds={builds} />
       )}
     </section>
   )

--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation"
 import { Suspense } from "react"
 
 import { BuildCardLink } from "@/components/build/build-card-link"
+import { BuildsResults } from "@/components/builds/builds-results"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Icons } from "@/components/icons"
@@ -412,34 +413,39 @@ async function CommunityBuildsSection({
           </CardContent>
         </Card>
       ) : (
-        <div className="flex flex-col gap-2.5">
-          {builds.map((build) => (
-            <BuildCardLink
-              key={build.id}
-              slug={build.slug}
-              name={build.name}
-              itemName={build.item.name}
-              itemImageName={build.item.imageName}
-              voteCount={build.voteCount}
-              viewCount={build.viewCount}
-              subtitle={
-                build.organization ? (
-                  <p className="line-clamp-1 text-xs">
-                    <OrgBadge
-                      name={build.organization.name}
-                      slug={build.organization.slug}
-                      linked={false}
-                    />
-                  </p>
-                ) : (
-                  <p className="text-muted-foreground line-clamp-1 text-xs">
-                    by {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
-                  </p>
-                )
-              }
-            />
-          ))}
-        </div>
+        <BuildsResults
+          renderCard={(layout) =>
+            builds.map((build) => (
+              <BuildCardLink
+                key={build.id}
+                slug={build.slug}
+                name={build.name}
+                itemName={build.item.name}
+                itemImageName={build.item.imageName}
+                voteCount={build.voteCount}
+                viewCount={build.viewCount}
+                layout={layout}
+                subtitle={
+                  layout === "list"
+                    ? build.organization ? (
+                        <p className="line-clamp-1 text-sm">
+                          <OrgBadge
+                            name={build.organization.name}
+                            slug={build.organization.slug}
+                            linked={false}
+                          />
+                        </p>
+                      ) : (
+                        <p className="text-muted-foreground line-clamp-1 text-sm">
+                          by {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
+                        </p>
+                      )
+                    : undefined
+                }
+              />
+            ))
+          }
+        />
       )}
     </section>
   )

--- a/src/app/builds/mine/page.tsx
+++ b/src/app/builds/mine/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { redirect } from "next/navigation"
 
 import { BuildCardLink } from "@/components/build/build-card-link"
+import { BuildsResults } from "@/components/builds/builds-results"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Badge } from "@/components/ui/badge"
@@ -123,32 +124,35 @@ export default async function MyBuildsPage({
             </div>
           ) : (
             <>
-              <div className="flex flex-col gap-2.5">
-                {builds.map((build) => (
-                  <BuildCardLink
-                    key={build.id}
-                    slug={build.slug}
-                    name={build.name}
-                    itemName={build.item.name}
-                    itemImageName={build.item.imageName}
-                    voteCount={build.voteCount}
-                    viewCount={build.viewCount}
-                    imageOverlay={
-                      <div className="absolute top-2 right-2">
-                        <Badge
-                          variant="secondary"
-                          className="gap-1 px-1.5 py-0.5 text-xs"
-                        >
-                          {getVisibilityIcon(build.visibility)}
-                          <span className="hidden sm:inline">
-                            {getVisibilityLabel(build.visibility)}
-                          </span>
-                        </Badge>
-                      </div>
-                    }
-                  />
-                ))}
-              </div>
+              <BuildsResults
+                renderCard={(layout) =>
+                  builds.map((build) => (
+                    <BuildCardLink
+                      key={build.id}
+                      slug={build.slug}
+                      name={build.name}
+                      itemName={build.item.name}
+                      itemImageName={build.item.imageName}
+                      voteCount={build.voteCount}
+                      viewCount={build.viewCount}
+                      layout={layout}
+                      imageOverlay={
+                        <div className="absolute top-2 right-2">
+                          <Badge
+                            variant="secondary"
+                            className="gap-1 px-1.5 py-0.5 text-xs"
+                          >
+                            {getVisibilityIcon(build.visibility)}
+                            <span className="hidden sm:inline">
+                              {getVisibilityLabel(build.visibility)}
+                            </span>
+                          </Badge>
+                        </div>
+                      }
+                    />
+                  ))
+                }
+              />
 
               {/* Pagination */}
               {totalPages > 1 && (

--- a/src/app/builds/page.tsx
+++ b/src/app/builds/page.tsx
@@ -1,20 +1,15 @@
 import type { Metadata } from "next"
-import Image from "next/image"
 import Link from "next/link"
 import { Suspense } from "react"
 
 import { CategoryTabs } from "@/components/browse/category-tabs"
 import { SearchBar } from "@/components/browse/search-bar"
-import { BuildStats } from "@/components/build/build-card-link"
 import { BuildsFilterDropdown, BuildsSortDropdown } from "@/components/builds"
-import { BuildsResults } from "@/components/builds/builds-results"
+import { CommunityBuildsList } from "@/components/builds/community-builds-list"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { getPublicBuilds, type BuildListItem } from "@/lib/db/index"
-import { getImageUrl } from "@/lib/warframe/images"
-import { getCategoryConfig } from "@/lib/warframe/categories"
+import { getPublicBuilds } from "@/lib/db/index"
 import type { BrowseCategory } from "@/lib/warframe/types"
 
 export const metadata: Metadata = {
@@ -32,22 +27,6 @@ interface BuildsPageProps {
     hasGuide?: string
     hasShards?: string
   }>
-}
-
-// Simple relative time formatting without date-fns
-function getRelativeTime(date: Date): string {
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMs / 3600000)
-  const diffDays = Math.floor(diffMs / 86400000)
-
-  if (diffMins < 1) return "just now"
-  if (diffMins < 60) return `${diffMins}m ago`
-  if (diffHours < 24) return `${diffHours}h ago`
-  if (diffDays < 30) return `${diffDays}d ago`
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`
-  return `${Math.floor(diffDays / 365)}y ago`
 }
 
 /** Build a URLSearchParams string preserving all active filters */
@@ -74,99 +53,6 @@ function buildFilterUrl(
   if (overrides.page) params.set("page", overrides.page)
   const str = params.toString()
   return `/builds${str ? `?${str}` : ""}`
-}
-
-function BuildCard({ build, layout = "list" }: { build: BuildListItem; layout?: "grid" | "list" }) {
-  const timeAgo = getRelativeTime(new Date(build.createdAt))
-  const categoryLabel =
-    getCategoryConfig(build.item.browseCategory as BrowseCategory)?.label ??
-    build.item.browseCategory
-  const authorName =
-    build.user.displayUsername || build.user.username || build.user.name || "Anonymous"
-
-  if (layout === "grid") {
-    return (
-      <Link
-        href={`/builds/${build.slug}`}
-        className="bg-card hover:bg-card/80 block overflow-hidden rounded-lg border transition-colors"
-      >
-        <div className="bg-muted/20 relative aspect-video">
-          <Image
-            src={getImageUrl(build.item.imageName ?? undefined)}
-            alt={build.item.name}
-            fill
-            unoptimized
-            sizes="(max-width: 768px) 50vw, 300px"
-            className="object-cover"
-          />
-        </div>
-        <div className="flex flex-col gap-1 p-3">
-          <h3 className="line-clamp-1 text-sm font-semibold">{build.name}</h3>
-          <p className="text-muted-foreground text-xs">{build.item.name}</p>
-          <BuildStats voteCount={build.voteCount} viewCount={build.viewCount} />
-        </div>
-      </Link>
-    )
-  }
-
-  return (
-    <div className="bg-card hover:bg-card/80 relative flex items-center gap-4 rounded-lg border p-4 transition-colors">
-      {/* Full-card link */}
-      <Link
-        href={`/builds/${build.slug}`}
-        className="absolute inset-0 rounded-lg"
-        aria-label={build.name}
-      />
-
-      {/* Item Image */}
-      <div className="bg-muted/20 relative size-20 shrink-0 overflow-hidden rounded-lg">
-        <Image
-          src={getImageUrl(build.item.imageName ?? undefined)}
-          alt={build.item.name}
-          fill
-          unoptimized
-          sizes="80px"
-          className="object-cover"
-        />
-      </div>
-
-      {/* Build Info */}
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <h3 className="truncate text-base font-semibold">{build.name}</h3>
-        <p className="text-muted-foreground text-sm">
-          {build.item.name} build by{" "}
-          {build.organization ? (
-            <Link
-              href={`/org/${build.organization.slug}`}
-              className="relative z-10 text-[#a78bfa] underline decoration-[#a78bfa]/40 hover:decoration-[#a78bfa]"
-            >
-              {build.organization.name}
-            </Link>
-          ) : (
-            <Link
-              href={`/profile/${build.user.username || ""}`}
-              className="relative z-10 underline decoration-current/40 hover:decoration-current"
-            >
-              {authorName}
-            </Link>
-          )}
-        </p>
-        <div className="flex gap-2 pt-1">
-          <Badge variant="secondary" className="text-xs">
-            {timeAgo}
-          </Badge>
-          <Badge variant="secondary" className="text-xs">
-            {categoryLabel}
-          </Badge>
-        </div>
-      </div>
-
-      {/* Stats */}
-      <div className="shrink-0 pl-4">
-        <BuildStats voteCount={build.voteCount} viewCount={build.viewCount} />
-      </div>
-    </div>
-  )
 }
 
 export default async function BuildsPage({ searchParams }: BuildsPageProps) {
@@ -259,14 +145,7 @@ export default async function BuildsPage({ searchParams }: BuildsPageProps) {
             </div>
           ) : (
             <>
-              <BuildsResults
-                count={total}
-                renderCard={(layout) =>
-                  builds.map((build) => (
-                    <BuildCard key={build.id} build={build} layout={layout} />
-                  ))
-                }
-              />
+              <CommunityBuildsList builds={builds} count={total} />
 
               {/* Pagination */}
               {totalPages > 1 && (

--- a/src/app/builds/page.tsx
+++ b/src/app/builds/page.tsx
@@ -7,6 +7,7 @@ import { CategoryTabs } from "@/components/browse/category-tabs"
 import { SearchBar } from "@/components/browse/search-bar"
 import { BuildStats } from "@/components/build/build-card-link"
 import { BuildsFilterDropdown, BuildsSortDropdown } from "@/components/builds"
+import { BuildsResults } from "@/components/builds/builds-results"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Badge } from "@/components/ui/badge"
@@ -75,13 +76,38 @@ function buildFilterUrl(
   return `/builds${str ? `?${str}` : ""}`
 }
 
-function BuildCard({ build }: { build: BuildListItem }) {
+function BuildCard({ build, layout = "list" }: { build: BuildListItem; layout?: "grid" | "list" }) {
   const timeAgo = getRelativeTime(new Date(build.createdAt))
   const categoryLabel =
     getCategoryConfig(build.item.browseCategory as BrowseCategory)?.label ??
     build.item.browseCategory
   const authorName =
     build.user.displayUsername || build.user.username || build.user.name || "Anonymous"
+
+  if (layout === "grid") {
+    return (
+      <Link
+        href={`/builds/${build.slug}`}
+        className="bg-card hover:bg-card/80 block overflow-hidden rounded-lg border transition-colors"
+      >
+        <div className="bg-muted/20 relative aspect-video">
+          <Image
+            src={getImageUrl(build.item.imageName ?? undefined)}
+            alt={build.item.name}
+            fill
+            unoptimized
+            sizes="(max-width: 768px) 50vw, 300px"
+            className="object-cover"
+          />
+        </div>
+        <div className="flex flex-col gap-1 p-3">
+          <h3 className="line-clamp-1 text-sm font-semibold">{build.name}</h3>
+          <p className="text-muted-foreground text-xs">{build.item.name}</p>
+          <BuildStats voteCount={build.voteCount} viewCount={build.viewCount} />
+        </div>
+      </Link>
+    )
+  }
 
   return (
     <div className="bg-card hover:bg-card/80 relative flex items-center gap-4 rounded-lg border p-4 transition-colors">
@@ -219,12 +245,6 @@ export default async function BuildsPage({ searchParams }: BuildsPageProps) {
             />
           </Suspense>
 
-          {/* Results info */}
-          <div className="text-muted-foreground text-sm">
-            {total} {total === 1 ? "build" : "builds"}
-            {q && ` matching "${q}"`}
-          </div>
-
           {/* Results */}
           {builds.length === 0 ? (
             <div className="py-16 text-center">
@@ -239,11 +259,14 @@ export default async function BuildsPage({ searchParams }: BuildsPageProps) {
             </div>
           ) : (
             <>
-              <div className="flex flex-col gap-2.5">
-                {builds.map((build) => (
-                  <BuildCard key={build.id} build={build} />
-                ))}
-              </div>
+              <BuildsResults
+                count={total}
+                renderCard={(layout) =>
+                  builds.map((build) => (
+                    <BuildCard key={build.id} build={build} layout={layout} />
+                  ))
+                }
+              />
 
               {/* Pagination */}
               {totalPages > 1 && (

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { redirect } from "next/navigation"
 
 import { BuildCardLink } from "@/components/build/build-card-link"
+import { BuildsResults } from "@/components/builds/builds-results"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Button } from "@/components/ui/button"
@@ -64,25 +65,30 @@ export default async function FavoritesPage({
             </div>
           ) : (
             <>
-              <div className="flex flex-col gap-2.5">
-                {builds.map((build) => (
-                  <BuildCardLink
-                    key={build.id}
-                    slug={build.slug}
-                    name={build.name}
-                    itemName={build.item.name}
-                    itemImageName={build.item.imageName}
-                    voteCount={build.voteCount}
-                    viewCount={build.viewCount}
-                    subtitle={
-                      <p className="text-muted-foreground line-clamp-1 text-xs">
-                        {build.item.name} by{" "}
-                        {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
-                      </p>
-                    }
-                  />
-                ))}
-              </div>
+              <BuildsResults
+                renderCard={(layout) =>
+                  builds.map((build) => (
+                    <BuildCardLink
+                      key={build.id}
+                      slug={build.slug}
+                      name={build.name}
+                      itemName={build.item.name}
+                      itemImageName={build.item.imageName}
+                      voteCount={build.voteCount}
+                      viewCount={build.viewCount}
+                      layout={layout}
+                      subtitle={
+                        layout === "list" ? (
+                          <p className="text-muted-foreground line-clamp-1 text-sm">
+                            {build.item.name} by{" "}
+                            {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
+                          </p>
+                        ) : undefined
+                      }
+                    />
+                  ))
+                }
+              />
 
               {/* Pagination */}
               {totalPages > 1 && (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import { Toaster } from "sonner"
 
+import { ViewPreferenceProvider } from "@/components/build/view-preference"
 import { ThemeProvider } from "@/components/theme-provider"
 
 import "./globals.css"
@@ -52,7 +53,9 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <ViewPreferenceProvider>
+            {children}
+          </ViewPreferenceProvider>
           <Toaster
             richColors
             position="bottom-right"

--- a/src/components/build/browse-item-builds.tsx
+++ b/src/components/build/browse-item-builds.tsx
@@ -11,6 +11,7 @@ interface BrowseItemBuild {
   item: { name: string; imageName: string | null }
   voteCount: number
   viewCount: number
+  createdAt: Date
   user: {
     name: string | null
     username: string | null
@@ -37,6 +38,7 @@ export function BrowseItemBuilds({ builds }: { builds: BrowseItemBuild[] }) {
           itemImageName={build.item.imageName}
           voteCount={build.voteCount}
           viewCount={build.viewCount}
+          createdAt={build.createdAt}
           layout={layout}
           subtitle={
             layout === "list"

--- a/src/components/build/browse-item-builds.tsx
+++ b/src/components/build/browse-item-builds.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { BuildCardLink } from "@/components/build/build-card-link"
+import { BuildList, useBuildLayout } from "@/components/build/build-list"
+import { OrgBadge } from "@/components/org"
+
+interface BrowseItemBuild {
+  id: string
+  slug: string
+  name: string
+  item: { name: string; imageName: string | null }
+  voteCount: number
+  viewCount: number
+  user: {
+    name: string | null
+    username: string | null
+    displayUsername: string | null
+  }
+  organization: {
+    id: string
+    name: string
+    slug: string
+  } | null
+}
+
+export function BrowseItemBuilds({ builds }: { builds: BrowseItemBuild[] }) {
+  const layout = useBuildLayout()
+
+  return (
+    <BuildList>
+      {builds.map((build) => (
+        <BuildCardLink
+          key={build.id}
+          slug={build.slug}
+          name={build.name}
+          itemName={build.item.name}
+          itemImageName={build.item.imageName}
+          voteCount={build.voteCount}
+          viewCount={build.viewCount}
+          layout={layout}
+          subtitle={
+            layout === "list"
+              ? build.organization ? (
+                  <p className="line-clamp-1 text-sm">
+                    <OrgBadge
+                      name={build.organization.name}
+                      slug={build.organization.slug}
+                      linked={false}
+                    />
+                  </p>
+                ) : (
+                  <p className="text-muted-foreground line-clamp-1 text-sm">
+                    by {build.user.displayUsername || build.user.username || build.user.name || "Anonymous"}
+                  </p>
+                )
+              : undefined
+          }
+        />
+      ))}
+    </BuildList>
+  )
+}

--- a/src/components/build/build-card-link.tsx
+++ b/src/components/build/build-card-link.tsx
@@ -52,7 +52,7 @@ export function BuildCardLink({
           />
           {imageOverlay}
         </div>
-        <div className="flex flex-col gap-1 p-3">
+        <div className="flex flex-col gap-1 p-2">
           <h3 className="line-clamp-1 text-sm font-semibold">{name}</h3>
           {subtitle ?? (
             <p className="text-muted-foreground text-xs">{itemName}</p>

--- a/src/components/build/build-card-link.tsx
+++ b/src/components/build/build-card-link.tsx
@@ -15,12 +15,28 @@ interface BuildCardLinkProps {
   voteCount: number
   viewCount: number
   layout?: ViewMode
+  createdAt?: Date
   /** Optional content rendered over the image (e.g. visibility badge) */
   imageOverlay?: ReactNode
   /** Optional subtitle line (e.g. "by username") */
   subtitle?: ReactNode
   /** Optional extra content after stats */
   footer?: ReactNode
+}
+
+function getRelativeTime(date: Date): string {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return "just now"
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 30) return `${diffDays}d ago`
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`
+  return `${Math.floor(diffDays / 365)}y ago`
 }
 
 export function BuildCardLink({
@@ -31,6 +47,7 @@ export function BuildCardLink({
   voteCount,
   viewCount,
   layout = "list",
+  createdAt,
   imageOverlay,
   subtitle,
   footer,
@@ -57,7 +74,10 @@ export function BuildCardLink({
           {subtitle ?? (
             <p className="text-muted-foreground text-xs">{itemName}</p>
           )}
-          <BuildStats voteCount={voteCount} viewCount={viewCount} />
+          <div className="text-muted-foreground flex items-center justify-between text-xs">
+            <BuildStats voteCount={voteCount} viewCount={viewCount} />
+            {createdAt && <span>{getRelativeTime(new Date(createdAt))}</span>}
+          </div>
           {footer}
         </div>
       </Link>

--- a/src/components/build/build-card-link.tsx
+++ b/src/components/build/build-card-link.tsx
@@ -5,6 +5,8 @@ import type { ReactNode } from "react"
 
 import { getImageUrl } from "@/lib/warframe/images"
 
+import type { ViewMode } from "./view-preference"
+
 interface BuildCardLinkProps {
   slug: string
   name: string
@@ -12,6 +14,7 @@ interface BuildCardLinkProps {
   itemImageName: string | null
   voteCount: number
   viewCount: number
+  layout?: ViewMode
   /** Optional content rendered over the image (e.g. visibility badge) */
   imageOverlay?: ReactNode
   /** Optional subtitle line (e.g. "by username") */
@@ -27,10 +30,40 @@ export function BuildCardLink({
   itemImageName,
   voteCount,
   viewCount,
+  layout = "list",
   imageOverlay,
   subtitle,
   footer,
 }: BuildCardLinkProps) {
+  if (layout === "grid") {
+    return (
+      <Link
+        href={`/builds/${slug}`}
+        className="bg-card hover:bg-card/80 block overflow-hidden rounded-lg border transition-colors"
+      >
+        <div className="bg-muted/20 relative aspect-video">
+          <Image
+            src={getImageUrl(itemImageName ?? undefined)}
+            alt={itemName}
+            fill
+            unoptimized
+            sizes="(max-width: 768px) 50vw, 300px"
+            className="object-cover"
+          />
+          {imageOverlay}
+        </div>
+        <div className="flex flex-col gap-1 p-3">
+          <h3 className="line-clamp-1 text-sm font-semibold">{name}</h3>
+          {subtitle ?? (
+            <p className="text-muted-foreground text-xs">{itemName}</p>
+          )}
+          <BuildStats voteCount={voteCount} viewCount={viewCount} />
+          {footer}
+        </div>
+      </Link>
+    )
+  }
+
   return (
     <Link
       href={`/builds/${slug}`}

--- a/src/components/build/build-list.tsx
+++ b/src/components/build/build-list.tsx
@@ -31,7 +31,7 @@ export function BuildList({ children, count, className }: BuildListProps) {
       <div
         className={
           viewMode === "grid"
-            ? "grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+            ? "grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6"
             : "flex flex-col gap-2.5"
         }
       >

--- a/src/components/build/build-list.tsx
+++ b/src/components/build/build-list.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import type { ReactNode } from "react"
+
+import { cn } from "@/lib/utils"
+
+import { useViewPreference, ViewToggle } from "./view-preference"
+
+interface BuildListProps {
+  children: ReactNode
+  /** Count label shown next to the toggle, e.g. "5 builds" */
+  count?: number
+  className?: string
+}
+
+export function BuildList({ children, count, className }: BuildListProps) {
+  const { viewMode } = useViewPreference()
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      <div className="flex items-center justify-between">
+        {count !== undefined ? (
+          <p className="text-muted-foreground text-sm">
+            {count} {count === 1 ? "build" : "builds"}
+          </p>
+        ) : (
+          <div />
+        )}
+        <ViewToggle />
+      </div>
+      <div
+        className={
+          viewMode === "grid"
+            ? "grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+            : "flex flex-col gap-2.5"
+        }
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export function useBuildLayout() {
+  return useViewPreference().viewMode
+}

--- a/src/components/build/view-preference.tsx
+++ b/src/components/build/view-preference.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { LayoutGrid, List } from "lucide-react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export type ViewMode = "grid" | "list"
+
+const STORAGE_KEY = "arsenyx_view_preference"
+
+interface ViewPreferenceContextValue {
+  viewMode: ViewMode
+  setViewMode: (mode: ViewMode) => void
+}
+
+const ViewPreferenceContext = createContext<ViewPreferenceContextValue>({
+  viewMode: "grid",
+  setViewMode: () => {},
+})
+
+export function ViewPreferenceProvider({ children }: { children: ReactNode }) {
+  const [viewMode, setViewModeState] = useState<ViewMode>("grid")
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (saved === "grid" || saved === "list") {
+        setViewModeState(saved)
+      }
+    } catch {
+      // localStorage unavailable
+    }
+  }, [])
+
+  const setViewMode = useCallback((mode: ViewMode) => {
+    setViewModeState(mode)
+    try {
+      localStorage.setItem(STORAGE_KEY, mode)
+    } catch {
+      // localStorage unavailable
+    }
+  }, [])
+
+  return (
+    <ViewPreferenceContext value={{ viewMode, setViewMode }}>
+      {children}
+    </ViewPreferenceContext>
+  )
+}
+
+export function useViewPreference() {
+  return useContext(ViewPreferenceContext)
+}
+
+export function ViewToggle({ className }: { className?: string }) {
+  const { viewMode, setViewMode } = useViewPreference()
+
+  return (
+    <div className={cn("flex items-center gap-0.5", className)}>
+      <Button
+        variant="ghost"
+        size="sm"
+        className={cn(
+          "size-8 p-0",
+          viewMode === "grid" && "bg-accent text-accent-foreground",
+        )}
+        onClick={() => setViewMode("grid")}
+        aria-label="Grid view"
+      >
+        <LayoutGrid className="size-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className={cn(
+          "size-8 p-0",
+          viewMode === "list" && "bg-accent text-accent-foreground",
+        )}
+        onClick={() => setViewMode("list")}
+        aria-label="List view"
+      >
+        <List className="size-4" />
+      </Button>
+    </div>
+  )
+}

--- a/src/components/builds/builds-results.tsx
+++ b/src/components/builds/builds-results.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import type { ReactNode } from "react"
+
+import { BuildList, useBuildLayout } from "@/components/build/build-list"
+
+/**
+ * Client wrapper that provides view mode context to server-rendered build cards.
+ * Used by the community builds page where BuildCard is a server component.
+ */
+export function BuildsResults({
+  children,
+  count,
+  renderCard,
+}: {
+  children?: ReactNode
+  count?: number
+  renderCard?: (layout: "grid" | "list") => ReactNode
+}) {
+  const layout = useBuildLayout()
+
+  return (
+    <BuildList count={count}>
+      {renderCard ? renderCard(layout) : children}
+    </BuildList>
+  )
+}

--- a/src/components/builds/community-builds-list.tsx
+++ b/src/components/builds/community-builds-list.tsx
@@ -60,13 +60,27 @@ function CommunityBuildCard({
             className="object-cover"
           />
         </div>
-        <div className="flex flex-col gap-1 p-3">
+        <div className="flex flex-col gap-1 p-2">
           <h3 className="line-clamp-1 text-sm font-semibold">{build.name}</h3>
-          <p className="text-muted-foreground text-xs">{build.item.name}</p>
-          <BuildStats
-            voteCount={build.voteCount}
-            viewCount={build.viewCount}
-          />
+          <p className="text-muted-foreground line-clamp-1 text-xs">
+            {build.item.name}
+          </p>
+          <p className="text-muted-foreground line-clamp-1 text-xs">
+            {build.organization ? (
+              <span className="text-[#a78bfa]">
+                {build.organization.name}
+              </span>
+            ) : (
+              <>by {authorName}</>
+            )}
+          </p>
+          <div className="text-muted-foreground flex items-center justify-between text-xs">
+            <BuildStats
+              voteCount={build.voteCount}
+              viewCount={build.viewCount}
+            />
+            <span>{timeAgo}</span>
+          </div>
         </div>
       </Link>
     )

--- a/src/components/builds/community-builds-list.tsx
+++ b/src/components/builds/community-builds-list.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import Image from "next/image"
+import Link from "next/link"
+
+import { BuildStats } from "@/components/build/build-card-link"
+import { BuildList, useBuildLayout } from "@/components/build/build-list"
+import { Badge } from "@/components/ui/badge"
+import type { BuildListItem } from "@/lib/db/index"
+import { getCategoryConfig } from "@/lib/warframe/categories"
+import { getImageUrl } from "@/lib/warframe/images"
+import type { BrowseCategory } from "@/lib/warframe/types"
+
+// Simple relative time formatting
+function getRelativeTime(date: Date): string {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return "just now"
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 30) return `${diffDays}d ago`
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`
+  return `${Math.floor(diffDays / 365)}y ago`
+}
+
+function CommunityBuildCard({
+  build,
+  layout,
+}: {
+  build: BuildListItem
+  layout: "grid" | "list"
+}) {
+  const timeAgo = getRelativeTime(new Date(build.createdAt))
+  const categoryLabel =
+    getCategoryConfig(build.item.browseCategory as BrowseCategory)?.label ??
+    build.item.browseCategory
+  const authorName =
+    build.user.displayUsername ||
+    build.user.username ||
+    build.user.name ||
+    "Anonymous"
+
+  if (layout === "grid") {
+    return (
+      <Link
+        href={`/builds/${build.slug}`}
+        className="bg-card hover:bg-card/80 block overflow-hidden rounded-lg border transition-colors"
+      >
+        <div className="bg-muted/20 relative aspect-video">
+          <Image
+            src={getImageUrl(build.item.imageName ?? undefined)}
+            alt={build.item.name}
+            fill
+            unoptimized
+            sizes="(max-width: 768px) 50vw, 300px"
+            className="object-cover"
+          />
+        </div>
+        <div className="flex flex-col gap-1 p-3">
+          <h3 className="line-clamp-1 text-sm font-semibold">{build.name}</h3>
+          <p className="text-muted-foreground text-xs">{build.item.name}</p>
+          <BuildStats
+            voteCount={build.voteCount}
+            viewCount={build.viewCount}
+          />
+        </div>
+      </Link>
+    )
+  }
+
+  return (
+    <div className="bg-card hover:bg-card/80 relative flex items-center gap-4 rounded-lg border p-4 transition-colors">
+      <Link
+        href={`/builds/${build.slug}`}
+        className="absolute inset-0 rounded-lg"
+        aria-label={build.name}
+      />
+      <div className="bg-muted/20 relative size-20 shrink-0 overflow-hidden rounded-lg">
+        <Image
+          src={getImageUrl(build.item.imageName ?? undefined)}
+          alt={build.item.name}
+          fill
+          unoptimized
+          sizes="80px"
+          className="object-cover"
+        />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <h3 className="truncate text-base font-semibold">{build.name}</h3>
+        <p className="text-muted-foreground text-sm">
+          {build.item.name} build by{" "}
+          {build.organization ? (
+            <Link
+              href={`/org/${build.organization.slug}`}
+              className="relative z-10 text-[#a78bfa] underline decoration-[#a78bfa]/40 hover:decoration-[#a78bfa]"
+            >
+              {build.organization.name}
+            </Link>
+          ) : (
+            <Link
+              href={`/profile/${build.user.username || ""}`}
+              className="relative z-10 underline decoration-current/40 hover:decoration-current"
+            >
+              {authorName}
+            </Link>
+          )}
+        </p>
+        <div className="flex gap-2 pt-1">
+          <Badge variant="secondary" className="text-xs">
+            {timeAgo}
+          </Badge>
+          <Badge variant="secondary" className="text-xs">
+            {categoryLabel}
+          </Badge>
+        </div>
+      </div>
+      <div className="shrink-0 pl-4">
+        <BuildStats voteCount={build.voteCount} viewCount={build.viewCount} />
+      </div>
+    </div>
+  )
+}
+
+export function CommunityBuildsList({
+  builds,
+  count,
+}: {
+  builds: BuildListItem[]
+  count: number
+}) {
+  const layout = useBuildLayout()
+
+  return (
+    <BuildList count={count}>
+      {builds.map((build) => (
+        <CommunityBuildCard key={build.id} build={build} layout={layout} />
+      ))}
+    </BuildList>
+  )
+}

--- a/src/components/profile/profile-builds.tsx
+++ b/src/components/profile/profile-builds.tsx
@@ -135,6 +135,7 @@ export function ProfileBuilds({
                 itemImageName={build.item.imageName}
                 voteCount={build.voteCount}
                 viewCount={build.viewCount}
+                createdAt={build.createdAt}
                 layout={layout}
               />
             ))}

--- a/src/components/profile/profile-builds.tsx
+++ b/src/components/profile/profile-builds.tsx
@@ -7,6 +7,7 @@ import {
   getProfileBuildsAction,
 } from "@/app/actions/profile"
 import { BuildCardLink } from "@/components/build/build-card-link"
+import { BuildList, useBuildLayout } from "@/components/build/build-list"
 import { Button } from "@/components/ui/button"
 import {
   Empty,
@@ -35,6 +36,7 @@ export function ProfileBuilds({
   initialHasMore,
   emptyMessage = "This user hasn't created any builds yet",
 }: ProfileBuildsProps) {
+  const layout = useBuildLayout()
   const [builds, setBuilds] = useState(initialBuilds)
   const [hasMore, setHasMore] = useState(initialHasMore)
   const [page, setPage] = useState(1)
@@ -123,7 +125,7 @@ export function ProfileBuilds({
         </Empty>
       ) : (
         <>
-          <div className="flex flex-col gap-2.5">
+          <BuildList>
             {builds.map((build) => (
               <BuildCardLink
                 key={build.id}
@@ -133,9 +135,10 @@ export function ProfileBuilds({
                 itemImageName={build.item.imageName}
                 voteCount={build.voteCount}
                 viewCount={build.viewCount}
+                layout={layout}
               />
             ))}
-          </div>
+          </BuildList>
           {hasMore && (
             <div className="flex justify-center">
               <Button


### PR DESCRIPTION
## Summary
- Switch build cards from grid to list layout with horizontal rows (thumbnail, title, author, stats)
- Add global grid/list view toggle (localStorage-backed, grid default) across all build list pages
- Fix category labels to show proper names (e.g. "Exalted Weapon" not "exalted-weapons")
- Use displayUsername for correct capitalization (e.g. "Reuzehagel" not "reuzehagel")
- Make org/user names clickable links on build cards
- Add build search and category filter to org pages
- Add dates and author info to grid cards

## Test plan
- [ ] Verify grid/list toggle works on community builds page
- [ ] Verify toggle preference persists across pages via localStorage
- [ ] Check grid shows 6 columns with author, stats, and date
- [ ] Check list shows horizontal rows with full titles
- [ ] Verify org page has search and category filter
- [ ] Verify usernames show correct capitalization
- [ ] Verify org/user names are clickable links in list view