### PR TITLE
fix: hydrate helminth augment mods during build load

### DIFF
--- a/src/components/build-editor/build-container.tsx
+++ b/src/components/build-editor/build-container.tsx
@@ -74,6 +74,7 @@ export function BuildContainer({
     compatibleMods,
     compatibleArcanes,
     importedBuild,
+    helminthAugmentMods,
   })
 
   // Merge helminth augment mods into the compatible mods list when a

--- a/src/components/build-editor/hooks/use-build-state.ts
+++ b/src/components/build-editor/hooks/use-build-state.ts
@@ -152,11 +152,11 @@ export function createInitialBuildState(
 
     const modMap = new Map(compatibleMods.map((m) => [m.uniqueName, m]))
 
-    // Include helminth augment mods in the lookup map so they hydrate correctly
-    if (helminthAugmentMods && importedBuild.helminthAbility) {
-      const augments =
-        helminthAugmentMods[importedBuild.helminthAbility.ability.uniqueName]
-      if (augments) {
+    // Include helminth augment mods in the lookup map so they hydrate correctly.
+    // Add ALL helminth augments (not just for the current ability) to handle builds
+    // saved before helminthAbility tracking was added.
+    if (helminthAugmentMods) {
+      for (const augments of Object.values(helminthAugmentMods)) {
         for (const mod of augments) {
           if (!modMap.has(mod.uniqueName)) {
             modMap.set(mod.uniqueName, mod)

--- a/src/components/build-editor/hooks/use-build-state.ts
+++ b/src/components/build-editor/hooks/use-build-state.ts
@@ -111,6 +111,7 @@ export function createInitialBuildState(
   compatibleMods: Mod[],
   importedBuild?: Partial<BuildState>,
   compatibleArcanes?: Arcane[],
+  helminthAugmentMods?: Record<string, Mod[]>,
 ): BuildState {
   const baseState = createBaseBuildState(item, category)
 
@@ -150,6 +151,19 @@ export function createInitialBuildState(
     }
 
     const modMap = new Map(compatibleMods.map((m) => [m.uniqueName, m]))
+
+    // Include helminth augment mods in the lookup map so they hydrate correctly
+    if (helminthAugmentMods && importedBuild.helminthAbility) {
+      const augments =
+        helminthAugmentMods[importedBuild.helminthAbility.ability.uniqueName]
+      if (augments) {
+        for (const mod of augments) {
+          if (!modMap.has(mod.uniqueName)) {
+            modMap.set(mod.uniqueName, mod)
+          }
+        }
+      }
+    }
 
     const hydrateSlot = (slot: ModSlot) => {
       if (slot.mod) {
@@ -543,6 +557,7 @@ export interface UseBuildStateProps {
   compatibleMods: Mod[]
   compatibleArcanes: Arcane[]
   importedBuild?: Partial<BuildState>
+  helminthAugmentMods?: Record<string, Mod[]>
 }
 
 export function useBuildState({
@@ -551,10 +566,11 @@ export function useBuildState({
   compatibleMods,
   compatibleArcanes,
   importedBuild,
+  helminthAugmentMods,
 }: UseBuildStateProps) {
   const [buildState, dispatch] = useReducer(
     buildReducer,
-    { item, category, compatibleMods, compatibleArcanes, importedBuild },
+    { item, category, compatibleMods, compatibleArcanes, importedBuild, helminthAugmentMods },
     (init) =>
       createInitialBuildState(
         init.item,
@@ -562,6 +578,7 @@ export function useBuildState({
         init.compatibleMods,
         init.importedBuild,
         init.compatibleArcanes,
+        init.helminthAugmentMods,
       ),
   )
 

--- a/src/components/build-editor/hooks/use-build-state.ts
+++ b/src/components/build-editor/hooks/use-build-state.ts
@@ -152,15 +152,11 @@ export function createInitialBuildState(
 
     const modMap = new Map(compatibleMods.map((m) => [m.uniqueName, m]))
 
-    // Include helminth augment mods in the lookup map so they hydrate correctly.
-    // Add ALL helminth augments (not just for the current ability) to handle builds
-    // saved before helminthAbility tracking was added.
+    // Add all helminth augments so they hydrate even without helminthAbility data
     if (helminthAugmentMods) {
       for (const augments of Object.values(helminthAugmentMods)) {
         for (const mod of augments) {
-          if (!modMap.has(mod.uniqueName)) {
-            modMap.set(mod.uniqueName, mod)
-          }
+          modMap.set(mod.uniqueName, mod)
         }
       }
     }

--- a/src/lib/build-codec.ts
+++ b/src/lib/build-codec.ts
@@ -26,6 +26,14 @@ interface EncodedBuild {
   ar?: EncodedArcane[] // Arcane slots (2)
   sh?: number[] // Shard slots (5) - encoded as numbers
   n?: string // Build name
+  h?: EncodedHelminth // Helminth ability
+}
+
+interface EncodedHelminth {
+  si: number // Slot index (which ability was replaced)
+  u: string // Ability unique name
+  n: string // Ability name
+  s: string // Source warframe name
 }
 
 interface EncodedSlot {
@@ -80,6 +88,15 @@ export function encodeBuild(state: BuildState): string {
     state.shardSlots.some((s) => s !== null)
   ) {
     encoded.sh = encodeShards(state.shardSlots)
+  }
+
+  if (state.helminthAbility) {
+    encoded.h = {
+      si: state.helminthAbility.slotIndex,
+      u: state.helminthAbility.ability.uniqueName,
+      n: state.helminthAbility.ability.name,
+      s: state.helminthAbility.ability.source,
+    }
   }
 
   if (state.buildName) {
@@ -216,6 +233,18 @@ export function decodeBuild(base64String: string): Partial<BuildState> | null {
     // Decode shards
     if (encoded.sh) {
       state.shardSlots = decodeShards(encoded.sh)
+    }
+
+    // Decode helminth ability
+    if (encoded.h) {
+      state.helminthAbility = {
+        slotIndex: encoded.h.si,
+        ability: {
+          uniqueName: encoded.h.u,
+          name: encoded.h.n,
+          source: encoded.h.s,
+        },
+      }
     }
 
     return state

--- a/src/lib/build-codec.ts
+++ b/src/lib/build-codec.ts
@@ -34,6 +34,8 @@ interface EncodedHelminth {
   u: string // Ability unique name
   n: string // Ability name
   s: string // Source warframe name
+  im?: string // Ability image name
+  d?: string // Ability description
 }
 
 interface EncodedSlot {
@@ -96,6 +98,8 @@ export function encodeBuild(state: BuildState): string {
       u: state.helminthAbility.ability.uniqueName,
       n: state.helminthAbility.ability.name,
       s: state.helminthAbility.ability.source,
+      im: state.helminthAbility.ability.imageName,
+      d: state.helminthAbility.ability.description,
     }
   }
 
@@ -243,6 +247,8 @@ export function decodeBuild(base64String: string): Partial<BuildState> | null {
           uniqueName: encoded.h.u,
           name: encoded.h.n,
           source: encoded.h.s,
+          imageName: encoded.h.im,
+          description: encoded.h.d,
         },
       }
     }

--- a/src/lib/build-codec.ts
+++ b/src/lib/build-codec.ts
@@ -30,12 +30,12 @@ interface EncodedBuild {
 }
 
 interface EncodedHelminth {
-  si: number // Slot index (which ability was replaced)
-  u: string // Ability unique name
-  n: string // Ability name
-  s: string // Source warframe name
-  im?: string // Ability image name
-  d?: string // Ability description
+  si: number // Replaced ability slot
+  u: string // Unique name
+  n: string // Name
+  s: string // Source warframe
+  im?: string // Image name
+  d?: string // Description
 }
 
 interface EncodedSlot {


### PR DESCRIPTION
## Summary
- Helminth augment mods (e.g. Shock Trooper on Chroma with subsumed Shock) were rendering as "?" cards on saved builds
- Root cause: `createInitialBuildState` built its mod lookup map from only the base compatible mods, excluding helminth augments which were merged later in a `useMemo`
- Now passes `helminthAugmentMods` into initial state creation so augments are resolved on first render, fixing the "?" display and React hydration error #418

## Test plan
- [ ] Load the Chroma Prime Solo Profit Taker build (or any build with a helminth ability + its augment mod)
- [ ] Verify Shock Trooper renders correctly instead of showing "?"
- [ ] Verify no React hydration errors in console
- [ ] Verify editing mode still correctly merges helminth augments into the search panel