### PR TITLE
feat(web): support two aura slots on Jade

### DIFF
--- a/apps/web/src/components/build-editor/calculations.ts
+++ b/apps/web/src/components/build-editor/calculations.ts
@@ -136,7 +136,7 @@ export function auraBonusForMod(
 export interface CapacityInput {
   placed: Partial<Record<SlotId, PlacedMod>>
   formaPolarities: Partial<Record<SlotId, Polarity>>
-  auraInnate?: Polarity
+  auraInnates: (Polarity | undefined)[]
   normalInnates: (Polarity | undefined)[]
   hasReactor: boolean
   maxLevelCap?: number
@@ -153,7 +153,7 @@ export function calculateCapacity(input: CapacityInput): CapacityResult {
   const {
     placed,
     formaPolarities,
-    auraInnate,
+    auraInnates,
     normalInnates,
     hasReactor,
     maxLevelCap,
@@ -163,12 +163,14 @@ export function calculateCapacity(input: CapacityInput): CapacityResult {
   const base = hasReactor ? level * 2 : level
 
   let auraBonus = 0
-  const auraPlaced = placed.aura
-  if (auraPlaced) {
+  for (let i = 0; i < auraInnates.length; i++) {
+    const id = `aura-${i}` as SlotId
+    const auraPlaced = placed[id]
+    if (!auraPlaced) continue
     auraBonus += auraBonusForMod(
       auraPlaced.mod,
       auraPlaced.rank,
-      effectivePolarity(auraInnate, formaPolarities.aura),
+      effectivePolarity(auraInnates[i], formaPolarities[id]),
     )
   }
 
@@ -196,17 +198,22 @@ export function calculateCapacity(input: CapacityInput): CapacityResult {
 }
 
 export interface FormaCountInput {
-  auraInnate?: Polarity
+  auraInnates: (Polarity | undefined)[]
   exilusInnate?: Polarity
   normalInnates: (Polarity | undefined)[]
   formaPolarities: Partial<Record<SlotId, Polarity>>
 }
 
 export function calculateFormaCount(input: FormaCountInput): number {
-  const { auraInnate, exilusInnate, normalInnates, formaPolarities } = input
+  const { auraInnates, exilusInnate, normalInnates, formaPolarities } = input
   let total = 0
 
-  total += singleSlotForma(auraInnate, formaPolarities.aura)
+  for (let i = 0; i < auraInnates.length; i++) {
+    total += singleSlotForma(
+      auraInnates[i],
+      formaPolarities[`aura-${i}` as SlotId],
+    )
+  }
   total += singleSlotForma(exilusInnate, formaPolarities.exilus)
 
   const normalSlots: NormalSlotEntry[] = normalInnates.map((innate, i) => ({

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -13,7 +13,7 @@ export {
   calculateModEndoCost,
   calculateTotalEndoCost,
 } from "./calculations"
-export { getArcaneSlotCount, hasAuraSlot, hasExilusSlot } from "./layout"
+export { getArcaneSlotCount, getAuraSlotCount, hasExilusSlot } from "./layout"
 export { ArcaneRow, ModGrid, toPolarity } from "./mod-grid"
 export { ModCard } from "./mod-card"
 export { ModSearchGrid } from "./mod-search-grid"

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -14,7 +14,7 @@ export {
   calculateTotalEndoCost,
 } from "./calculations"
 export { getArcaneSlotCount, getAuraSlotCount, hasExilusSlot } from "./layout"
-export { ArcaneRow, ModGrid, toPolarity } from "./mod-grid"
+export { ArcaneRow, getAuraPolarities, ModGrid, toPolarity } from "./mod-grid"
 export { ModCard } from "./mod-card"
 export { ModSearchGrid } from "./mod-search-grid"
 export { RivenDialog, type RivenDialogValues } from "./riven-dialog"

--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -1,4 +1,4 @@
-import type { BrowseCategory } from "@/lib/warframe"
+import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 
 /** Arcane slot count per category, mirroring legacy `src/lib/builds/layout.ts`. */
 export function getArcaneSlotCount(category: BrowseCategory): number {
@@ -20,7 +20,16 @@ export function hasExilusSlot(category: BrowseCategory): boolean {
   return category !== "necramechs"
 }
 
-/** Categories with an Aura slot (polarity bonus to capacity). */
-export function hasAuraSlot(category: BrowseCategory): boolean {
-  return category === "warframes" || category === "companions"
+/**
+ * Number of Aura slots for an item. Warframes derive from `item.aura` —
+ * an array means multiple aura slots (Jade: 2). Companions always have 1.
+ */
+export function getAuraSlotCount(
+  category: BrowseCategory,
+  item: Pick<DetailItem, "aura">,
+): number {
+  if (category === "companions") return 1
+  if (category !== "warframes") return 0
+  if (Array.isArray(item.aura)) return item.aura.length
+  return item.aura ? 1 : 0
 }

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -4,7 +4,7 @@ import type { Arcane, Polarity } from "@arsenyx/shared/warframe/types"
 import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 
 import { ArcaneSlot } from "./arcane-slot"
-import { hasAuraSlot, hasExilusSlot } from "./layout"
+import { getAuraSlotCount, hasExilusSlot } from "./layout"
 import { ModSlot } from "./mod-slot"
 import { CANONICAL_POLARITIES } from "./polarity-picker"
 import type { ArcaneSlotsState } from "./use-arcane-slots"
@@ -69,12 +69,18 @@ export function ModGrid({
   arcaneRow?: React.ReactNode
   readOnly?: boolean
 }) {
-  const showAura = hasAuraSlot(category)
+  const auraSlotCount = getAuraSlotCount(category, item)
   const showExilus = hasExilusSlot(category)
   const slotsPerRow = isCompanion ? 5 : 4
 
-  const auraRaw = Array.isArray(item.aura) ? item.aura[0] : item.aura
-  const auraPolarity = toPolarity(auraRaw)
+  const auraRaws = Array.isArray(item.aura)
+    ? item.aura
+    : item.aura
+      ? [item.aura]
+      : []
+  const auraPolarities = Array.from({ length: auraSlotCount }, (_, i) =>
+    toPolarity(auraRaws[i]),
+  )
   const polarities = item.polarities ?? []
 
   const normalRows: number[][] = []
@@ -112,14 +118,28 @@ export function ModGrid({
 
   return (
     <div className="flex flex-col gap-6 sm:gap-4">
-      {(showAura || showExilus) && (
+      {(auraSlotCount > 0 || showExilus) && (
         <div className="flex w-full justify-center gap-2 sm:gap-4">
-          {showAura && (
-            <ModSlot kind="aura" {...slotProps("aura", auraPolarity)} />
+          {auraSlotCount > 0 && (
+            <ModSlot
+              kind="aura"
+              {...slotProps("aura-0" as SlotId, auraPolarities[0])}
+            />
           )}
           {showExilus && (
             <ModSlot kind="exilus" {...slotProps("exilus", undefined)} />
           )}
+          {Array.from({ length: Math.max(0, auraSlotCount - 1) }, (_, i) => {
+            const idx = i + 1
+            const id = `aura-${idx}` as SlotId
+            return (
+              <ModSlot
+                key={id}
+                kind="aura"
+                {...slotProps(id, auraPolarities[idx])}
+              />
+            )
+          })}
         </div>
       )}
 

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -17,6 +17,23 @@ export function toPolarity(v: string | undefined): Polarity | undefined {
   return CANONICAL_SET.has(v as Polarity) ? (v as Polarity) : undefined
 }
 
+/**
+ * Per-slot innate polarities for an item's aura slots. `item.aura` may be a
+ * single polarity string (most frames) or an array (Jade: 2 slots). Length
+ * always matches `count` so callers can zip by index.
+ */
+export function getAuraPolarities(
+  item: Pick<DetailItem, "aura">,
+  count: number,
+): (Polarity | undefined)[] {
+  const raws = Array.isArray(item.aura)
+    ? item.aura
+    : item.aura
+      ? [item.aura]
+      : []
+  return Array.from({ length: count }, (_, i) => toPolarity(raws[i]))
+}
+
 export function ArcaneRow({
   count,
   arcanes,
@@ -73,14 +90,7 @@ export function ModGrid({
   const showExilus = hasExilusSlot(category)
   const slotsPerRow = isCompanion ? 5 : 4
 
-  const auraRaws = Array.isArray(item.aura)
-    ? item.aura
-    : item.aura
-      ? [item.aura]
-      : []
-  const auraPolarities = Array.from({ length: auraSlotCount }, (_, i) =>
-    toPolarity(auraRaws[i]),
-  )
+  const auraPolarities = getAuraPolarities(item, auraSlotCount)
   const polarities = item.polarities ?? []
 
   const normalRows: number[][] = []

--- a/apps/web/src/components/build-editor/mod-search-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-search-grid.tsx
@@ -250,10 +250,7 @@ export function ModSearchGrid({
   // Navigate in visual 2D, skipping dimmed/used cards by continuing in the
   // same direction until a focusable card is found (or clamp at the edge).
   const GRID_ROWS = 2
-  const moveFromDisplayedIndex = (
-    from: number,
-    dir: Dir,
-  ): number | null => {
+  const moveFromDisplayedIndex = (from: number, dir: Dir): number | null => {
     const row = from % GRID_ROWS
     const col = Math.floor(from / GRID_ROWS)
     const focusable = (i: number) =>
@@ -312,9 +309,7 @@ export function ModSearchGrid({
                 if (!onSelect) return
                 const firstName = focusableOrder[0]
                 if (!firstName) return
-                const first = displayed.find(
-                  (m) => m.uniqueName === firstName,
-                )
+                const first = displayed.find((m) => m.uniqueName === firstName)
                 if (!first) return
                 e.preventDefault()
                 onSelect(first)

--- a/apps/web/src/components/build-editor/use-build-slots.ts
+++ b/apps/web/src/components/build-editor/use-build-slots.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from "react"
 
 import type { ModSlotKind } from "./mod-slot"
 
-export type SlotId = "aura" | "exilus" | `normal-${number}`
+export type SlotId = `aura-${number}` | "exilus" | `normal-${number}`
 
 export interface PlacedMod {
   mod: Mod
@@ -19,7 +19,7 @@ export function isExilusCompatible(mod: Mod): boolean {
 }
 
 function slotKind(id: SlotId): ModSlotKind {
-  if (id === "aura") return "aura"
+  if (id.startsWith("aura-")) return "aura"
   if (id === "exilus") return "exilus"
   return "normal"
 }
@@ -41,18 +41,23 @@ function maxRank(mod: Mod): number {
 
 export interface SlotLayout {
   normalSlotCount: number
-  showAura: boolean
+  auraSlotCount: number
   showExilus: boolean
 }
 
 /**
- * Ordered list of visible slots in reading order: aura?, exilus?, normal-0..N.
- * Used by keyboard nav and auto-advance to step one slot forward.
+ * Ordered list of visible slots in reading order:
+ * aura-0, exilus?, aura-1..N-1, normal-0..N.
+ * Exilus sits between the first and second aura so the top row reads
+ * `Aura | Exilus | Aura` for Jade (two auras), or `Aura | Exilus` otherwise.
  */
 export function getVisibleSlots(layout: SlotLayout): SlotId[] {
   const out: SlotId[] = []
-  if (layout.showAura) out.push("aura")
+  if (layout.auraSlotCount > 0) out.push("aura-0")
   if (layout.showExilus) out.push("exilus")
+  for (let i = 1; i < layout.auraSlotCount; i++) {
+    out.push(`aura-${i}` as SlotId)
+  }
   for (let i = 0; i < layout.normalSlotCount; i++) {
     out.push(`normal-${i}` as SlotId)
   }
@@ -95,7 +100,7 @@ export function useBuildSlots(
   initial?: {
     placed?: Partial<Record<SlotId, PlacedMod>>
     formaPolarities?: Partial<Record<SlotId, Polarity>>
-    showAura?: boolean
+    auraSlotCount?: number
     showExilus?: boolean
     /** Set to null for read-only views that shouldn't start with a focused slot. */
     initialSelected?: SlotId | null
@@ -111,9 +116,10 @@ export function useBuildSlots(
     Partial<Record<SlotId, Polarity>>
   >(() => initial?.formaPolarities ?? {})
 
+  const auraSlotCount = initial?.auraSlotCount ?? 0
   const layout: SlotLayout = {
     normalSlotCount,
-    showAura: initial?.showAura ?? false,
+    auraSlotCount,
     showExilus: initial?.showExilus ?? false,
   }
 
@@ -129,20 +135,19 @@ export function useBuildSlots(
           return { ...prev, [selected]: { mod, rank: maxRank(mod) } }
         }
 
+        const auraIds = Array.from(
+          { length: auraSlotCount },
+          (_, i) => `aura-${i}` as SlotId,
+        )
+        const normalIds = Array.from(
+          { length: normalSlotCount },
+          (_, i) => `normal-${i}` as SlotId,
+        )
         const tryIds: SlotId[] = isAuraMod(mod)
-          ? ["aura"]
+          ? auraIds
           : isExilusCompatible(mod)
-            ? [
-                "exilus",
-                ...Array.from(
-                  { length: normalSlotCount },
-                  (_, i) => `normal-${i}` as SlotId,
-                ),
-              ]
-            : Array.from(
-                { length: normalSlotCount },
-                (_, i) => `normal-${i}` as SlotId,
-              )
+            ? ["exilus", ...normalIds]
+            : normalIds
 
         for (const id of tryIds) {
           if (!prev[id] && canPlaceIn(mod, id)) {
@@ -156,7 +161,7 @@ export function useBuildSlots(
     // layout is derived from `initial` options that are stable per editor
     // mount; no need to include every field.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [normalSlotCount, selected, layout.showAura, layout.showExilus],
+    [normalSlotCount, selected, layout.auraSlotCount, layout.showExilus],
   )
 
   const placeAt = useCallback((id: SlotId, mod: Mod, rank?: number) => {

--- a/apps/web/src/components/build-editor/use-keyboard-nav.ts
+++ b/apps/web/src/components/build-editor/use-keyboard-nav.ts
@@ -17,17 +17,30 @@ const COLS = 4
 
 function buildGrid(layout: SlotLayout): (SlotId | null)[][] {
   const grid: (SlotId | null)[][] = []
-  if (layout.showAura || layout.showExilus) {
-    const top: (SlotId | null)[] = new Array(COLS).fill(null)
-    if (layout.showAura) top[0] = "aura"
-    if (layout.showExilus) top[1] = "exilus"
+  const { auraSlotCount, showExilus } = layout
+  if (auraSlotCount > 0 || showExilus) {
+    // Reading order: aura-0, exilus?, aura-1..N-1
+    const topOrder: SlotId[] = []
+    if (auraSlotCount > 0) topOrder.push("aura-0" as SlotId)
+    if (showExilus) topOrder.push("exilus")
+    for (let i = 1; i < auraSlotCount; i++) {
+      topOrder.push(`aura-${i}` as SlotId)
+    }
+    const top: (SlotId | null)[] = new Array(
+      Math.max(COLS, topOrder.length),
+    ).fill(null)
+    topOrder.forEach((id, idx) => {
+      top[idx] = id
+    })
     grid.push(top)
   }
   for (let i = 0; i < layout.normalSlotCount; i += COLS) {
     const row: (SlotId | null)[] = []
     for (let j = 0; j < COLS; j++) {
       const idx = i + j
-      row.push(idx < layout.normalSlotCount ? (`normal-${idx}` as SlotId) : null)
+      row.push(
+        idx < layout.normalSlotCount ? (`normal-${idx}` as SlotId) : null,
+      )
     }
     grid.push(row)
   }
@@ -103,12 +116,12 @@ export function useSlotKeyboardNav({
 }) {
   // Pull primitives so the effect doesn't re-register on every render just
   // because `layout` is a fresh object identity from the caller.
-  const { normalSlotCount, showAura, showExilus } = layout
+  const { normalSlotCount, auraSlotCount, showExilus } = layout
   useEffect(() => {
     if (!enabled) return
     const layoutSnapshot: SlotLayout = {
       normalSlotCount,
-      showAura,
+      auraSlotCount,
       showExilus,
     }
     const onKey = (e: KeyboardEvent) => {
@@ -134,5 +147,5 @@ export function useSlotKeyboardNav({
     }
     window.addEventListener("keydown", onKey)
     return () => window.removeEventListener("keydown", onKey)
-  }, [slots, normalSlotCount, showAura, showExilus, enabled])
+  }, [slots, normalSlotCount, auraSlotCount, showExilus, enabled])
 }

--- a/apps/web/src/lib/build-codec-adapter.ts
+++ b/apps/web/src/lib/build-codec-adapter.ts
@@ -26,6 +26,7 @@ type EditorState = {
   helminth: Record<number, HelminthAbility>
   zawComponents?: { grip: string; link: string }
   normalSlotCount: number
+  auraSlotCount: number
 }
 
 function toSharedPlacedMod(p: PlacedMod): SharedPlacedMod {
@@ -89,9 +90,13 @@ function buildSlot(
 }
 
 export function savedDataToBuildState(state: EditorState): BuildState {
-  const auraSlots: ModSlot[] = [
-    buildSlot("aura", "aura", state.slots.aura, state.formaPolarities.aura),
-  ]
+  const auraSlots: ModSlot[] = Array.from(
+    { length: state.auraSlotCount },
+    (_, i) => {
+      const id = `aura-${i}` as SlotId
+      return buildSlot(id, "aura", state.slots[id], state.formaPolarities[id])
+    },
+  )
   const exilusSlot = buildSlot(
     "exilus",
     "exilus",
@@ -177,9 +182,10 @@ export function buildStateToSavedData(
     }
   }
 
-  // Pre-Jade builds stored a singular auraSlot.
+  // Pre-Jade builds stored a singular auraSlot. Newer builds store an array.
   const auraFallback = (state as { auraSlot?: ModSlot }).auraSlot
-  assign("aura", state.auraSlots?.[0] ?? auraFallback)
+  const auraSlotsIn = state.auraSlots ?? (auraFallback ? [auraFallback] : [])
+  auraSlotsIn.forEach((s, i) => assign(`aura-${i}` as SlotId, s))
   assign("exilus", state.exilusSlot)
   state.normalSlots?.forEach((s, i) => assign(`normal-${i}` as SlotId, s))
 
@@ -237,5 +243,33 @@ export function normalizeBuildData(
   ) {
     return buildStateToSavedData(r, mods, arcanes).data
   }
-  return r as SavedBuildData
+  return migrateLegacyAuraKey(r as SavedBuildData)
+}
+
+/**
+ * Builds saved before Jade's two-aura support used a bare "aura" key.
+ * Rewrite it to "aura-0" so current loaders find it.
+ */
+function migrateLegacyAuraKey(data: SavedBuildData): SavedBuildData {
+  const slots = data.slots as Partial<Record<string, PlacedMod>> | undefined
+  const forma = data.formaPolarities as
+    | Partial<Record<string, Polarity>>
+    | undefined
+  const needsSlotMigration = slots && "aura" in slots && !("aura-0" in slots)
+  const needsFormaMigration = forma && "aura" in forma && !("aura-0" in forma)
+  if (!needsSlotMigration && !needsFormaMigration) return data
+
+  const nextSlots: Partial<Record<SlotId, PlacedMod>> = { ...(slots ?? {}) }
+  const nextForma: Partial<Record<SlotId, Polarity>> = { ...(forma ?? {}) }
+  if (needsSlotMigration) {
+    const legacy = (slots as Record<string, PlacedMod>).aura
+    delete (nextSlots as Record<string, unknown>).aura
+    if (legacy) nextSlots["aura-0"] = legacy
+  }
+  if (needsFormaMigration) {
+    const legacy = (forma as Record<string, Polarity>).aura
+    delete (nextForma as Record<string, unknown>).aura
+    if (legacy) nextForma["aura-0"] = legacy
+  }
+  return { ...data, slots: nextSlots, formaPolarities: nextForma }
 }

--- a/apps/web/src/lib/overframe/index.ts
+++ b/apps/web/src/lib/overframe/index.ts
@@ -140,7 +140,7 @@ function interpretSlot(
   const warframeLike = isWarframeLike(category)
   if (slot_id === 9) {
     return warframeLike
-      ? { kind: "mod", id: "aura" }
+      ? { kind: "mod", id: "aura-0" }
       : { kind: "mod", id: "exilus" }
   }
   if (slot_id === 10) {
@@ -160,10 +160,13 @@ function innatePolarityFor(
   detail: DetailItem,
   slotId: SlotId,
 ): Polarity | undefined {
-  if (slotId === "aura") {
+  if (slotId.startsWith("aura-")) {
+    const idx = Number(slotId.slice("aura-".length))
     const a = detail.aura
     if (!a) return undefined
-    return (Array.isArray(a) ? a[0] : a) as Polarity | undefined
+    return (Array.isArray(a) ? a[idx] : idx === 0 ? a : undefined) as
+      | Polarity
+      | undefined
   }
   if (slotId === "exilus") return undefined // not stored in items index
   if (slotId.startsWith("normal-")) {

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -26,7 +26,9 @@ import {
   calculateFormaCount,
   calculateTotalEndoCost,
   getArcaneSlotCount,
+  getAuraPolarities,
   getAuraSlotCount,
+  hasExilusSlot,
   ItemSidebar,
   ModGrid,
   toPolarity,
@@ -141,11 +143,12 @@ function BuildViewerBody({
     [allArcanes, category],
   )
 
+  const auraSlotCount = getAuraSlotCount(category, item)
   const slots = useBuildSlots(normalSlotCount, {
     placed: saved.slots,
     formaPolarities: saved.formaPolarities,
-    auraSlotCount: getAuraSlotCount(category, item),
-    showExilus: true,
+    auraSlotCount,
+    showExilus: hasExilusSlot(category),
     initialSelected: null,
   })
   const arcanes = useArcaneSlots(arcaneCount, saved.arcanes)
@@ -154,15 +157,10 @@ function BuildViewerBody({
   const hasReactor = saved.hasReactor ?? true
   const zawComponents = saved.zawComponents
 
-  const auraSlotCount = getAuraSlotCount(category, item)
-  const auraInnates = useMemo(() => {
-    const raws = Array.isArray(item.aura)
-      ? item.aura
-      : item.aura
-        ? [item.aura]
-        : []
-    return Array.from({ length: auraSlotCount }, (_, i) => toPolarity(raws[i]))
-  }, [item.aura, auraSlotCount])
+  const auraInnates = useMemo(
+    () => getAuraPolarities(item, auraSlotCount),
+    [item, auraSlotCount],
+  )
   const normalInnates = useMemo(
     () =>
       Array.from({ length: normalSlotCount }, (_, i) =>

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -26,6 +26,7 @@ import {
   calculateFormaCount,
   calculateTotalEndoCost,
   getArcaneSlotCount,
+  getAuraSlotCount,
   ItemSidebar,
   ModGrid,
   toPolarity,
@@ -56,9 +57,9 @@ import { authClient } from "@/lib/auth-client"
 import { useDeleteBuild, useForkBuild } from "@/lib/build-actions"
 import { normalizeBuildData } from "@/lib/build-codec-adapter"
 import { buildQuery, type BuildDetail } from "@/lib/build-query"
-import { modsQuery } from "@/lib/mods-query"
 import { useToggleBookmark, useToggleLike } from "@/lib/build-social"
 import { itemQuery } from "@/lib/item-query"
+import { modsQuery } from "@/lib/mods-query"
 import { padShards } from "@/lib/shards"
 import { authorName, formatVisibility } from "@/lib/user-display"
 import { cn } from "@/lib/utils"
@@ -143,6 +144,8 @@ function BuildViewerBody({
   const slots = useBuildSlots(normalSlotCount, {
     placed: saved.slots,
     formaPolarities: saved.formaPolarities,
+    auraSlotCount: getAuraSlotCount(category, item),
+    showExilus: true,
     initialSelected: null,
   })
   const arcanes = useArcaneSlots(arcaneCount, saved.arcanes)
@@ -151,8 +154,15 @@ function BuildViewerBody({
   const hasReactor = saved.hasReactor ?? true
   const zawComponents = saved.zawComponents
 
-  const auraRaw = Array.isArray(item.aura) ? item.aura[0] : item.aura
-  const auraInnate = toPolarity(auraRaw)
+  const auraSlotCount = getAuraSlotCount(category, item)
+  const auraInnates = useMemo(() => {
+    const raws = Array.isArray(item.aura)
+      ? item.aura
+      : item.aura
+        ? [item.aura]
+        : []
+    return Array.from({ length: auraSlotCount }, (_, i) => toPolarity(raws[i]))
+  }, [item.aura, auraSlotCount])
   const normalInnates = useMemo(
     () =>
       Array.from({ length: normalSlotCount }, (_, i) =>
@@ -168,25 +178,25 @@ function BuildViewerBody({
   const formaCount = useMemo(
     () =>
       calculateFormaCount({
-        auraInnate,
+        auraInnates,
         normalInnates,
         formaPolarities: slots.formaPolarities,
       }),
-    [auraInnate, normalInnates, slots.formaPolarities],
+    [auraInnates, normalInnates, slots.formaPolarities],
   )
   const capacity = useMemo(
     () =>
       calculateCapacity({
         placed: slots.placed,
         formaPolarities: slots.formaPolarities,
-        auraInnate,
+        auraInnates,
         normalInnates,
         hasReactor,
       }),
     [
       slots.placed,
       slots.formaPolarities,
-      auraInnate,
+      auraInnates,
       normalInnates,
       hasReactor,
     ],

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -41,6 +41,7 @@ import {
   calculateFormaCount,
   calculateTotalEndoCost,
   getArcaneSlotCount,
+  getAuraPolarities,
   GuideEditor,
   getAuraSlotCount,
   hasExilusSlot,
@@ -347,14 +348,10 @@ function EditorShell() {
     })
   }
 
-  const auraInnates = useMemo(() => {
-    const raws = Array.isArray(item.aura)
-      ? item.aura
-      : item.aura
-        ? [item.aura]
-        : []
-    return Array.from({ length: auraSlotCount }, (_, i) => toPolarity(raws[i]))
-  }, [item.aura, auraSlotCount])
+  const auraInnates = useMemo(
+    () => getAuraPolarities(item, auraSlotCount),
+    [item, auraSlotCount],
+  )
   const normalInnates = useMemo(
     () =>
       Array.from({ length: normalSlotCount }, (_, i) =>

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -42,7 +42,7 @@ import {
   calculateTotalEndoCost,
   getArcaneSlotCount,
   GuideEditor,
-  hasAuraSlot,
+  getAuraSlotCount,
   hasExilusSlot,
   ItemSidebar,
   ModGrid,
@@ -77,9 +77,9 @@ import { itemQuery } from "@/lib/item-query"
 import { modsQuery } from "@/lib/mods-query"
 import { myOrgsQuery } from "@/lib/org-query"
 import { padShards, type PlacedShard } from "@/lib/shards"
-import { isEditableTarget } from "@/lib/utils"
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard"
 import { formatVisibility } from "@/lib/user-display"
+import { isEditableTarget } from "@/lib/utils"
 import {
   CATEGORIES,
   getImageUrl,
@@ -188,17 +188,17 @@ function EditorShell() {
 
   const isCompanion = category === "companions"
   const normalSlotCount = 8
-  const showAura = hasAuraSlot(category)
+  const auraSlotCount = getAuraSlotCount(category, item)
   const showExilus = hasExilusSlot(category)
   const slots = useBuildSlots(normalSlotCount, {
     placed: savedData.slots,
     formaPolarities: savedData.formaPolarities,
-    showAura,
+    auraSlotCount,
     showExilus,
   })
   useSlotKeyboardNav({
     slots,
-    layout: { normalSlotCount, showAura, showExilus },
+    layout: { normalSlotCount, auraSlotCount, showExilus },
   })
   const arcaneCount = getArcaneSlotCount(category)
   const arcanes = useArcaneSlots(arcaneCount, savedData.arcanes)
@@ -347,8 +347,14 @@ function EditorShell() {
     })
   }
 
-  const auraRaw = Array.isArray(item.aura) ? item.aura[0] : item.aura
-  const auraInnate = toPolarity(auraRaw)
+  const auraInnates = useMemo(() => {
+    const raws = Array.isArray(item.aura)
+      ? item.aura
+      : item.aura
+        ? [item.aura]
+        : []
+    return Array.from({ length: auraSlotCount }, (_, i) => toPolarity(raws[i]))
+  }, [item.aura, auraSlotCount])
   const normalInnates = useMemo(
     () =>
       Array.from({ length: normalSlotCount }, (_, i) =>
@@ -364,11 +370,11 @@ function EditorShell() {
   const formaCount = useMemo(
     () =>
       calculateFormaCount({
-        auraInnate,
+        auraInnates,
         normalInnates,
         formaPolarities: slots.formaPolarities,
       }),
-    [auraInnate, normalInnates, slots.formaPolarities],
+    [auraInnates, normalInnates, slots.formaPolarities],
   )
   const isUpdate = !!existingBuild && existingBuild.isOwner
 
@@ -390,6 +396,7 @@ function EditorShell() {
       helminth,
       zawComponents,
       normalSlotCount,
+      auraSlotCount,
     })
     const encoded = encodeBuild(state)
     const url = `${window.location.origin}/create?item=${encodeURIComponent(slug)}&category=${encodeURIComponent(category)}&share=${encodeURIComponent(encoded)}`
@@ -474,14 +481,14 @@ function EditorShell() {
       calculateCapacity({
         placed: slots.placed,
         formaPolarities: slots.formaPolarities,
-        auraInnate,
+        auraInnates,
         normalInnates,
         hasReactor,
       }),
     [
       slots.placed,
       slots.formaPolarities,
-      auraInnate,
+      auraInnates,
       normalInnates,
       hasReactor,
     ],

--- a/packages/shared/src/warframe/types.ts
+++ b/packages/shared/src/warframe/types.ts
@@ -49,7 +49,7 @@ export interface Warframe extends BaseItem {
   power: number
   sprintSpeed?: number
   abilities?: Ability[]
-  aura?: string
+  aura?: string | string[]
   polarities?: string[]
   passiveDescription?: string
   sex?: "Male" | "Female"


### PR DESCRIPTION
## Summary

Fix Jade so her editor shows two aura slots (**Aura | Exilus | Aura**) instead of the single-aura layout every other frame uses. Resolves the **Fix Jade** item in TODO.md.

## Why

Jade's JSON data already encodes two aura polarities (`"aura":["aura","vazarin"]`), but the editor hardcoded a single aura slot everywhere (`SlotId = "aura"`, `hasAuraSlot(): boolean`, `item.aura[0]` reads), so the second slot never rendered and the capacity/forma math ignored it.

## What changed

- **Slot model** — `SlotId` is now `` `aura-${number}` ``; `SlotLayout.showAura: boolean` → `auraSlotCount: number`. Placement, visible-slot order, and keyboard nav all loop over aura slots.
- **Layout helper** — `hasAuraSlot(category)` → `getAuraSlotCount(category, item)`. Warframes derive from `item.aura.length`, companions stay at 1.
- **Rendering** — top row emits `Aura-0 | Exilus | Aura-1…` so Jade reads Aura | Exilus | Aura and other frames are unchanged. Per-slot innate polarity comes from `item.aura[i]`.
- **Calcs** — `auraInnate?: Polarity` → `auraInnates: Polarity[]` in both `CapacityInput` and `FormaCountInput`; capacity bonus and forma count loop over all aura slots.
- **Codec / persistence** — `savedDataToBuildState` emits `aura-${i}` slots; `buildStateToSavedData` iterates `state.auraSlots`. Added `migrateLegacyAuraKey` in `normalizeBuildData` so pre-existing builds with `slots.aura` transparently become `slots["aura-0"]`. The legacy singular `auraSlot` BuildState fallback also funnels into `aura-0`.
- **Overframe import** — slot id 9 maps to `aura-0`; `innatePolarityFor` indexes into `detail.aura`.
- **Types** — `Warframe.aura?: string` → `string | string[]`.

Item-driven, not Jade-special-cased: any future multi-aura frame works automatically from its JSON data.

## Test plan

- [x] `bun run build` (apps/web) — passes
- [x] `bunx tsc --noEmit` (apps/api) — passes
- [x] `bunx oxlint` on touched files — clean (two pre-existing warnings unrelated to this change)
- [ ] Open Jade in the editor: top row reads **Aura | Exilus | Aura**, second aura shows `vazarin` innate polarity
- [ ] Place two Aura mods: first → `aura-0`, second → `aura-1`; keyboard arrows move between all three top-row slots
- [ ] Equip matching-polarity auras in both slots: capacity bonus doubles
- [ ] Add forma to `aura-1`: forma count increments
- [ ] Share URL round-trips both aura slots
- [ ] Save + reload a Jade build: both auras persist
- [ ] Non-Jade frame (e.g. Volt): layout unchanged, single **Aura | Exilus** header
- [ ] Load a pre-existing build that predates this change (`slots.aura`): migrates cleanly, mod lands in first aura slot