### PR TITLE
Remove non-functional notifications button

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -46,10 +46,6 @@ export function Header() {
 
         <div className="flex items-center gap-1">
           <SearchCommand />
-          <Button variant="ghost" size="icon" className="hidden sm:flex">
-            <Icons.bell />
-            <span className="sr-only">Notifications</span>
-          </Button>
           <ThemeToggle />
           <div className="hidden md:flex">
             <UserMenu />


### PR DESCRIPTION
## Summary
- Removed the bell icon button from the header that had no implementation behind it
- No notifications system exists (no backend, no data model), so the button was dead UI

## Why
Rather than building a full notifications feature (table, read/unread state, polling, dropdown UI) for a build planner app where it adds little value, just remove the button. It can be re-added if a real use case emerges later.

Closes #34