### PR TITLE
fix(editor): necramechs have 12 mod slots and no arcanes

### DIFF
--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -4,7 +4,6 @@ import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 export function getArcaneSlotCount(category: BrowseCategory): number {
   switch (category) {
     case "warframes":
-    case "necramechs":
       return 2
     case "primary":
     case "secondary":
@@ -34,7 +33,9 @@ export function getAuraSlotCount(
   return item.aura ? 1 : 0
 }
 
-/** Normal mod slot count. Companions have 10; everything else has 8. */
+/** Normal mod slot count. Companions have 10, necramechs have 12, everything else 8. */
 export function getNormalSlotCount(category: BrowseCategory): number {
-  return category === "companions" ? 10 : 8
+  if (category === "companions") return 10
+  if (category === "necramechs") return 12
+  return 8
 }


### PR DESCRIPTION
## Summary
- Necramechs now render a 12-slot mod layout (3 rows of 4) instead of the warframe 8-slot layout.
- Necramechs no longer get 2 arcane slots — they don't take arcanes in-game.
- Added `getNormalSlotCount(category)` alongside the existing `getArcaneSlotCount` / `hasAuraSlot` / `hasExilusSlot` helpers in `apps/web/src/components/build-editor/layout.ts`; both `create.tsx` and `builds.$slug.tsx` use it instead of hardcoding `8`.

## Test plan
- [ ] Open the create editor for a Voidrig / Bonewidow — confirm 12 normal mod slots (3 rows of 4), exilus hidden, no arcane row.
- [ ] Open the create editor for a warframe — still 8 slots + aura + exilus + 2 arcanes.
- [ ] View an existing necramech build — renders with 12-slot layout.