### PR TITLE
fix(editor): overlevel mod capacity for Lich weapons and Necramechs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,8 @@
 
 - [ ] Add riven mod support to Overframe import
 - [x] Fix companions
-- [ ] Fix Lich weapons
+- [x] Fix Lich weapons
+- [ ] Overleveled weapons — display unique rank bonuses (Kuva/Tenet/Coda elemental bonus)
 - [ ] Fix Necramech
 - [ ] Fix Jade
 - [ ] Check exalted weapons

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -16,6 +16,7 @@ export {
 export {
   getArcaneSlotCount,
   getAuraSlotCount,
+  getMaxLevelCap,
   getNormalSlotCount,
   hasExilusSlot,
 } from "./layout"

--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -39,3 +39,16 @@ export function getNormalSlotCount(category: BrowseCategory): number {
   if (category === "necramechs") return 12
   return 8
 }
+
+/**
+ * Max rank for an item. Necramechs overlevel to 40 (not flagged in WFCD data).
+ * Kuva/Tenet/Coda weapons + Paracesis carry `maxLevelCap: 40` in their JSON.
+ * Undefined for normal-rank items; `calculateCapacity` treats that as 30.
+ */
+export function getMaxLevelCap(
+  category: BrowseCategory,
+  item: Pick<DetailItem, "maxLevelCap">,
+): number | undefined {
+  if (category === "necramechs") return 40
+  return item.maxLevelCap
+}

--- a/apps/web/src/lib/warframe.ts
+++ b/apps/web/src/lib/warframe.ts
@@ -81,6 +81,7 @@ export interface DetailItem extends BrowseItem {
   sprintSpeed?: number
   abilities?: ItemAbility[]
   // weapon
+  maxLevelCap?: number
   totalDamage?: number
   criticalChance?: number
   criticalMultiplier?: number

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -28,6 +28,7 @@ import {
   getArcaneSlotCount,
   getAuraPolarities,
   getAuraSlotCount,
+  getMaxLevelCap,
   getNormalSlotCount,
   hasExilusSlot,
   ItemSidebar,
@@ -191,6 +192,7 @@ function BuildViewerBody({
         auraInnates,
         normalInnates,
         hasReactor,
+        maxLevelCap: getMaxLevelCap(category, item),
       }),
     [
       slots.placed,
@@ -198,6 +200,8 @@ function BuildViewerBody({
       auraInnates,
       normalInnates,
       hasReactor,
+      category,
+      item.maxLevelCap,
     ],
   )
 

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -43,6 +43,7 @@ import {
   getArcaneSlotCount,
   getAuraPolarities,
   getAuraSlotCount,
+  getMaxLevelCap,
   getNormalSlotCount,
   GuideEditor,
   hasExilusSlot,
@@ -482,6 +483,7 @@ function EditorShell() {
         auraInnates,
         normalInnates,
         hasReactor,
+        maxLevelCap: getMaxLevelCap(category, item),
       }),
     [
       slots.placed,
@@ -489,6 +491,8 @@ function EditorShell() {
       auraInnates,
       normalInnates,
       hasReactor,
+      category,
+      item.maxLevelCap,
     ],
   )
 


### PR DESCRIPTION
## Summary

- Kuva/Tenet/Coda weapons + Paracesis + Necramechs can overlevel past rank 30 (up to 40 via 5 forma). With an Orokin Catalyst/Reactor this gives up to 80 mod capacity, but the editor was capping them at 60 — valid in-game builds looked over-capacity.
- `calculateCapacity` already accepted `maxLevelCap`, and WFCD weapon JSON already carries `"maxLevelCap": 40` for all 54 affected weapons. Fix is just wiring: expose the field on `DetailItem` and pass it through from both editor (`create.tsx`) and viewer (`builds.$slug.tsx`).
- New `getMaxLevelCap(category, item)` helper in `build-editor/layout.ts` special-cases necramechs (WFCD doesn''t flag them), mirroring the existing `getNormalSlotCount` pattern from 9bf6cd9.
- Ticks **Fix Lich weapons** off TODO.md and logs a follow-up for the separate unique rank bonus display feature.

## Test plan

- [x] `just dev`, open `/create/melee/paracesis` → capacity reads 40/80 with catalyst (was 30/60)
- [x] `/create/primary/kuva-bramma`, `/create/melee/tenet-livia`, `/create/primary/coda-bubonico` → 40/80 with catalyst
- [x] `/create/necramechs/voidrig` → 40/80 with reactor
- [x] Control: `/create/primary/braton` still 30/60
- [x] Open a saved Lich-weapon build at `/builds/<slug>` — capacity matches editor