### PR TITLE
fix(companions): correct slot layout + mobile remove button

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## Bugs
 
 - [ ] Add riven mod support to Overframe import
-- [ ] Fix companions
+- [x] Fix companions
 - [ ] Fix Lich weapons
 - [ ] Fix Necramech
 - [ ] Fix Jade

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -13,7 +13,12 @@ export {
   calculateModEndoCost,
   calculateTotalEndoCost,
 } from "./calculations"
-export { getArcaneSlotCount, getAuraSlotCount, hasExilusSlot } from "./layout"
+export {
+  getArcaneSlotCount,
+  getAuraSlotCount,
+  getNormalSlotCount,
+  hasExilusSlot,
+} from "./layout"
 export { ArcaneRow, getAuraPolarities, ModGrid, toPolarity } from "./mod-grid"
 export { ModCard } from "./mod-card"
 export { ModSearchGrid } from "./mod-search-grid"

--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -15,21 +15,26 @@ export function getArcaneSlotCount(category: BrowseCategory): number {
   }
 }
 
-/** Categories that have an Exilus slot. Necramechs don't; everything else does. */
+/** Categories that have an Exilus slot. Necramechs and companions don't. */
 export function hasExilusSlot(category: BrowseCategory): boolean {
-  return category !== "necramechs"
+  return category !== "necramechs" && category !== "companions"
 }
 
 /**
  * Number of Aura slots for an item. Warframes derive from `item.aura` —
- * an array means multiple aura slots (Jade: 2). Companions always have 1.
+ * an array means multiple aura slots (Jade: 2). Companions and other
+ * categories have none.
  */
 export function getAuraSlotCount(
   category: BrowseCategory,
   item: Pick<DetailItem, "aura">,
 ): number {
-  if (category === "companions") return 1
   if (category !== "warframes") return 0
   if (Array.isArray(item.aura)) return item.aura.length
   return item.aura ? 1 : 0
+}
+
+/** Normal mod slot count. Companions have 10; everything else has 8. */
+export function getNormalSlotCount(category: BrowseCategory): number {
+  return category === "companions" ? 10 : 8
 }

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -153,19 +153,30 @@ export function ModGrid({
         </div>
       )}
 
-      {normalRows.map((row, rowIdx) => (
-        <div
-          key={rowIdx}
-          className="grid grid-cols-2 justify-center gap-x-2 gap-y-6 sm:flex sm:gap-4"
-        >
-          {row.map((i) => {
+      {isCompanion ? (
+        <div className="grid grid-cols-2 gap-x-2 gap-y-6 lg:mx-auto lg:w-fit lg:grid-cols-5 lg:gap-4">
+          {Array.from({ length: normalSlotCount }, (_, i) => {
             const id: SlotId = `normal-${i}`
             return (
               <ModSlot key={i} {...slotProps(id, toPolarity(polarities[i]))} />
             )
           })}
         </div>
-      ))}
+      ) : (
+        normalRows.map((row, rowIdx) => (
+          <div
+            key={rowIdx}
+            className="grid grid-cols-2 justify-center gap-x-2 gap-y-6 sm:flex sm:gap-4"
+          >
+            {row.map((i) => {
+              const id: SlotId = `normal-${i}`
+              return (
+                <ModSlot key={i} {...slotProps(id, toPolarity(polarities[i]))} />
+              )
+            })}
+          </div>
+        ))
+      )}
 
       {arcaneRow}
     </div>

--- a/apps/web/src/components/build-editor/mod-slot.tsx
+++ b/apps/web/src/components/build-editor/mod-slot.tsx
@@ -1,6 +1,6 @@
 import { isRivenMod } from "@arsenyx/shared/warframe/rivens"
 import type { Mod, Polarity } from "@arsenyx/shared/warframe/types"
-import { Pencil, Plus } from "lucide-react"
+import { Pencil, Plus, X, type LucideIcon } from "lucide-react"
 import { useState, type MouseEvent } from "react"
 
 import {
@@ -125,18 +125,23 @@ export function ModSlot({
               }
               matchState={getMatchState(mod.polarity, effective)}
             />
-            {!readOnly && isRivenMod(mod) && onEditRiven && (
-              <button
-                type="button"
-                aria-label="Edit riven stats"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onEditRiven()
-                }}
-                className="bg-background/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground absolute top-1 right-1 z-30 flex size-5 items-center justify-center rounded-full border opacity-0 transition-opacity group-hover:opacity-100 max-md:opacity-100"
-              >
-                <Pencil className="size-3" />
-              </button>
+            {!readOnly && (onRemove || (isRivenMod(mod) && onEditRiven)) && (
+              <div className="absolute -top-2 -right-2 z-30 flex flex-col gap-1 md:hidden">
+                {onRemove && (
+                  <MobileSlotButton
+                    icon={X}
+                    label="Remove mod"
+                    onClick={onRemove}
+                  />
+                )}
+                {isRivenMod(mod) && onEditRiven && (
+                  <MobileSlotButton
+                    icon={Pencil}
+                    label="Edit riven stats"
+                    onClick={onEditRiven}
+                  />
+                )}
+              </div>
             )}
           </>
         ) : (
@@ -168,5 +173,29 @@ export function ModSlot({
         </PopoverContent>
       )}
     </Popover>
+  )
+}
+
+function MobileSlotButton({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: LucideIcon
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      className="bg-background/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground flex size-5 items-center justify-center rounded-full border"
+    >
+      <Icon className="size-3" />
+    </button>
   )
 }

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -28,6 +28,7 @@ import {
   getArcaneSlotCount,
   getAuraPolarities,
   getAuraSlotCount,
+  getNormalSlotCount,
   hasExilusSlot,
   ItemSidebar,
   ModGrid,
@@ -135,7 +136,7 @@ function BuildViewerBody({
   const categoryLabel =
     CATEGORIES.find((c) => c.id === category)?.label ?? category
   const isCompanion = category === "companions"
-  const normalSlotCount = 8
+  const normalSlotCount = getNormalSlotCount(category)
   const arcaneCount = getArcaneSlotCount(category)
 
   const arcaneOptions = useMemo(

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -42,8 +42,9 @@ import {
   calculateTotalEndoCost,
   getArcaneSlotCount,
   getAuraPolarities,
-  GuideEditor,
   getAuraSlotCount,
+  getNormalSlotCount,
+  GuideEditor,
   hasExilusSlot,
   ItemSidebar,
   ModGrid,
@@ -188,7 +189,7 @@ function EditorShell() {
     CATEGORIES.find((c) => c.id === category)?.label ?? category
 
   const isCompanion = category === "companions"
-  const normalSlotCount = 8
+  const normalSlotCount = getNormalSlotCount(category)
   const auraSlotCount = getAuraSlotCount(category, item)
   const showExilus = hasExilusSlot(category)
   const slots = useBuildSlots(normalSlotCount, {


### PR DESCRIPTION
## Summary
- Companions now have **10 normal mod slots** (5×2) and **no aura/exilus** row — matches the in-game layout. Below `lg` the grid collapses to 2 cols so the rows stay even on narrow screens.
- Placed mods on mobile get an always-visible **X remove button** (top-right, outside the slot). Riven mods get a stacked pencil button under it. Desktop hides both and keeps right-click-to-remove as before.
- Extracted \`getNormalSlotCount(category)\` into \`apps/web/src/components/build-editor/layout.ts\` so the \`10 : 8\` ternary isn't duplicated across \`create.tsx\` and \`builds.\$slug.tsx\`.
- Factored the two mobile slot buttons into a local \`MobileSlotButton\` component in \`mod-slot.tsx\`.
- Ticked \`- [x] Fix companions\` in TODO.md.

## Test plan
- [ ] Open \`/create/companions/adarza-kavat\` on desktop — no aura/exilus row, 5×2 grid of mod slots, right-click removes placed mods
- [ ] Same URL on mobile viewport (<1024px) — 2×5 grid fills container, X button appears outside top-right of each placed mod, tapping it removes
- [ ] Place a riven on a companion weapon build on mobile — pencil button appears below the X
- [ ] Open an existing saved companion build — loads with 10 slots; any legacy mods in aura/exilus are silently dropped
- [ ] Sanity-check a warframe build — still shows aura + exilus + 4×2 normal grid