### PR TITLE
Fix Zaws: stats, mods, browse filtering, and component selection

### DIFF
--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -480,11 +480,17 @@ function getZawStrikeStats(item: { attacks?: Attack[] }): {
     0,
   )
 
+  // WFCD attack mode stats may be in percentage (18) or decimal (0.18) form.
+  // Mirror the normalization used in weapon-stats.ts so display stays consistent.
+  const rawCrit = attack.crit_chance ?? 0
+  const rawStatus = attack.status_chance ?? 0
+  const toDecimal = (v: number) => (v > 1 ? v / 100 : v)
+
   return {
     totalDamage,
-    criticalChance: (attack.crit_chance ?? 0) / 100,
-    criticalMultiplier: attack.crit_mult ?? 1,
-    statusChance: (attack.status_chance ?? 0) / 100,
+    criticalChance: toDecimal(rawCrit),
+    criticalMultiplier: attack.crit_mult ?? 2,
+    statusChance: toDecimal(rawStatus),
     fireRate: attack.speed ?? 1,
   }
 }

--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -17,7 +17,7 @@ import { getPublicBuildsForItem } from "@/lib/db/index"
 import { getCategoryConfig, getImageUrl, isValidCategory } from "@/lib/warframe"
 // Server-only imports (uses Node.js fs via @wfcd/items)
 import { getItemBySlug, getStaticItems } from "@/lib/warframe/items"
-import type { BrowseCategory, Warframe, Gun, Melee } from "@/lib/warframe/types"
+import type { Attack, BrowseCategory, Warframe, Gun, Melee } from "@/lib/warframe/types"
 
 // Generate static params for top items
 export async function generateStaticParams() {
@@ -166,7 +166,9 @@ export default async function ItemPage({ params }: ItemPageProps) {
                   <div className="flex items-center gap-1">
                     <span className="text-muted-foreground">Type:</span>
                     <span className="font-medium">
-                      {(item as { type?: string }).type}
+                      {(item as { type?: string }).type === "Zaw Component"
+                        ? "Zaw Strike"
+                        : (item as { type?: string }).type}
                     </span>
                   </div>
                 )}
@@ -222,8 +224,46 @@ export default async function ItemPage({ params }: ItemPageProps) {
               </Card>
             )}
 
+            {/* Zaw Strike Stats (from attacks array) */}
+            {isWeapon &&
+              (item as { type?: string }).type === "Zaw Component" && (() => {
+                const zawStats = getZawStrikeStats(item as { attacks?: Attack[] })
+                if (!zawStats) return null
+                return (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-lg">Strike Stats</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <dl className="grid grid-cols-2 gap-3 text-sm">
+                        <StatItem
+                          label="Damage"
+                          value={Math.round(zawStats.totalDamage)}
+                        />
+                        <StatItem
+                          label="Crit Chance"
+                          value={`${(zawStats.criticalChance * 100).toFixed(1)}%`}
+                        />
+                        <StatItem
+                          label="Crit Multi"
+                          value={`${zawStats.criticalMultiplier}x`}
+                        />
+                        <StatItem
+                          label="Status"
+                          value={`${(zawStats.statusChance * 100).toFixed(1)}%`}
+                        />
+                        <StatItem
+                          label="Attack Speed"
+                          value={zawStats.fireRate}
+                        />
+                      </dl>
+                    </CardContent>
+                  </Card>
+                )
+              })()}
+
             {/* Weapon Stats */}
-            {isWeapon && (
+            {isWeapon && (item as { type?: string }).type !== "Zaw Component" && (
               <Card>
                 <CardHeader>
                   <CardTitle className="text-lg">Weapon Stats</CardTitle>
@@ -415,6 +455,38 @@ async function CommunityBuildsSection({
       )}
     </section>
   )
+}
+
+/** Extract display stats from a Zaw Strike's attacks array */
+function getZawStrikeStats(item: { attacks?: Attack[] }): {
+  totalDamage: number
+  criticalChance: number
+  criticalMultiplier: number
+  statusChance: number
+  fireRate: number
+} | null {
+  const attacks = item.attacks
+  if (!attacks || attacks.length === 0) return null
+
+  const attack = attacks[0]
+  const damage =
+    typeof attack.damage === "object" && attack.damage
+      ? attack.damage
+      : null
+  if (!damage) return null
+
+  const totalDamage = Object.values(damage).reduce(
+    (sum: number, v) => sum + (typeof v === "number" ? v : 0),
+    0,
+  )
+
+  return {
+    totalDamage,
+    criticalChance: (attack.crit_chance ?? 0) / 100,
+    criticalMultiplier: attack.crit_mult ?? 1,
+    statusChance: (attack.status_chance ?? 0) / 100,
+    fireRate: attack.speed ?? 1,
+  }
 }
 
 function StatItem({

--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -230,13 +230,13 @@ export default async function ItemPage({ params }: ItemPageProps) {
                 </CardHeader>
                 <CardContent>
                   <dl className="grid grid-cols-2 gap-3 text-sm">
-                    {(item as Gun).totalDamage && (
+                    {!!(item as Gun).totalDamage && (
                       <StatItem
                         label="Damage"
                         value={(item as Gun).totalDamage}
                       />
                     )}
-                    {(item as Gun).criticalChance && (
+                    {!!(item as Gun).criticalChance && (
                       <StatItem
                         label="Crit Chance"
                         value={`${((item as Gun).criticalChance! * 100).toFixed(
@@ -244,13 +244,13 @@ export default async function ItemPage({ params }: ItemPageProps) {
                         )}%`}
                       />
                     )}
-                    {(item as Gun).criticalMultiplier && (
+                    {!!(item as Gun).criticalMultiplier && (
                       <StatItem
                         label="Crit Multi"
                         value={`${(item as Gun).criticalMultiplier}x`}
                       />
                     )}
-                    {(item as Gun).procChance && (
+                    {!!(item as Gun).procChance && (
                       <StatItem
                         label="Status"
                         value={`${((item as Gun).procChance! * 100).toFixed(
@@ -258,25 +258,25 @@ export default async function ItemPage({ params }: ItemPageProps) {
                         )}%`}
                       />
                     )}
-                    {(item as Gun).fireRate && (
+                    {!!(item as Gun).fireRate && (
                       <StatItem
                         label="Fire Rate"
                         value={parseFloat((item as Gun).fireRate!.toFixed(3))}
                       />
                     )}
-                    {(item as Gun).magazineSize && (
+                    {!!(item as Gun).magazineSize && (
                       <StatItem
                         label="Magazine"
                         value={(item as Gun).magazineSize}
                       />
                     )}
-                    {(item as Gun).reloadTime && (
+                    {!!(item as Gun).reloadTime && (
                       <StatItem
                         label="Reload"
                         value={`${parseFloat((item as Gun).reloadTime!.toFixed(2))}s`}
                       />
                     )}
-                    {isMelee && (item as Melee).range && (
+                    {isMelee && !!(item as Melee).range && (
                       <StatItem label="Range" value={(item as Melee).range} />
                     )}
                   </dl>

--- a/src/app/browse/[category]/[slug]/page.tsx
+++ b/src/app/browse/[category]/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { getPublicBuildsForItem } from "@/lib/db/index"
 import { getCategoryConfig, getImageUrl, isValidCategory } from "@/lib/warframe"
 // Server-only imports (uses Node.js fs via @wfcd/items)
 import { getItemBySlug, getStaticItems } from "@/lib/warframe/items"
+import { sumDamageTypes } from "@/lib/warframe/stats/stat-engine"
 import type { Attack, BrowseCategory, Warframe, Gun, Melee } from "@/lib/warframe/types"
 
 // Generate static params for top items
@@ -475,22 +476,16 @@ function getZawStrikeStats(item: { attacks?: Attack[] }): {
       : null
   if (!damage) return null
 
-  const totalDamage = Object.values(damage).reduce(
-    (sum: number, v) => sum + (typeof v === "number" ? v : 0),
-    0,
-  )
+  const totalDamage = sumDamageTypes(damage)
 
-  // WFCD attack mode stats may be in percentage (18) or decimal (0.18) form.
-  // Mirror the normalization used in weapon-stats.ts so display stays consistent.
-  const rawCrit = attack.crit_chance ?? 0
-  const rawStatus = attack.status_chance ?? 0
+  // WFCD attack stats may be percentage (18) or decimal (0.18) — normalize to decimal.
   const toDecimal = (v: number) => (v > 1 ? v / 100 : v)
 
   return {
     totalDamage,
-    criticalChance: toDecimal(rawCrit),
+    criticalChance: toDecimal(attack.crit_chance ?? 0),
     criticalMultiplier: attack.crit_mult ?? 2,
-    statusChance: toDecimal(rawStatus),
+    statusChance: toDecimal(attack.status_chance ?? 0),
     fireRate: attack.speed ?? 1,
   }
 }

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -12,6 +12,21 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-04-16",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Zaw support — select Grip and Link components for Zaw Strike builds with dynamic stat recalculation",
+      },
+      {
+        type: "fix",
+        description:
+          "Fixed Zaw Strikes showing no mods and zero stats on the browse page",
+      },
+    ],
+  },
+  {
     date: "2026-04-15",
     changes: [
       {

--- a/src/components/build-editor/build-container.tsx
+++ b/src/components/build-editor/build-container.tsx
@@ -445,6 +445,7 @@ export function BuildContainer({
                 }
                 arcaneDataMap={arcaneDataMap}
                 zawComponents={buildState.zawComponents}
+                zawStrikeName={item.name}
                 onZawGripChange={handleSetZawGrip}
                 onZawLinkChange={handleSetZawLink}
                 readOnly={!canEdit}

--- a/src/components/build-editor/build-container.tsx
+++ b/src/components/build-editor/build-container.tsx
@@ -444,9 +444,15 @@ export function BuildContainer({
                   undefined
                 }
                 arcaneDataMap={arcaneDataMap}
-                zawComponents={buildState.zawComponents}
-                onZawGripChange={handleSetZawGrip}
-                onZawLinkChange={handleSetZawLink}
+                zawComponents={
+                  buildState.zawComponents
+                    ? {
+                        ...buildState.zawComponents,
+                        onGripChange: handleSetZawGrip,
+                        onLinkChange: handleSetZawLink,
+                      }
+                    : undefined
+                }
                 readOnly={!canEdit}
               />
             </div>

--- a/src/components/build-editor/build-container.tsx
+++ b/src/components/build-editor/build-container.tsx
@@ -67,6 +67,8 @@ export function BuildContainer({
     handleChangeArcaneRank,
     handlePlaceShard,
     handleRemoveShard,
+    handleSetZawGrip,
+    handleSetZawLink,
     usedModNames,
     usedArcaneNames,
     arcaneDataMap,
@@ -442,6 +444,9 @@ export function BuildContainer({
                   undefined
                 }
                 arcaneDataMap={arcaneDataMap}
+                zawComponents={buildState.zawComponents}
+                onZawGripChange={handleSetZawGrip}
+                onZawLinkChange={handleSetZawLink}
                 readOnly={!canEdit}
               />
             </div>

--- a/src/components/build-editor/build-container.tsx
+++ b/src/components/build-editor/build-container.tsx
@@ -445,7 +445,6 @@ export function BuildContainer({
                 }
                 arcaneDataMap={arcaneDataMap}
                 zawComponents={buildState.zawComponents}
-                zawStrikeName={item.name}
                 onZawGripChange={handleSetZawGrip}
                 onZawLinkChange={handleSetZawLink}
                 readOnly={!canEdit}

--- a/src/components/build-editor/hooks/use-build-state.ts
+++ b/src/components/build-editor/hooks/use-build-state.ts
@@ -119,7 +119,6 @@ export function createInitialBuildState(
 
   if (isZawStrike(item.name) && !importedBuild?.zawComponents) {
     baseState.zawComponents = {
-      strike: item.name,
       grip: "Jayap",
       link: "Jai",
     }

--- a/src/components/build-editor/hooks/use-build-state.ts
+++ b/src/components/build-editor/hooks/use-build-state.ts
@@ -1,6 +1,7 @@
 import { useReducer, useCallback, useMemo } from "react"
 
 import { createBaseBuildState } from "@/lib/builds/layout"
+import { isZawStrike } from "@/lib/warframe/zaw-data"
 import {
   getCapacityStatus,
   calculateTotalEndoCost,
@@ -115,6 +116,14 @@ export function createInitialBuildState(
   helminthAugmentMods?: Record<string, Mod[]>,
 ): BuildState {
   const baseState = createBaseBuildState(item, category)
+
+  if (isZawStrike(item.name) && !importedBuild?.zawComponents) {
+    baseState.zawComponents = {
+      strike: item.name,
+      grip: "Jayap",
+      link: "Jai",
+    }
+  }
 
   if (importedBuild) {
     const mergeSlot = (baseSlot: ModSlot, importedSlot?: ModSlot): ModSlot => {
@@ -261,6 +270,8 @@ export type BuildAction =
       item: BrowseableItem
       category: BrowseCategory
     }
+  | { type: "SET_ZAW_GRIP"; grip: string }
+  | { type: "SET_ZAW_LINK"; link: string }
 
 // Slot-level helpers used by multiple actions
 function getModFromSlot(id: string, state: BuildState): PlacedMod | undefined {
@@ -547,6 +558,23 @@ function buildReducer(state: BuildState, action: BuildAction): BuildState {
       }
     }
 
+    case "SET_ZAW_GRIP": {
+      return {
+        ...state,
+        zawComponents: state.zawComponents
+          ? { ...state.zawComponents, grip: action.grip }
+          : undefined,
+      }
+    }
+    case "SET_ZAW_LINK": {
+      return {
+        ...state,
+        zawComponents: state.zawComponents
+          ? { ...state.zawComponents, link: action.link }
+          : undefined,
+      }
+    }
+
     default:
       return state
   }
@@ -664,6 +692,18 @@ export function useBuildState({
     dispatch({ type: "REMOVE_SHARD", slotIndex })
   }, [])
 
+  // --- Zaw actions ---
+
+  const handleSetZawGrip = useCallback(
+    (grip: string) => dispatch({ type: "SET_ZAW_GRIP", grip }),
+    [dispatch],
+  )
+
+  const handleSetZawLink = useCallback(
+    (link: string) => dispatch({ type: "SET_ZAW_LINK", link }),
+    [dispatch],
+  )
+
   // --- Derived state ---
 
   const usedModNames = useMemo((): Set<string> => {
@@ -728,6 +768,9 @@ export function useBuildState({
 
     handlePlaceShard,
     handleRemoveShard,
+
+    handleSetZawGrip,
+    handleSetZawLink,
 
     usedModNames,
     usedArcaneNames,

--- a/src/components/build-editor/mod-grid.tsx
+++ b/src/components/build-editor/mod-grid.tsx
@@ -78,7 +78,9 @@ interface ModGridProps {
   readOnly?: boolean
   /** Number of normal slots per row (default: 4) */
   slotsPerRow?: number
-  zawComponents?: { strike: string; grip: string; link: string }
+  /** Present when the build item is a Zaw Strike. The strike name is the item name. */
+  zawComponents?: { grip: string; link: string }
+  zawStrikeName?: string
   onZawGripChange?: (grip: string) => void
   onZawLinkChange?: (link: string) => void
 }
@@ -103,6 +105,7 @@ export function ModGrid({
   readOnly = false,
   slotsPerRow = 4,
   zawComponents,
+  zawStrikeName,
   onZawGripChange,
   onZawLinkChange,
 }: ModGridProps) {
@@ -217,9 +220,9 @@ export function ModGrid({
                 readOnly={readOnly}
               />
             ))}
-            {zawComponents && (
+            {zawComponents && zawStrikeName && (
               <ZawComponentSelector
-                strikeName={zawComponents.strike}
+                strikeName={zawStrikeName}
                 gripName={zawComponents.grip}
                 linkName={zawComponents.link}
                 onGripChange={onZawGripChange ?? (() => {})}

--- a/src/components/build-editor/mod-grid.tsx
+++ b/src/components/build-editor/mod-grid.tsx
@@ -2,7 +2,7 @@
 
 import { useDroppable, useDraggable } from "@dnd-kit/core"
 import { CSS } from "@dnd-kit/utilities"
-import { Plus, X } from "lucide-react"
+import { Pencil, Plus, X } from "lucide-react"
 import { useState, useMemo, memo } from "react"
 
 import { PolarityIcon } from "@/components/icons"
@@ -431,15 +431,11 @@ const ModSlotCard = memo(function ModSlotCard({
               isDragging && "opacity-0",
               transform && "will-change-transform",
             )}
-            onClick={(e) => {
+            onClick={() => {
               if (readOnly) return
-              if (e.shiftKey) {
-                setPolarityOpen(true)
-              } else if (slot.mod && isRivenMod(slot.mod) && onRivenEdit) {
-                onRivenEdit(slot.id, slot.mod)
-              } else {
-                onSelect()
-              }
+              onSelect()
+              // Click bubbles to PopoverTrigger to open the polarity picker.
+              // Riven stat editing lives on the pencil button below.
             }}
             onContextMenu={(e: React.MouseEvent) => {
               e.preventDefault()
@@ -472,6 +468,24 @@ const ModSlotCard = memo(function ModSlotCard({
               <X className="size-3" />
             </button>
           )}
+          {!readOnly &&
+            !isDragging &&
+            slot.mod &&
+            isRivenMod(slot.mod) &&
+            onRivenEdit && (
+              <button
+                type="button"
+                className="bg-background/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground absolute top-4 -right-1.5 z-10 flex size-5 items-center justify-center rounded-full border transition-opacity group-hover:opacity-100 max-md:opacity-100 md:opacity-0"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setPolarityOpen(false)
+                  onRivenEdit(slot.id, slot.mod!)
+                }}
+                aria-label="Edit riven stats"
+              >
+                <Pencil className="size-3" />
+              </button>
+            )}
         </PopoverTrigger>
         {!readOnly && polaritySelectorContent}
       </Popover>

--- a/src/components/build-editor/mod-grid.tsx
+++ b/src/components/build-editor/mod-grid.tsx
@@ -78,9 +78,8 @@ interface ModGridProps {
   readOnly?: boolean
   /** Number of normal slots per row (default: 4) */
   slotsPerRow?: number
-  /** Present when the build item is a Zaw Strike. The strike name is the item name. */
+  /** Present when the build item is a Zaw Strike. */
   zawComponents?: { grip: string; link: string }
-  zawStrikeName?: string
   onZawGripChange?: (grip: string) => void
   onZawLinkChange?: (link: string) => void
 }
@@ -105,7 +104,6 @@ export function ModGrid({
   readOnly = false,
   slotsPerRow = 4,
   zawComponents,
-  zawStrikeName,
   onZawGripChange,
   onZawLinkChange,
 }: ModGridProps) {
@@ -220,9 +218,8 @@ export function ModGrid({
                 readOnly={readOnly}
               />
             ))}
-            {zawComponents && zawStrikeName && (
+            {zawComponents && (
               <ZawComponentSelector
-                strikeName={zawStrikeName}
                 gripName={zawComponents.grip}
                 linkName={zawComponents.link}
                 onGripChange={onZawGripChange ?? (() => {})}

--- a/src/components/build-editor/mod-grid.tsx
+++ b/src/components/build-editor/mod-grid.tsx
@@ -78,10 +78,13 @@ interface ModGridProps {
   readOnly?: boolean
   /** Number of normal slots per row (default: 4) */
   slotsPerRow?: number
-  /** Present when the build item is a Zaw Strike. */
-  zawComponents?: { grip: string; link: string }
-  onZawGripChange?: (grip: string) => void
-  onZawLinkChange?: (link: string) => void
+  /** Present when the build item is a Zaw Strike. Handlers required when set. */
+  zawComponents?: {
+    grip: string
+    link: string
+    onGripChange: (grip: string) => void
+    onLinkChange: (link: string) => void
+  }
 }
 
 export function ModGrid({
@@ -104,8 +107,6 @@ export function ModGrid({
   readOnly = false,
   slotsPerRow = 4,
   zawComponents,
-  onZawGripChange,
-  onZawLinkChange,
 }: ModGridProps) {
   // Calculate set counts
   const setCounts = useMemo(() => {
@@ -222,8 +223,8 @@ export function ModGrid({
               <ZawComponentSelector
                 gripName={zawComponents.grip}
                 linkName={zawComponents.link}
-                onGripChange={onZawGripChange ?? (() => {})}
-                onLinkChange={onZawLinkChange ?? (() => {})}
+                onGripChange={zawComponents.onGripChange}
+                onLinkChange={zawComponents.onLinkChange}
                 readOnly={readOnly}
               />
             )}

--- a/src/components/build-editor/mod-grid.tsx
+++ b/src/components/build-editor/mod-grid.tsx
@@ -37,6 +37,7 @@ import type {
 } from "@/lib/warframe/types"
 
 import { ArcaneSlotCard } from "./arcane-slot-card"
+import { ZawComponentSelector } from "./zaw-component-selector"
 
 // All available polarities for the selector
 const ALL_POLARITIES: Polarity[] = [
@@ -77,6 +78,9 @@ interface ModGridProps {
   readOnly?: boolean
   /** Number of normal slots per row (default: 4) */
   slotsPerRow?: number
+  zawComponents?: { strike: string; grip: string; link: string }
+  onZawGripChange?: (grip: string) => void
+  onZawLinkChange?: (link: string) => void
 }
 
 export function ModGrid({
@@ -98,6 +102,9 @@ export function ModGrid({
   arcaneDataMap,
   readOnly = false,
   slotsPerRow = 4,
+  zawComponents,
+  onZawGripChange,
+  onZawLinkChange,
 }: ModGridProps) {
   // Calculate set counts
   const setCounts = useMemo(() => {
@@ -190,9 +197,9 @@ export function ModGrid({
           ),
         )}
 
-        {/* Row 4: Arcanes */}
-        {arcaneSlots.length > 0 && (
-          <div className="mt-2 flex w-full justify-center gap-3 sm:gap-6">
+        {/* Row 4: Arcanes + Zaw Components */}
+        {(arcaneSlots.length > 0 || zawComponents) && (
+          <div className="mt-2 flex w-full items-start justify-center gap-3 sm:gap-6">
             {arcaneSlots.map((arcane, index) => (
               <ArcaneSlotCard
                 key={`arcane-${index}`}
@@ -210,6 +217,16 @@ export function ModGrid({
                 readOnly={readOnly}
               />
             ))}
+            {zawComponents && (
+              <ZawComponentSelector
+                strikeName={zawComponents.strike}
+                gripName={zawComponents.grip}
+                linkName={zawComponents.link}
+                onGripChange={onZawGripChange ?? (() => {})}
+                onLinkChange={onZawLinkChange ?? (() => {})}
+                readOnly={readOnly}
+              />
+            )}
           </div>
         )}
       </div>

--- a/src/components/build-editor/zaw-component-selector.tsx
+++ b/src/components/build-editor/zaw-component-selector.tsx
@@ -1,15 +1,19 @@
 "use client"
 
+import Image from "next/image"
+import { useState } from "react"
+
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+import { getImageUrl } from "@/lib/warframe/images"
 import {
   ZAW_GRIPS,
   ZAW_LINKS,
+  getZawComponentImage,
   getZawWeaponType,
 } from "@/lib/warframe/zaw-data"
 
@@ -22,9 +26,6 @@ interface ZawComponentSelectorProps {
   readOnly?: boolean
 }
 
-const gripItems = ZAW_GRIPS.map((grip) => ({ value: grip.name, label: grip.name }))
-const linkItems = ZAW_LINKS.map((link) => ({ value: link.name, label: link.name }))
-
 export function ZawComponentSelector({
   strikeName,
   gripName,
@@ -36,68 +37,141 @@ export function ZawComponentSelector({
   const weaponType = getZawWeaponType(strikeName, gripName)
 
   return (
-    <div className="flex flex-col gap-2">
-      <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+    <div className="flex flex-col items-center gap-1.5">
+      <span className="text-muted-foreground/60 font-mono text-[10px] tracking-wider uppercase">
         Zaw Parts
-      </p>
+      </span>
+
+      <div className="flex items-start gap-2 sm:gap-3">
+        <ZawPartCard
+          label="Grip"
+          value={gripName}
+          options={ZAW_GRIPS.map((g) => ({
+            name: g.name,
+            hint: g.oneHanded ? "1H" : "2H",
+          }))}
+          onChange={onGripChange}
+          readOnly={readOnly}
+        />
+        <ZawPartCard
+          label="Link"
+          value={linkName}
+          options={ZAW_LINKS.map((l) => ({ name: l.name }))}
+          onChange={onLinkChange}
+          readOnly={readOnly}
+        />
+      </div>
 
       {weaponType && (
-        <p className="text-xs">
-          <span className="text-muted-foreground">Type: </span>
-          <span className="font-medium">{weaponType}</span>
+        <p className="text-muted-foreground text-[10px]">
+          Type:{" "}
+          <span className="text-foreground font-medium">{weaponType}</span>
         </p>
       )}
-
-      <div className="flex flex-col gap-1.5">
-        <label className="text-muted-foreground text-[10px] uppercase">
-          Grip
-        </label>
-        <Select
-          items={gripItems}
-          value={gripName}
-          onValueChange={(value) => {
-            if (value) onGripChange(value)
-          }}
-        >
-          <SelectTrigger className="h-7 text-xs" disabled={readOnly}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {ZAW_GRIPS.map((grip) => (
-              <SelectItem key={grip.name} value={grip.name}>
-                {grip.name}
-                <span className="text-muted-foreground ml-1">
-                  ({grip.oneHanded ? "1H" : "2H"})
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <label className="text-muted-foreground text-[10px] uppercase">
-          Link
-        </label>
-        <Select
-          items={linkItems}
-          value={linkName}
-          onValueChange={(value) => {
-            if (value) onLinkChange(value)
-          }}
-        >
-          <SelectTrigger className="h-7 text-xs" disabled={readOnly}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {ZAW_LINKS.map((link) => (
-              <SelectItem key={link.name} value={link.name}>
-                {link.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
     </div>
+  )
+}
+
+interface ZawPartCardProps {
+  label: string
+  value: string
+  options: { name: string; hint?: string }[]
+  onChange: (name: string) => void
+  readOnly: boolean
+}
+
+function ZawPartCard({
+  label,
+  value,
+  options,
+  onChange,
+  readOnly,
+}: ZawPartCardProps) {
+  const [open, setOpen] = useState(false)
+  const imageName = getZawComponentImage(value)
+
+  const card = (
+    <div
+      className={cn(
+        "bg-card/80 relative flex flex-col items-center overflow-hidden rounded-md select-none",
+        "h-[80px] w-[90px] sm:h-[90px] sm:w-[110px] md:h-[100px] md:w-[130px]",
+        !readOnly &&
+          "hover:ring-primary/50 cursor-pointer transition-shadow hover:ring-1",
+        open && "ring-primary ring-offset-background ring-2 ring-offset-1",
+      )}
+    >
+      <div className="relative mt-1.5 h-[55px] w-[70px] overflow-hidden rounded sm:h-[60px] sm:w-[76px]">
+        <Image
+          src={getImageUrl(imageName)}
+          alt={value}
+          fill
+          sizes="80px"
+          className="object-contain"
+          unoptimized
+        />
+      </div>
+      <span className="text-foreground mt-0.5 line-clamp-1 px-1 text-center text-[10px] leading-tight font-medium">
+        {value}
+      </span>
+      <span className="text-muted-foreground/70 mt-0.5 text-[9px] font-medium tracking-wider uppercase">
+        {label}
+      </span>
+    </div>
+  )
+
+  if (readOnly) return card
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button type="button" aria-label={`Select ${label.toLowerCase()}`} />
+        }
+      >
+        {card}
+      </PopoverTrigger>
+      <PopoverContent className="w-[260px] p-2" align="center">
+        <div className="grid max-h-[320px] grid-cols-3 gap-1.5 overflow-y-auto">
+          {options.map((opt) => {
+            const optImage = getZawComponentImage(opt.name)
+            const isSelected = opt.name === value
+            return (
+              <button
+                key={opt.name}
+                type="button"
+                onClick={() => {
+                  onChange(opt.name)
+                  setOpen(false)
+                }}
+                className={cn(
+                  "bg-card/60 flex flex-col items-center gap-0.5 rounded p-1 text-[10px] transition-colors",
+                  "hover:bg-accent",
+                  isSelected && "ring-primary ring-1",
+                )}
+              >
+                <div className="relative h-[44px] w-[52px] overflow-hidden rounded">
+                  <Image
+                    src={getImageUrl(optImage)}
+                    alt={opt.name}
+                    fill
+                    sizes="56px"
+                    className="object-contain"
+                    unoptimized
+                  />
+                </div>
+                <span className="line-clamp-1 w-full text-center leading-tight font-medium">
+                  {opt.name}
+                </span>
+                {opt.hint && (
+                  <span className="text-muted-foreground text-[9px]">
+                    {opt.hint}
+                  </span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/src/components/build-editor/zaw-component-selector.tsx
+++ b/src/components/build-editor/zaw-component-selector.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  ZAW_GRIPS,
+  ZAW_LINKS,
+  getZawWeaponType,
+} from "@/lib/warframe/zaw-data"
+
+interface ZawComponentSelectorProps {
+  strikeName: string
+  gripName: string
+  linkName: string
+  onGripChange: (grip: string) => void
+  onLinkChange: (link: string) => void
+  readOnly?: boolean
+}
+
+const gripItems = ZAW_GRIPS.map((grip) => ({ value: grip.name, label: grip.name }))
+const linkItems = ZAW_LINKS.map((link) => ({ value: link.name, label: link.name }))
+
+export function ZawComponentSelector({
+  strikeName,
+  gripName,
+  linkName,
+  onGripChange,
+  onLinkChange,
+  readOnly = false,
+}: ZawComponentSelectorProps) {
+  const weaponType = getZawWeaponType(strikeName, gripName)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+        Zaw Parts
+      </p>
+
+      {weaponType && (
+        <p className="text-xs">
+          <span className="text-muted-foreground">Type: </span>
+          <span className="font-medium">{weaponType}</span>
+        </p>
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-muted-foreground text-[10px] uppercase">
+          Grip
+        </label>
+        <Select
+          items={gripItems}
+          value={gripName}
+          onValueChange={(value) => {
+            if (value) onGripChange(value)
+          }}
+        >
+          <SelectTrigger className="h-7 text-xs" disabled={readOnly}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ZAW_GRIPS.map((grip) => (
+              <SelectItem key={grip.name} value={grip.name}>
+                {grip.name}
+                <span className="text-muted-foreground ml-1">
+                  ({grip.oneHanded ? "1H" : "2H"})
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-muted-foreground text-[10px] uppercase">
+          Link
+        </label>
+        <Select
+          items={linkItems}
+          value={linkName}
+          onValueChange={(value) => {
+            if (value) onLinkChange(value)
+          }}
+        >
+          <SelectTrigger className="h-7 text-xs" disabled={readOnly}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ZAW_LINKS.map((link) => (
+              <SelectItem key={link.name} value={link.name}>
+                {link.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}

--- a/src/components/build-editor/zaw-component-selector.tsx
+++ b/src/components/build-editor/zaw-component-selector.tsx
@@ -14,11 +14,9 @@ import {
   ZAW_GRIPS,
   ZAW_LINKS,
   getZawComponentImage,
-  getZawWeaponType,
 } from "@/lib/warframe/zaw-data"
 
 interface ZawComponentSelectorProps {
-  strikeName: string
   gripName: string
   linkName: string
   onGripChange: (grip: string) => void
@@ -27,47 +25,31 @@ interface ZawComponentSelectorProps {
 }
 
 export function ZawComponentSelector({
-  strikeName,
   gripName,
   linkName,
   onGripChange,
   onLinkChange,
   readOnly = false,
 }: ZawComponentSelectorProps) {
-  const weaponType = getZawWeaponType(strikeName, gripName)
-
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <span className="text-muted-foreground/60 font-mono text-[10px] tracking-wider uppercase">
-        Zaw Parts
-      </span>
-
-      <div className="flex items-start gap-2 sm:gap-3">
-        <ZawPartCard
-          label="Grip"
-          value={gripName}
-          options={ZAW_GRIPS.map((g) => ({
-            name: g.name,
-            hint: g.oneHanded ? "1H" : "2H",
-          }))}
-          onChange={onGripChange}
-          readOnly={readOnly}
-        />
-        <ZawPartCard
-          label="Link"
-          value={linkName}
-          options={ZAW_LINKS.map((l) => ({ name: l.name }))}
-          onChange={onLinkChange}
-          readOnly={readOnly}
-        />
-      </div>
-
-      {weaponType && (
-        <p className="text-muted-foreground text-[10px]">
-          Type:{" "}
-          <span className="text-foreground font-medium">{weaponType}</span>
-        </p>
-      )}
+    <div className="flex items-start gap-2 sm:gap-3">
+      <ZawPartCard
+        label="Grip"
+        value={gripName}
+        options={ZAW_GRIPS.map((g) => ({
+          name: g.name,
+          hint: g.oneHanded ? "1H" : "2H",
+        }))}
+        onChange={onGripChange}
+        readOnly={readOnly}
+      />
+      <ZawPartCard
+        label="Link"
+        value={linkName}
+        options={ZAW_LINKS.map((l) => ({ name: l.name }))}
+        onChange={onLinkChange}
+        readOnly={readOnly}
+      />
     </div>
   )
 }

--- a/src/components/build-editor/zaw-component-selector.tsx
+++ b/src/components/build-editor/zaw-component-selector.tsx
@@ -16,6 +16,12 @@ import {
   getZawComponentImage,
 } from "@/lib/warframe/zaw-data"
 
+const GRIP_OPTIONS = ZAW_GRIPS.map((g) => ({
+  name: g.name,
+  hint: g.oneHanded ? "1H" : "2H",
+}))
+const LINK_OPTIONS = ZAW_LINKS.map((l) => ({ name: l.name }))
+
 interface ZawComponentSelectorProps {
   gripName: string
   linkName: string
@@ -36,17 +42,14 @@ export function ZawComponentSelector({
       <ZawPartCard
         label="Grip"
         value={gripName}
-        options={ZAW_GRIPS.map((g) => ({
-          name: g.name,
-          hint: g.oneHanded ? "1H" : "2H",
-        }))}
+        options={GRIP_OPTIONS}
         onChange={onGripChange}
         readOnly={readOnly}
       />
       <ZawPartCard
         label="Link"
         value={linkName}
-        options={ZAW_LINKS.map((l) => ({ name: l.name }))}
+        options={LINK_OPTIONS}
         onChange={onLinkChange}
         readOnly={readOnly}
       />
@@ -113,7 +116,7 @@ function ZawPartCard({
         {card}
       </PopoverTrigger>
       <PopoverContent className="w-[260px] p-2" align="center">
-        <div className="grid max-h-[320px] grid-cols-3 gap-1.5 overflow-y-auto">
+        <div className="grid max-h-[320px] grid-cols-3 gap-1.5 overflow-y-auto p-0.5">
           {options.map((opt) => {
             const optImage = getZawComponentImage(opt.name)
             const isSelected = opt.name === value
@@ -128,7 +131,7 @@ function ZawPartCard({
                 className={cn(
                   "bg-card/60 flex flex-col items-center gap-0.5 rounded p-1 text-[10px] transition-colors",
                   "hover:bg-accent",
-                  isSelected && "ring-primary ring-1",
+                  isSelected && "ring-primary ring-1 ring-inset",
                 )}
               >
                 <div className="relative h-[44px] w-[52px] overflow-hidden rounded">

--- a/src/lib/__tests__/build-codec.test.ts
+++ b/src/lib/__tests__/build-codec.test.ts
@@ -432,17 +432,15 @@ describe("edge cases", () => {
       itemUniqueName: "/Lotus/Weapons/Tenno/Zaw/ZawStrike",
     })
     build.zawComponents = {
-      strike: "Balla",
       grip: "Korb",
-      link: "Ekwana Jai II",
+      link: "Ekwana Jai Ii",
     }
 
     const encoded = encodeBuild(build)
     const decoded = decodeBuild(encoded)
 
-    expect(decoded?.zawComponents?.strike).toBe("Balla")
     expect(decoded?.zawComponents?.grip).toBe("Korb")
-    expect(decoded?.zawComponents?.link).toBe("Ekwana Jai II")
+    expect(decoded?.zawComponents?.link).toBe("Ekwana Jai Ii")
   })
 
   it("handles all 5 shard slots filled and tauforged", () => {

--- a/src/lib/__tests__/build-codec.test.ts
+++ b/src/lib/__tests__/build-codec.test.ts
@@ -426,6 +426,25 @@ describe("edge cases", () => {
     expect(decoded?.normalSlots?.[0].mod?.baseDrain).toBe(10)
   })
 
+  it("round-trips Zaw components", () => {
+    const build = createEmptyBuildState({
+      itemCategory: "melee",
+      itemUniqueName: "/Lotus/Weapons/Tenno/Zaw/ZawStrike",
+    })
+    build.zawComponents = {
+      strike: "Balla",
+      grip: "Korb",
+      link: "Ekwana Jai II",
+    }
+
+    const encoded = encodeBuild(build)
+    const decoded = decodeBuild(encoded)
+
+    expect(decoded?.zawComponents?.strike).toBe("Balla")
+    expect(decoded?.zawComponents?.grip).toBe("Korb")
+    expect(decoded?.zawComponents?.link).toBe("Ekwana Jai II")
+  })
+
   it("handles all 5 shard slots filled and tauforged", () => {
     const build = createEmptyBuildState()
     build.shardSlots = [

--- a/src/lib/__tests__/build-codec.test.ts
+++ b/src/lib/__tests__/build-codec.test.ts
@@ -433,14 +433,14 @@ describe("edge cases", () => {
     })
     build.zawComponents = {
       grip: "Korb",
-      link: "Ekwana Jai Ii",
+      link: "Ekwana Jai II",
     }
 
     const encoded = encodeBuild(build)
     const decoded = decodeBuild(encoded)
 
     expect(decoded?.zawComponents?.grip).toBe("Korb")
-    expect(decoded?.zawComponents?.link).toBe("Ekwana Jai Ii")
+    expect(decoded?.zawComponents?.link).toBe("Ekwana Jai II")
   })
 
   it("handles all 5 shard slots filled and tauforged", () => {

--- a/src/lib/build-codec.ts
+++ b/src/lib/build-codec.ts
@@ -34,7 +34,7 @@ interface EncodedBuild {
   sh?: number[] // Shard slots (5) - encoded as numbers
   n?: string // Build name
   h?: EncodedHelminth // Helminth ability
-  zc?: { s: string; g: string; l: string } // Zaw components (strike, grip, link)
+  zc?: { g: string; l: string } // Zaw components (grip, link — strike is the item)
 }
 
 interface EncodedHelminth {
@@ -126,7 +126,6 @@ export function encodeBuild(state: BuildState): string {
 
   if (state.zawComponents) {
     encoded.zc = {
-      s: state.zawComponents.strike,
       g: state.zawComponents.grip,
       l: state.zawComponents.link,
     }
@@ -296,7 +295,6 @@ export function decodeBuild(base64String: string): Partial<BuildState> | null {
     // Decode Zaw components
     if (encoded.zc) {
       state.zawComponents = {
-        strike: encoded.zc.s,
         grip: encoded.zc.g,
         link: encoded.zc.l,
       }

--- a/src/lib/build-codec.ts
+++ b/src/lib/build-codec.ts
@@ -34,6 +34,7 @@ interface EncodedBuild {
   sh?: number[] // Shard slots (5) - encoded as numbers
   n?: string // Build name
   h?: EncodedHelminth // Helminth ability
+  zc?: { s: string; g: string; l: string } // Zaw components (strike, grip, link)
 }
 
 interface EncodedHelminth {
@@ -121,6 +122,14 @@ export function encodeBuild(state: BuildState): string {
 
   if (state.buildName) {
     encoded.n = state.buildName
+  }
+
+  if (state.zawComponents) {
+    encoded.zc = {
+      s: state.zawComponents.strike,
+      g: state.zawComponents.grip,
+      l: state.zawComponents.link,
+    }
   }
 
   // Encode to base64
@@ -281,6 +290,15 @@ export function decodeBuild(base64String: string): Partial<BuildState> | null {
           imageName: encoded.h.im,
           description: encoded.h.d,
         },
+      }
+    }
+
+    // Decode Zaw components
+    if (encoded.zc) {
+      state.zawComponents = {
+        strike: encoded.zc.s,
+        grip: encoded.zc.g,
+        link: encoded.zc.l,
       }
     }
 

--- a/src/lib/warframe/__tests__/items-zaw-filter.test.ts
+++ b/src/lib/warframe/__tests__/items-zaw-filter.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test"
+
+import { getItemsByCategory, getItemBySlug } from "../items"
+
+describe("Zaw item filtering", () => {
+  it("includes Zaw Strikes in melee category", () => {
+    const meleeItems = getItemsByCategory("melee")
+    const strikeNames = [
+      "Balla",
+      "Cyath",
+      "Dehtat",
+      "Dokrahm",
+      "Kronsh",
+      "Mewan",
+      "Ooltha",
+      "Rabvee",
+      "Sepfahn",
+      "Plague Keewar",
+      "Plague Kripath",
+    ]
+    for (const name of strikeNames) {
+      expect(
+        meleeItems.some((i) => i.name === name),
+      ).toBe(true)
+    }
+  })
+
+  it("excludes Zaw Grips from melee category", () => {
+    const meleeItems = getItemsByCategory("melee")
+    const gripNames = [
+      "Peye",
+      "Laka",
+      "Kwath",
+      "Seekalla",
+      "Jayap",
+      "Korb",
+      "Kroostra",
+      "Shtung",
+      "Plague Akwin",
+      "Plague Bokwin",
+    ]
+    for (const name of gripNames) {
+      expect(
+        meleeItems.some((i) => i.name === name),
+      ).toBe(false)
+    }
+  })
+
+  it("excludes Zaw Links from melee category", () => {
+    const meleeItems = getItemsByCategory("melee")
+    const linkNames = ["Jai", "Ruhang", "Ekwana Jai", "Vargeet Jai"]
+    for (const name of linkNames) {
+      expect(
+        meleeItems.some((i) => i.name === name),
+      ).toBe(false)
+    }
+  })
+
+  it("excludes PvP duplicate Strikes", () => {
+    const meleeItems = getItemsByCategory("melee")
+    // Each Strike should appear exactly once
+    const ballaCount = meleeItems.filter(
+      (i) => i.name === "Balla",
+    ).length
+    expect(ballaCount).toBe(1)
+  })
+
+  it("returns null for Grip slug lookup", () => {
+    const result = getItemBySlug("melee", "peye")
+    expect(result).toBeNull()
+  })
+})

--- a/src/lib/warframe/__tests__/mods-zaw.test.ts
+++ b/src/lib/warframe/__tests__/mods-zaw.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test"
+
+import { getModsForItem } from "../mods"
+
+describe("Zaw mod filtering", () => {
+  it("returns melee mods for Zaw Component items", () => {
+    const mods = getModsForItem({
+      type: "Zaw Component",
+      category: "Melee",
+      name: "Balla",
+    })
+    expect(mods.length).toBeGreaterThan(0)
+
+    // Should include standard melee mods like Pressure Point
+    const hasPressurePoint = mods.some((m) => m.name === "Pressure Point")
+    expect(hasPressurePoint).toBe(true)
+  })
+
+  it("does not include primary or secondary mods for Zaw Components", () => {
+    const mods = getModsForItem({
+      type: "Zaw Component",
+      category: "Melee",
+      name: "Balla",
+    })
+    const hasSerration = mods.some((m) => m.name === "Serration")
+    const hasHornetStrike = mods.some((m) => m.name === "Hornet Strike")
+    expect(hasSerration).toBe(false)
+    expect(hasHornetStrike).toBe(false)
+  })
+})

--- a/src/lib/warframe/__tests__/zaw-data.test.ts
+++ b/src/lib/warframe/__tests__/zaw-data.test.ts
@@ -58,13 +58,7 @@ describe("Zaw data", () => {
       status_chance: 18,
       speed: 1,
     }
-    const stats = calculateZawBaseStats(
-      strikeAttack,
-      "Peye",
-      "Jai",
-      false,
-      "Balla",
-    )
+    const stats = calculateZawBaseStats(strikeAttack, "Peye", "Jai", "Balla")
     expect(stats.totalDamage).toBeCloseTo(224 - 4)
     expect(stats.speed).toBeCloseTo(1 + 0.083)
   })

--- a/src/lib/warframe/__tests__/zaw-data.test.ts
+++ b/src/lib/warframe/__tests__/zaw-data.test.ts
@@ -39,7 +39,7 @@ describe("Zaw data", () => {
 
   it("identifies links correctly", () => {
     expect(isZawLink("Jai")).toBe(true)
-    expect(isZawLink("Vargeet Jai Ii")).toBe(true)
+    expect(isZawLink("Vargeet Jai II")).toBe(true)
     expect(isZawLink("Balla")).toBe(false)
   })
 

--- a/src/lib/warframe/__tests__/zaw-data.test.ts
+++ b/src/lib/warframe/__tests__/zaw-data.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  ZAW_STRIKES,
+  ZAW_GRIPS,
+  ZAW_LINKS,
+  getZawWeaponType,
+  isZawStrike,
+  isZawGrip,
+  isZawLink,
+  calculateZawBaseStats,
+} from "../zaw-data"
+
+describe("Zaw data", () => {
+  it("has 11 strikes", () => {
+    expect(ZAW_STRIKES).toHaveLength(11)
+  })
+
+  it("has 10 grips", () => {
+    expect(ZAW_GRIPS).toHaveLength(10)
+  })
+
+  it("has 16 links", () => {
+    expect(ZAW_LINKS).toHaveLength(16)
+  })
+
+  it("identifies strikes correctly", () => {
+    expect(isZawStrike("Balla")).toBe(true)
+    expect(isZawStrike("Plague Kripath")).toBe(true)
+    expect(isZawStrike("Peye")).toBe(false)
+    expect(isZawStrike("Jai")).toBe(false)
+  })
+
+  it("identifies grips correctly", () => {
+    expect(isZawGrip("Peye")).toBe(true)
+    expect(isZawGrip("Plague Akwin")).toBe(true)
+    expect(isZawGrip("Balla")).toBe(false)
+  })
+
+  it("identifies links correctly", () => {
+    expect(isZawLink("Jai")).toBe(true)
+    expect(isZawLink("Vargeet Jai Ii")).toBe(true)
+    expect(isZawLink("Balla")).toBe(false)
+  })
+
+  it("resolves weapon type from strike + grip", () => {
+    expect(getZawWeaponType("Balla", "Peye")).toBe("Dagger")
+    expect(getZawWeaponType("Balla", "Jayap")).toBe("Staff")
+    expect(getZawWeaponType("Dokrahm", "Kwath")).toBe("Scythe")
+    expect(getZawWeaponType("Dokrahm", "Kroostra")).toBe("Heavy Blade")
+  })
+
+  it("calculates base stats with grip and link modifiers", () => {
+    const strikeAttack = {
+      damage: { impact: 11.2, puncture: 134.4, slash: 78.4 },
+      crit_chance: 18,
+      crit_mult: 2,
+      status_chance: 18,
+      speed: 1,
+    }
+    const stats = calculateZawBaseStats(
+      strikeAttack,
+      "Peye",
+      "Jai",
+      false,
+      "Balla",
+    )
+    expect(stats.totalDamage).toBeCloseTo(224 - 4)
+    expect(stats.speed).toBeCloseTo(1 + 0.083)
+  })
+})

--- a/src/lib/warframe/__tests__/zaw-data.test.ts
+++ b/src/lib/warframe/__tests__/zaw-data.test.ts
@@ -58,7 +58,12 @@ describe("Zaw data", () => {
       status_chance: 18,
       speed: 1,
     }
-    const stats = calculateZawBaseStats(strikeAttack, "Peye", "Jai", "Balla")
+    const stats = calculateZawBaseStats({
+      strikeAttack,
+      strikeName: "Balla",
+      gripName: "Peye",
+      linkName: "Jai",
+    })
     expect(stats.totalDamage).toBeCloseTo(224 - 4)
     expect(stats.speed).toBeCloseTo(1 + 0.083)
   })

--- a/src/lib/warframe/items.ts
+++ b/src/lib/warframe/items.ts
@@ -93,7 +93,11 @@ function toBrowseItem(
 function categorizeItem(item: BrowseableItem): BrowseCategory[] {
   if (!item.name || item.name.includes(" Blueprint")) return []
 
+  // Filter out items excluded from codex (PvP variants, duplicates)
+  if ((item as { excludeFromCodex?: boolean }).excludeFromCodex) return []
+
   const itemCategory = item.category as string
+  const itemType = (item as { type?: string }).type
   const categories: BrowseCategory[] = []
 
   if (itemCategory === "Warframes") {
@@ -109,7 +113,18 @@ function categorizeItem(item: BrowseableItem): BrowseCategory[] {
     }
   }
 
-  const itemType = (item as { type?: string }).type
+  // Zaw Components: only include Strikes (have attacks array with data).
+  // Filter out Grips and Links — they are not buildable items on their own.
+  if (itemType === "Zaw Component") {
+    const attacks = (item as { attacks?: { damage?: unknown }[] }).attacks
+    const hasAttackData =
+      attacks && attacks.length > 0 && attacks[0].damage != null
+    if (hasAttackData) {
+      categories.push("melee")
+    }
+    return categories
+  }
+
   const isCompanionWeapon = itemType === "Companion Weapon"
 
   // Exclude companion weapons from primary/secondary/melee categories

--- a/src/lib/warframe/mods.ts
+++ b/src/lib/warframe/mods.ts
@@ -290,6 +290,11 @@ export function getModsForItem(item: {
   const itemNameLower = itemName?.toLowerCase() ?? ""
   const allModsNormalized = getAllMods()
 
+  // Zaw Components are melee weapons
+  if (itemTypeLower === "zaw component") {
+    return getModsByCompatibility("Melee")
+  }
+
   return allModsNormalized.filter((mod) => {
     const compatName = mod.compatName?.toLowerCase() ?? ""
     const modType = mod.type?.toLowerCase() ?? ""

--- a/src/lib/warframe/stats/weapon-stats.ts
+++ b/src/lib/warframe/stats/weapon-stats.ts
@@ -1,6 +1,7 @@
 // Weapon-specific stat calculations (guns and melee)
 
 import { parseModStats } from "../stat-parser"
+import { getZawGrip, calculateZawBaseStats } from "../zaw-data"
 import type {
   WeaponStats,
   StatValue,
@@ -34,6 +35,22 @@ export function calculateWeaponStats(
 
   // Check if weapon has specific attack modes defined
   const hasSpecificAttackModes = weapon.attacks && weapon.attacks.length > 0
+
+  // Apply Zaw component modifiers if set
+  let zawOverride: ReturnType<typeof calculateZawBaseStats> | null = null
+  if (buildState.zawComponents && hasSpecificAttackModes) {
+    const { strike, grip, link } = buildState.zawComponents
+    const gripData = getZawGrip(grip)
+    if (gripData && weapon.attacks?.[0]) {
+      zawOverride = calculateZawBaseStats(
+        weapon.attacks[0],
+        grip,
+        link,
+        !gripData.oneHanded,
+        strike,
+      )
+    }
+  }
 
   // Primary attack mode from base weapon stats
   // Only create "Normal Attack" if there are no specific attack modes defined
@@ -115,19 +132,47 @@ export function calculateWeaponStats(
       // Skip "Normal Attack" only if we already created it from base weapon stats above
       if (attack.name === "Normal Attack" && attackModes.length > 0) continue
 
-      const attackDamage =
-        typeof attack.damage === "object" ? sumDamageTypes(attack.damage) : 0
+      const attackDamage = zawOverride
+        ? zawOverride.totalDamage
+        : typeof attack.damage === "object"
+          ? sumDamageTypes(attack.damage)
+          : 0
 
       // WFCD attack mode stats may be in percentage form (34) or decimal form (0.34)
       // Values > 1 are already percentages, values <= 1 need to be multiplied by 100
-      const rawCrit = attack.crit_chance ?? weapon.criticalChance ?? 0
-      const critBase = rawCrit > 1 ? rawCrit : rawCrit * 100
+      // zawOverride values are already in percentage form — skip normalization
+      const rawCrit = zawOverride
+        ? zawOverride.critChance
+        : attack.crit_chance ?? weapon.criticalChance ?? 0
+      const critBase = zawOverride
+        ? rawCrit
+        : rawCrit > 1
+          ? rawCrit
+          : rawCrit * 100
 
       // Critical multiplier is stored as actual multiplier (e.g., 3 for 3x)
-      const critMultBase = attack.crit_mult ?? weapon.criticalMultiplier ?? 1
+      const critMultBase = zawOverride
+        ? zawOverride.critMult
+        : attack.crit_mult ?? weapon.criticalMultiplier ?? 1
 
-      const rawStatus = attack.status_chance ?? weapon.procChance ?? 0
-      const statusBase = rawStatus > 1 ? rawStatus : rawStatus * 100
+      const rawStatus = zawOverride
+        ? zawOverride.statusChance
+        : attack.status_chance ?? weapon.procChance ?? 0
+      const statusBase = zawOverride
+        ? rawStatus
+        : rawStatus > 1
+          ? rawStatus
+          : rawStatus * 100
+
+      const fireRateBase = zawOverride
+        ? zawOverride.speed
+        : attack.speed ?? weapon.fireRate ?? 1
+
+      const damageSource = zawOverride
+        ? zawOverride.damageTypes
+        : typeof attack.damage === "object"
+          ? (attack.damage ?? {})
+          : {}
 
       const mode: AttackModeStats = {
         name: attack.name,
@@ -152,12 +197,12 @@ export function calculateWeaponStats(
         ),
         fireRate: calculateWeaponStat(
           "fire_rate",
-          attack.speed ?? weapon.fireRate ?? 1,
+          fireRateBase,
           mods,
           showMaxStacks,
         ),
         damageBreakdown: calculateDamageBreakdown(
-          typeof attack.damage === "object" ? attack.damage : {},
+          damageSource,
           mods,
           showMaxStacks,
         ),

--- a/src/lib/warframe/stats/weapon-stats.ts
+++ b/src/lib/warframe/stats/weapon-stats.ts
@@ -36,18 +36,17 @@ export function calculateWeaponStats(
   // Check if weapon has specific attack modes defined
   const hasSpecificAttackModes = weapon.attacks && weapon.attacks.length > 0
 
-  // Apply Zaw component modifiers if set
+  // Apply Zaw component modifiers if set. The Strike is the weapon being built.
   let zawOverride: ReturnType<typeof calculateZawBaseStats> | null = null
   if (buildState.zawComponents && hasSpecificAttackModes) {
-    const { strike, grip, link } = buildState.zawComponents
+    const { grip, link } = buildState.zawComponents
     const gripData = getZawGrip(grip)
     if (gripData && weapon.attacks?.[0]) {
       zawOverride = calculateZawBaseStats(
         weapon.attacks[0],
         grip,
         link,
-        !gripData.oneHanded,
-        strike,
+        weapon.name,
       )
     }
   }

--- a/src/lib/warframe/stats/weapon-stats.ts
+++ b/src/lib/warframe/stats/weapon-stats.ts
@@ -40,14 +40,13 @@ export function calculateWeaponStats(
   let zawOverride: ReturnType<typeof calculateZawBaseStats> | null = null
   if (buildState.zawComponents && hasSpecificAttackModes) {
     const { grip, link } = buildState.zawComponents
-    const gripData = getZawGrip(grip)
-    if (gripData && weapon.attacks?.[0]) {
-      zawOverride = calculateZawBaseStats(
-        weapon.attacks[0],
-        grip,
-        link,
-        weapon.name,
-      )
+    if (getZawGrip(grip) && weapon.attacks?.[0]) {
+      zawOverride = calculateZawBaseStats({
+        strikeAttack: weapon.attacks[0],
+        strikeName: weapon.name,
+        gripName: grip,
+        linkName: link,
+      })
     }
   }
 

--- a/src/lib/warframe/types.ts
+++ b/src/lib/warframe/types.ts
@@ -350,11 +350,11 @@ export interface BuildState {
     ability: HelminthAbility
   }
 
-  // Zaw component selection (Zaw melee weapons only)
+  // Zaw component selection (Zaw melee weapons only).
+  // Strike is derived from the build's item — it's not stored here.
   zawComponents?: {
-    strike: string // Strike name (matches item name)
-    grip: string // Grip name
-    link: string // Link name
+    grip: string
+    link: string
   }
 }
 

--- a/src/lib/warframe/types.ts
+++ b/src/lib/warframe/types.ts
@@ -349,6 +349,13 @@ export interface BuildState {
     slotIndex: number // 0-3, which ability slot was replaced
     ability: HelminthAbility
   }
+
+  // Zaw component selection (Zaw melee weapons only)
+  zawComponents?: {
+    strike: string // Strike name (matches item name)
+    grip: string // Grip name
+    link: string // Link name
+  }
 }
 
 export interface HelminthAbility {

--- a/src/lib/warframe/zaw-data.ts
+++ b/src/lib/warframe/zaw-data.ts
@@ -1,8 +1,24 @@
 // Zaw modular melee weapon data
 // Strikes: base stats come from WFCD attacks array
 // Grips & Links: hardcoded modifier tables (stable since Plains of Eidolon release)
+// Name casing (e.g. "Ekwana Ii Jai") matches WFCD's title-casing — do not "fix".
+
+import MeleeData from "@/data/warframe/Melee.json"
 
 import type { DamageTypes } from "./types"
+
+// Build a name → imageName lookup from WFCD Zaw Component entries so we can
+// render real grip/link icons without hardcoding volatile hash filenames.
+const zawImageMap = new Map<string, string>()
+for (const item of MeleeData as { name: string; type?: string; imageName?: string }[]) {
+  if (item.type === "Zaw Component" && item.imageName && !zawImageMap.has(item.name)) {
+    zawImageMap.set(item.name, item.imageName)
+  }
+}
+
+export function getZawComponentImage(name: string): string | undefined {
+  return zawImageMap.get(name)
+}
 
 // =============================================================================
 // TYPES
@@ -142,10 +158,10 @@ export function calculateZawBaseStats(
   },
   gripName: string,
   linkName: string,
-  isTwoHanded: boolean,
   strikeName: string,
 ): ZawBaseStats {
   const grip = gripMap.get(gripName)
+  const isTwoHanded = grip ? !grip.oneHanded : false
   const link = linkMap.get(linkName)
   const strike = strikeMap.get(strikeName)
 

--- a/src/lib/warframe/zaw-data.ts
+++ b/src/lib/warframe/zaw-data.ts
@@ -1,0 +1,191 @@
+// Zaw modular melee weapon data
+// Strikes: base stats come from WFCD attacks array
+// Grips & Links: hardcoded modifier tables (stable since Plains of Eidolon release)
+
+import type { DamageTypes } from "./types"
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface ZawStrike {
+  name: string
+  oneHanded: string
+  twoHanded: string
+  twoHandedMultiplier: number
+}
+
+export interface ZawGrip {
+  name: string
+  damage: number
+  speed: number
+  oneHanded: boolean
+}
+
+export interface ZawLink {
+  name: string
+  crit: number
+  status: number
+  damage: number
+  speed: number
+}
+
+export interface ZawBaseStats {
+  totalDamage: number
+  damageTypes: DamageTypes
+  critChance: number
+  critMult: number
+  statusChance: number
+  speed: number
+  weaponType: string
+}
+
+// =============================================================================
+// DATA TABLES
+// =============================================================================
+
+export const ZAW_STRIKES: ZawStrike[] = [
+  { name: "Balla", oneHanded: "Dagger", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Cyath", oneHanded: "Machete", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Dehtat", oneHanded: "Rapier", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Dokrahm", oneHanded: "Scythe", twoHanded: "Heavy Blade", twoHandedMultiplier: 1.15 },
+  { name: "Kronsh", oneHanded: "Machete", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Mewan", oneHanded: "Sword", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Ooltha", oneHanded: "Sword", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Rabvee", oneHanded: "Machete", twoHanded: "Hammer", twoHandedMultiplier: 1.15 },
+  { name: "Sepfahn", oneHanded: "Nikana", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Plague Keewar", oneHanded: "Scythe", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Plague Kripath", oneHanded: "Rapier", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+]
+
+export const ZAW_GRIPS: ZawGrip[] = [
+  { name: "Peye", damage: 0, speed: 0, oneHanded: true },
+  { name: "Laka", damage: -4, speed: 0.083, oneHanded: true },
+  { name: "Kwath", damage: 14, speed: -0.067, oneHanded: true },
+  { name: "Plague Akwin", damage: 7, speed: 0, oneHanded: true },
+  { name: "Jayap", damage: 0, speed: 0, oneHanded: false },
+  { name: "Seekalla", damage: -4, speed: 0.083, oneHanded: false },
+  { name: "Kroostra", damage: 28, speed: -0.067, oneHanded: false },
+  { name: "Shtung", damage: 14, speed: -0.033, oneHanded: false },
+  { name: "Korb", damage: 7, speed: -0.033, oneHanded: false },
+  { name: "Plague Bokwin", damage: 7, speed: 0, oneHanded: false },
+]
+
+export const ZAW_LINKS: ZawLink[] = [
+  { name: "Jai", damage: -4, speed: 0.083, crit: 0, status: 0 },
+  { name: "Jai Ii", damage: -8, speed: 0.167, crit: 0, status: 0 },
+  { name: "Ruhang", damage: 14, speed: -0.067, crit: 0, status: 0 },
+  { name: "Ruhang Ii", damage: 28, speed: -0.133, crit: 0, status: 0 },
+  { name: "Vargeet Jai", damage: -4, speed: 0.083, crit: 7, status: 0 },
+  { name: "Vargeet Ruhang", damage: 14, speed: -0.067, crit: 7, status: 0 },
+  { name: "Vargeet Ii Jai", damage: -4, speed: 0.083, crit: 14, status: 0 },
+  { name: "Vargeet Ii Ruhang", damage: 14, speed: -0.067, crit: 14, status: 0 },
+  { name: "Vargeet Jai Ii", damage: -8, speed: 0.167, crit: 7, status: 0 },
+  { name: "Vargeet Ruhang Ii", damage: 28, speed: -0.133, crit: 7, status: 0 },
+  { name: "Ekwana Jai", damage: -4, speed: 0.083, crit: 0, status: 7 },
+  { name: "Ekwana Ruhang", damage: 14, speed: -0.067, crit: 0, status: 7 },
+  { name: "Ekwana Ii Jai", damage: -4, speed: 0.083, crit: 0, status: 14 },
+  { name: "Ekwana Ii Ruhang", damage: 14, speed: -0.067, crit: 0, status: 14 },
+  { name: "Ekwana Jai Ii", damage: -8, speed: 0.167, crit: 0, status: 7 },
+  { name: "Ekwana Ruhang Ii", damage: 28, speed: -0.133, crit: 0, status: 7 },
+]
+
+// =============================================================================
+// LOOKUP HELPERS
+// =============================================================================
+
+const strikeMap = new Map(ZAW_STRIKES.map((s) => [s.name, s]))
+const gripMap = new Map(ZAW_GRIPS.map((g) => [g.name, g]))
+const linkMap = new Map(ZAW_LINKS.map((l) => [l.name, l]))
+
+export function isZawStrike(name: string): boolean {
+  return strikeMap.has(name)
+}
+
+export function isZawGrip(name: string): boolean {
+  return gripMap.has(name)
+}
+
+export function isZawLink(name: string): boolean {
+  return linkMap.has(name)
+}
+
+export function getZawStrike(name: string): ZawStrike | undefined {
+  return strikeMap.get(name)
+}
+
+export function getZawGrip(name: string): ZawGrip | undefined {
+  return gripMap.get(name)
+}
+
+export function getZawLink(name: string): ZawLink | undefined {
+  return linkMap.get(name)
+}
+
+export function getZawWeaponType(
+  strikeName: string,
+  gripName: string,
+): string | null {
+  const strike = strikeMap.get(strikeName)
+  const grip = gripMap.get(gripName)
+  if (!strike || !grip) return null
+  return grip.oneHanded ? strike.oneHanded : strike.twoHanded
+}
+
+export function calculateZawBaseStats(
+  strikeAttack: {
+    damage?: DamageTypes | string
+    crit_chance?: number
+    crit_mult?: number
+    status_chance?: number
+    speed?: number
+  },
+  gripName: string,
+  linkName: string,
+  isTwoHanded: boolean,
+  strikeName: string,
+): ZawBaseStats {
+  const grip = gripMap.get(gripName)
+  const link = linkMap.get(linkName)
+  const strike = strikeMap.get(strikeName)
+
+  const baseDamage =
+    typeof strikeAttack.damage === "object" && strikeAttack.damage
+      ? strikeAttack.damage
+      : {}
+
+  const baseTotalDamage = Object.values(baseDamage).reduce(
+    (sum: number, v) => sum + (typeof v === "number" ? v : 0),
+    0,
+  )
+
+  let totalDamage =
+    baseTotalDamage + (grip?.damage ?? 0) + (link?.damage ?? 0)
+
+  if (isTwoHanded && strike) {
+    totalDamage *= strike.twoHandedMultiplier
+  }
+
+  const damageScale = baseTotalDamage > 0 ? totalDamage / baseTotalDamage : 1
+  const scaledDamageTypes: DamageTypes = {}
+  for (const [key, value] of Object.entries(baseDamage)) {
+    if (typeof value === "number") {
+      scaledDamageTypes[key as keyof DamageTypes] = value * damageScale
+    }
+  }
+
+  const weaponType =
+    getZawWeaponType(strikeName, gripName) ?? "Melee"
+
+  return {
+    totalDamage,
+    damageTypes: scaledDamageTypes,
+    critChance: (strikeAttack.crit_chance ?? 0) + (link?.crit ?? 0),
+    critMult: strikeAttack.crit_mult ?? 2,
+    statusChance:
+      (strikeAttack.status_chance ?? 0) + (link?.status ?? 0),
+    speed:
+      (strikeAttack.speed ?? 1) + (grip?.speed ?? 0) + (link?.speed ?? 0),
+    weaponType,
+  }
+}

--- a/src/lib/warframe/zaw-data.ts
+++ b/src/lib/warframe/zaw-data.ts
@@ -1,7 +1,6 @@
 // Zaw modular melee weapon data
 // Strikes: base damage/crit/status/speed come from WFCD attacks array
 // Grips & Links: hardcoded modifier tables (stable since Plains of Eidolon release)
-// Name casing (e.g. "Ekwana Ii Jai") matches WFCD's title-casing — do not "fix".
 
 import { sumDamageTypes } from "./stats/stat-engine"
 import type { DamageTypes } from "./types"
@@ -70,21 +69,21 @@ export const ZAW_GRIPS: ZawGrip[] = [
 
 export const ZAW_LINKS: ZawLink[] = [
   { name: "Jai", imageName: "jai-7a47884ee7.png", damage: -4, speed: 0.083, crit: 0, status: 0 },
-  { name: "Jai Ii", imageName: "jai-ii-a41b8b50ea.png", damage: -8, speed: 0.167, crit: 0, status: 0 },
+  { name: "Jai II", imageName: "jai-ii-a41b8b50ea.png", damage: -8, speed: 0.167, crit: 0, status: 0 },
   { name: "Ruhang", imageName: "ruhang-8c9076606f.png", damage: 14, speed: -0.067, crit: 0, status: 0 },
-  { name: "Ruhang Ii", imageName: "ruhang-ii-7aec53bcfb.png", damage: 28, speed: -0.133, crit: 0, status: 0 },
+  { name: "Ruhang II", imageName: "ruhang-ii-7aec53bcfb.png", damage: 28, speed: -0.133, crit: 0, status: 0 },
   { name: "Vargeet Jai", imageName: "vargeet-jai-fb8680a3ed.png", damage: -4, speed: 0.083, crit: 7, status: 0 },
   { name: "Vargeet Ruhang", imageName: "vargeet-ruhang-df37a83490.png", damage: 14, speed: -0.067, crit: 7, status: 0 },
-  { name: "Vargeet Ii Jai", imageName: "vargeet-ii-jai-f92b870e32.png", damage: -4, speed: 0.083, crit: 14, status: 0 },
-  { name: "Vargeet Ii Ruhang", imageName: "vargeet-ii-ruhang-55b5f0ac91.png", damage: 14, speed: -0.067, crit: 14, status: 0 },
-  { name: "Vargeet Jai Ii", imageName: "vargeet-jai-ii-c27048f259.png", damage: -8, speed: 0.167, crit: 7, status: 0 },
-  { name: "Vargeet Ruhang Ii", imageName: "vargeet-ruhang-ii-a934774072.png", damage: 28, speed: -0.133, crit: 7, status: 0 },
+  { name: "Vargeet II Jai", imageName: "vargeet-ii-jai-f92b870e32.png", damage: -4, speed: 0.083, crit: 14, status: 0 },
+  { name: "Vargeet II Ruhang", imageName: "vargeet-ii-ruhang-55b5f0ac91.png", damage: 14, speed: -0.067, crit: 14, status: 0 },
+  { name: "Vargeet Jai II", imageName: "vargeet-jai-ii-c27048f259.png", damage: -8, speed: 0.167, crit: 7, status: 0 },
+  { name: "Vargeet Ruhang II", imageName: "vargeet-ruhang-ii-a934774072.png", damage: 28, speed: -0.133, crit: 7, status: 0 },
   { name: "Ekwana Jai", imageName: "ekwana-jai-5dd1e0aabe.png", damage: -4, speed: 0.083, crit: 0, status: 7 },
   { name: "Ekwana Ruhang", imageName: "ekwana-ruhang-47efe1fcbb.png", damage: 14, speed: -0.067, crit: 0, status: 7 },
-  { name: "Ekwana Ii Jai", imageName: "ekwana-ii-jai-c5361c4620.png", damage: -4, speed: 0.083, crit: 0, status: 14 },
-  { name: "Ekwana Ii Ruhang", imageName: "ekwana-ii-ruhang-263840a491.png", damage: 14, speed: -0.067, crit: 0, status: 14 },
-  { name: "Ekwana Jai Ii", imageName: "ekwana-jai-ii-7cdd0a08c0.png", damage: -8, speed: 0.167, crit: 0, status: 7 },
-  { name: "Ekwana Ruhang Ii", imageName: "ekwana-ruhang-ii-5e40256eb9.png", damage: 28, speed: -0.133, crit: 0, status: 7 },
+  { name: "Ekwana II Jai", imageName: "ekwana-ii-jai-c5361c4620.png", damage: -4, speed: 0.083, crit: 0, status: 14 },
+  { name: "Ekwana II Ruhang", imageName: "ekwana-ii-ruhang-263840a491.png", damage: 14, speed: -0.067, crit: 0, status: 14 },
+  { name: "Ekwana Jai II", imageName: "ekwana-jai-ii-7cdd0a08c0.png", damage: -8, speed: 0.167, crit: 0, status: 7 },
+  { name: "Ekwana Ruhang II", imageName: "ekwana-ruhang-ii-5e40256eb9.png", damage: 28, speed: -0.133, crit: 0, status: 7 },
 ]
 
 const strikeMap = new Map(ZAW_STRIKES.map((s) => [s.name, s]))

--- a/src/lib/warframe/zaw-data.ts
+++ b/src/lib/warframe/zaw-data.ts
@@ -1,31 +1,14 @@
 // Zaw modular melee weapon data
-// Strikes: base stats come from WFCD attacks array
+// Strikes: base damage/crit/status/speed come from WFCD attacks array
 // Grips & Links: hardcoded modifier tables (stable since Plains of Eidolon release)
 // Name casing (e.g. "Ekwana Ii Jai") matches WFCD's title-casing — do not "fix".
 
-import MeleeData from "@/data/warframe/Melee.json"
-
+import { sumDamageTypes } from "./stats/stat-engine"
 import type { DamageTypes } from "./types"
-
-// Build a name → imageName lookup from WFCD Zaw Component entries so we can
-// render real grip/link icons without hardcoding volatile hash filenames.
-const zawImageMap = new Map<string, string>()
-for (const item of MeleeData as { name: string; type?: string; imageName?: string }[]) {
-  if (item.type === "Zaw Component" && item.imageName && !zawImageMap.has(item.name)) {
-    zawImageMap.set(item.name, item.imageName)
-  }
-}
-
-export function getZawComponentImage(name: string): string | undefined {
-  return zawImageMap.get(name)
-}
-
-// =============================================================================
-// TYPES
-// =============================================================================
 
 export interface ZawStrike {
   name: string
+  imageName: string
   oneHanded: string
   twoHanded: string
   twoHandedMultiplier: number
@@ -33,6 +16,7 @@ export interface ZawStrike {
 
 export interface ZawGrip {
   name: string
+  imageName: string
   damage: number
   speed: number
   oneHanded: boolean
@@ -40,6 +24,7 @@ export interface ZawGrip {
 
 export interface ZawLink {
   name: string
+  imageName: string
   crit: number
   status: number
   damage: number
@@ -56,59 +41,51 @@ export interface ZawBaseStats {
   weaponType: string
 }
 
-// =============================================================================
-// DATA TABLES
-// =============================================================================
-
 export const ZAW_STRIKES: ZawStrike[] = [
-  { name: "Balla", oneHanded: "Dagger", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
-  { name: "Cyath", oneHanded: "Machete", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
-  { name: "Dehtat", oneHanded: "Rapier", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
-  { name: "Dokrahm", oneHanded: "Scythe", twoHanded: "Heavy Blade", twoHandedMultiplier: 1.15 },
-  { name: "Kronsh", oneHanded: "Machete", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
-  { name: "Mewan", oneHanded: "Sword", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
-  { name: "Ooltha", oneHanded: "Sword", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
-  { name: "Rabvee", oneHanded: "Machete", twoHanded: "Hammer", twoHandedMultiplier: 1.15 },
-  { name: "Sepfahn", oneHanded: "Nikana", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
-  { name: "Plague Keewar", oneHanded: "Scythe", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
-  { name: "Plague Kripath", oneHanded: "Rapier", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Balla", imageName: "balla-75b70ce303.png", oneHanded: "Dagger", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Cyath", imageName: "cyath-1b8937730a.png", oneHanded: "Machete", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Dehtat", imageName: "dehtat-2f3f0ddaa6.png", oneHanded: "Rapier", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Dokrahm", imageName: "dokrahm-37b48a9e1e.png", oneHanded: "Scythe", twoHanded: "Heavy Blade", twoHandedMultiplier: 1.15 },
+  { name: "Kronsh", imageName: "kronsh-f5ae3a6154.png", oneHanded: "Machete", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Mewan", imageName: "mewan-4c3f32889c.png", oneHanded: "Sword", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
+  { name: "Ooltha", imageName: "ooltha-fbca7e140b.png", oneHanded: "Sword", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Rabvee", imageName: "rabvee-0a58ffb572.png", oneHanded: "Machete", twoHanded: "Hammer", twoHandedMultiplier: 1.15 },
+  { name: "Sepfahn", imageName: "sepfahn-a6403cc3ff.png", oneHanded: "Nikana", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Plague Keewar", imageName: "plague-keewar-0492fb5b20.png", oneHanded: "Scythe", twoHanded: "Staff", twoHandedMultiplier: 1.09 },
+  { name: "Plague Kripath", imageName: "plague-kripath-c0d8fea486.png", oneHanded: "Rapier", twoHanded: "Polearm", twoHandedMultiplier: 1.09 },
 ]
 
 export const ZAW_GRIPS: ZawGrip[] = [
-  { name: "Peye", damage: 0, speed: 0, oneHanded: true },
-  { name: "Laka", damage: -4, speed: 0.083, oneHanded: true },
-  { name: "Kwath", damage: 14, speed: -0.067, oneHanded: true },
-  { name: "Plague Akwin", damage: 7, speed: 0, oneHanded: true },
-  { name: "Jayap", damage: 0, speed: 0, oneHanded: false },
-  { name: "Seekalla", damage: -4, speed: 0.083, oneHanded: false },
-  { name: "Kroostra", damage: 28, speed: -0.067, oneHanded: false },
-  { name: "Shtung", damage: 14, speed: -0.033, oneHanded: false },
-  { name: "Korb", damage: 7, speed: -0.033, oneHanded: false },
-  { name: "Plague Bokwin", damage: 7, speed: 0, oneHanded: false },
+  { name: "Peye", imageName: "peye-c489dd9227.png", damage: 0, speed: 0, oneHanded: true },
+  { name: "Laka", imageName: "laka-098b3b1be6.png", damage: -4, speed: 0.083, oneHanded: true },
+  { name: "Kwath", imageName: "kwath-b513ea67e8.png", damage: 14, speed: -0.067, oneHanded: true },
+  { name: "Plague Akwin", imageName: "plague-akwin-9002d44213.png", damage: 7, speed: 0, oneHanded: true },
+  { name: "Jayap", imageName: "jayap-3aae844297.png", damage: 0, speed: 0, oneHanded: false },
+  { name: "Seekalla", imageName: "seekalla-d8b757e408.png", damage: -4, speed: 0.083, oneHanded: false },
+  { name: "Kroostra", imageName: "kroostra-e74bcfc2ca.png", damage: 28, speed: -0.067, oneHanded: false },
+  { name: "Shtung", imageName: "shtung-66796b519a.png", damage: 14, speed: -0.033, oneHanded: false },
+  { name: "Korb", imageName: "korb-f2a7529b43.png", damage: 7, speed: -0.033, oneHanded: false },
+  { name: "Plague Bokwin", imageName: "plague-bokwin-ad3a2b7d7e.png", damage: 7, speed: 0, oneHanded: false },
 ]
 
 export const ZAW_LINKS: ZawLink[] = [
-  { name: "Jai", damage: -4, speed: 0.083, crit: 0, status: 0 },
-  { name: "Jai Ii", damage: -8, speed: 0.167, crit: 0, status: 0 },
-  { name: "Ruhang", damage: 14, speed: -0.067, crit: 0, status: 0 },
-  { name: "Ruhang Ii", damage: 28, speed: -0.133, crit: 0, status: 0 },
-  { name: "Vargeet Jai", damage: -4, speed: 0.083, crit: 7, status: 0 },
-  { name: "Vargeet Ruhang", damage: 14, speed: -0.067, crit: 7, status: 0 },
-  { name: "Vargeet Ii Jai", damage: -4, speed: 0.083, crit: 14, status: 0 },
-  { name: "Vargeet Ii Ruhang", damage: 14, speed: -0.067, crit: 14, status: 0 },
-  { name: "Vargeet Jai Ii", damage: -8, speed: 0.167, crit: 7, status: 0 },
-  { name: "Vargeet Ruhang Ii", damage: 28, speed: -0.133, crit: 7, status: 0 },
-  { name: "Ekwana Jai", damage: -4, speed: 0.083, crit: 0, status: 7 },
-  { name: "Ekwana Ruhang", damage: 14, speed: -0.067, crit: 0, status: 7 },
-  { name: "Ekwana Ii Jai", damage: -4, speed: 0.083, crit: 0, status: 14 },
-  { name: "Ekwana Ii Ruhang", damage: 14, speed: -0.067, crit: 0, status: 14 },
-  { name: "Ekwana Jai Ii", damage: -8, speed: 0.167, crit: 0, status: 7 },
-  { name: "Ekwana Ruhang Ii", damage: 28, speed: -0.133, crit: 0, status: 7 },
+  { name: "Jai", imageName: "jai-7a47884ee7.png", damage: -4, speed: 0.083, crit: 0, status: 0 },
+  { name: "Jai Ii", imageName: "jai-ii-a41b8b50ea.png", damage: -8, speed: 0.167, crit: 0, status: 0 },
+  { name: "Ruhang", imageName: "ruhang-8c9076606f.png", damage: 14, speed: -0.067, crit: 0, status: 0 },
+  { name: "Ruhang Ii", imageName: "ruhang-ii-7aec53bcfb.png", damage: 28, speed: -0.133, crit: 0, status: 0 },
+  { name: "Vargeet Jai", imageName: "vargeet-jai-fb8680a3ed.png", damage: -4, speed: 0.083, crit: 7, status: 0 },
+  { name: "Vargeet Ruhang", imageName: "vargeet-ruhang-df37a83490.png", damage: 14, speed: -0.067, crit: 7, status: 0 },
+  { name: "Vargeet Ii Jai", imageName: "vargeet-ii-jai-f92b870e32.png", damage: -4, speed: 0.083, crit: 14, status: 0 },
+  { name: "Vargeet Ii Ruhang", imageName: "vargeet-ii-ruhang-55b5f0ac91.png", damage: 14, speed: -0.067, crit: 14, status: 0 },
+  { name: "Vargeet Jai Ii", imageName: "vargeet-jai-ii-c27048f259.png", damage: -8, speed: 0.167, crit: 7, status: 0 },
+  { name: "Vargeet Ruhang Ii", imageName: "vargeet-ruhang-ii-a934774072.png", damage: 28, speed: -0.133, crit: 7, status: 0 },
+  { name: "Ekwana Jai", imageName: "ekwana-jai-5dd1e0aabe.png", damage: -4, speed: 0.083, crit: 0, status: 7 },
+  { name: "Ekwana Ruhang", imageName: "ekwana-ruhang-47efe1fcbb.png", damage: 14, speed: -0.067, crit: 0, status: 7 },
+  { name: "Ekwana Ii Jai", imageName: "ekwana-ii-jai-c5361c4620.png", damage: -4, speed: 0.083, crit: 0, status: 14 },
+  { name: "Ekwana Ii Ruhang", imageName: "ekwana-ii-ruhang-263840a491.png", damage: 14, speed: -0.067, crit: 0, status: 14 },
+  { name: "Ekwana Jai Ii", imageName: "ekwana-jai-ii-7cdd0a08c0.png", damage: -8, speed: 0.167, crit: 0, status: 7 },
+  { name: "Ekwana Ruhang Ii", imageName: "ekwana-ruhang-ii-5e40256eb9.png", damage: 28, speed: -0.133, crit: 0, status: 7 },
 ]
-
-// =============================================================================
-// LOOKUP HELPERS
-// =============================================================================
 
 const strikeMap = new Map(ZAW_STRIKES.map((s) => [s.name, s]))
 const gripMap = new Map(ZAW_GRIPS.map((g) => [g.name, g]))
@@ -138,6 +115,14 @@ export function getZawLink(name: string): ZawLink | undefined {
   return linkMap.get(name)
 }
 
+export function getZawComponentImage(name: string): string | undefined {
+  return (
+    strikeMap.get(name)?.imageName ??
+    gripMap.get(name)?.imageName ??
+    linkMap.get(name)?.imageName
+  )
+}
+
 export function getZawWeaponType(
   strikeName: string,
   gripName: string,
@@ -148,32 +133,36 @@ export function getZawWeaponType(
   return grip.oneHanded ? strike.oneHanded : strike.twoHanded
 }
 
-export function calculateZawBaseStats(
+export interface ZawBaseStatsInput {
   strikeAttack: {
     damage?: DamageTypes | string
     crit_chance?: number
     crit_mult?: number
     status_chance?: number
     speed?: number
-  },
-  gripName: string,
-  linkName: string,
-  strikeName: string,
-): ZawBaseStats {
+  }
+  strikeName: string
+  gripName: string
+  linkName: string
+}
+
+export function calculateZawBaseStats({
+  strikeAttack,
+  strikeName,
+  gripName,
+  linkName,
+}: ZawBaseStatsInput): ZawBaseStats {
   const grip = gripMap.get(gripName)
-  const isTwoHanded = grip ? !grip.oneHanded : false
   const link = linkMap.get(linkName)
   const strike = strikeMap.get(strikeName)
+  const isTwoHanded = grip ? !grip.oneHanded : false
 
   const baseDamage =
     typeof strikeAttack.damage === "object" && strikeAttack.damage
       ? strikeAttack.damage
       : {}
 
-  const baseTotalDamage = Object.values(baseDamage).reduce(
-    (sum: number, v) => sum + (typeof v === "number" ? v : 0),
-    0,
-  )
+  const baseTotalDamage = sumDamageTypes(baseDamage)
 
   let totalDamage =
     baseTotalDamage + (grip?.damage ?? 0) + (link?.damage ?? 0)
@@ -190,9 +179,6 @@ export function calculateZawBaseStats(
     }
   }
 
-  const weaponType =
-    getZawWeaponType(strikeName, gripName) ?? "Melee"
-
   return {
     totalDamage,
     damageTypes: scaledDamageTypes,
@@ -202,6 +188,6 @@ export function calculateZawBaseStats(
       (strikeAttack.status_chance ?? 0) + (link?.status ?? 0),
     speed:
       (strikeAttack.speed ?? 1) + (grip?.speed ?? 0) + (link?.speed ?? 0),
-    weaponType,
+    weaponType: getZawWeaponType(strikeName, gripName) ?? "Melee",
   }
 }


### PR DESCRIPTION
## Summary

Closes #38

- **Fix "00000" on browse page** — React renders `{0 && <JSX>}` as `0`; five zero-stat checks concatenated to "00000". Fixed with `!!` coercion on all weapon stat conditionals.
- **Fix missing mods** — `getModsForItem()` didn't match `type: "Zaw Component"` to melee mods. Added early return with `getModsByCompatibility("Melee")`.
- **Filter Grips/Links/PvP duplicates from browse** — Only Zaw Strikes (items with real `attacks` data) now appear in the melee category. Added `excludeFromCodex` filtering for PvP variants.
- **Show real stats on browse page** — Zaw Strikes now display damage, crit, status, and speed from their `attacks[0]` data instead of showing zeros. Type label shows "Zaw Strike" instead of "Zaw Component".
- **Zaw component selection** — New Grip/Link dropdown selectors in the build editor next to the arcane slot. Selecting components dynamically recalculates weapon stats (damage, crit, status, speed) including two-handed damage multipliers.
- **Build sharing** — Zaw component choices are serialized in the build codec so shared builds preserve Strike/Grip/Link selections.

## New files

- `src/lib/warframe/zaw-data.ts` — Static data tables for 11 Strikes (weapon type mapping + 2H multipliers), 10 Grips (damage/speed modifiers), 16 Links (crit/status/damage/speed modifiers), plus calculation helpers
- `src/components/build-editor/zaw-component-selector.tsx` — Grip/Link dropdown UI component

## Test plan

- [x] 8 tests for Zaw data tables and stat calculation
- [x] 5 tests for browse filtering (Strikes included, Grips/Links excluded, PvP duplicates excluded)
- [x] 2 tests for mod filtering (melee mods returned, primary/secondary excluded)
- [x] 1 test for build codec round-tripping of zawComponents
- [x] All 529 existing tests still pass (3 pre-existing failures from missing Prisma client in worktree)
- [ ] Manual: Browse to Balla page — should show "Zaw Strike" type and real stats
- [ ] Manual: Create a Balla build — should show mods, Grip/Link selectors, stats update when changing components