### PR TITLE
fix: revalidate browse pages after build deletion

### DIFF
--- a/src/app/actions/builds.ts
+++ b/src/app/actions/builds.ts
@@ -6,6 +6,7 @@
  * Authenticated actions for build CRUD operations
  */
 
+import { revalidatePath } from "next/cache"
 import { after } from "next/server"
 
 import { getServerSession } from "@/lib/auth"
@@ -125,6 +126,8 @@ export async function deleteBuildAction(
     if (!auth.success) return auth
 
     await deleteBuild(buildId, auth.data)
+    revalidatePath("/browse/[category]/[slug]", "page")
+    revalidatePath("/builds", "page")
     return ok()
   } catch (error) {
     console.error("Failed to delete build:", error)


### PR DESCRIPTION
## Summary
- Adds `revalidatePath` calls to `deleteBuildAction` so browse and builds pages reflect deletions immediately
- Without this, deleted builds remained visible on `/browse/[category]/[slug]` and `/builds` until the cache expired

## Test plan
- [ ] Delete a build and verify it no longer appears on the item's browse page
- [ ] Verify the `/builds` listing also updates after deletion