### PR TITLE
feat(editor): Lich bonus element dropdown (Kuva/Tenet/Coda)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [ ] Add riven mod support to Overframe import
 - [x] Fix companions
 - [x] Fix Lich weapons
-- [ ] Overleveled weapons — display unique rank bonuses (Kuva/Tenet/Coda elemental bonus)
+- [ ] Kuva/Tenet/Coda bonus element — flow selected element into `calculateWeaponStats` so picking one actually changes the damage numbers (dropdown + codec already wired; see [apps/web/src/lib/stats/weapon.ts](apps/web/src/lib/stats/weapon.ts))
 - [ ] Fix Necramech
 - [ ] Fix Jade
 - [ ] Check exalted weapons

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -19,6 +19,7 @@ export {
   getMaxLevelCap,
   getNormalSlotCount,
   hasExilusSlot,
+  isLichWeapon,
 } from "./layout"
 export { ArcaneRow, getAuraPolarities, ModGrid, toPolarity } from "./mod-grid"
 export { ModCard } from "./mod-card"

--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -1,4 +1,10 @@
-import type { Gun, Melee, Warframe } from "@arsenyx/shared/warframe/types"
+import {
+  LICH_BONUS_ELEMENTS,
+  type Gun,
+  type LichBonusElement,
+  type Melee,
+  type Warframe,
+} from "@arsenyx/shared/warframe/types"
 import { isZawStrike } from "@arsenyx/shared/warframe/zaw-data"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { ChevronLeft, Plus, Undo2, X, Zap } from "lucide-react"
@@ -11,6 +17,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 import {
@@ -53,6 +67,7 @@ import {
 } from "@/lib/warframe"
 import { adjustStrikeForZaw } from "@/lib/zaw-stats"
 
+import { isLichWeapon } from "./layout"
 import type { PlacedArcane } from "./use-arcane-slots"
 import type { PlacedMod, SlotId } from "./use-build-slots"
 import { ZawComponentSelector } from "./zaw-component-selector"
@@ -78,6 +93,8 @@ export interface ItemSidebarProps {
   onSetHelminth: (slotIndex: number, ability: HelminthAbility | null) => void
   zawComponents?: { grip: string; link: string }
   onSetZawComponents?: (components: { grip: string; link: string }) => void
+  lichBonusElement?: LichBonusElement | null
+  onSetLichBonusElement?: (value: LichBonusElement | null) => void
   placedMods: Partial<Record<SlotId, PlacedMod>>
   placedArcanes: (PlacedArcane | null)[]
   readOnly?: boolean
@@ -96,6 +113,8 @@ export function ItemSidebar({
   onSetHelminth,
   zawComponents,
   onSetZawComponents,
+  lichBonusElement,
+  onSetLichBonusElement,
   placedMods,
   placedArcanes,
   readOnly = false,
@@ -119,6 +138,7 @@ export function ItemSidebar({
       category === "archwing" ||
       category === "exalted-weapons" ||
       category === "companions")
+  const showLichBonus = isWeapon && isLichWeapon(item)
   const showShards = category === "warframes"
   const skipRankUpBonus = category === "necramechs" || isArchwingSuit
   const abilities = item.abilities ?? []
@@ -290,10 +310,59 @@ export function ItemSidebar({
             />
           </div>
         )}
+        {showLichBonus && (
+          <LichBonusElementPicker
+            value={lichBonusElement ?? null}
+            onChange={(v) => onSetLichBonusElement?.(v)}
+            readOnly={readOnly}
+          />
+        )}
         {warframeStats && <WarframeStatsPanel stats={warframeStats} />}
         {weaponStats && <WeaponStatsPanel stats={weaponStats} />}
         {companionStats && <CompanionStatsPanel stats={companionStats} />}
       </div>
+    </div>
+  )
+}
+
+const LICH_BONUS_ITEMS: { value: LichBonusElement | null; label: string }[] = [
+  { value: null, label: "No element selected" },
+  ...LICH_BONUS_ELEMENTS.map((el) => ({ value: el, label: `+60% ${el}` })),
+]
+
+function LichBonusElementPicker({
+  value,
+  onChange,
+  readOnly,
+}: {
+  value: LichBonusElement | null
+  onChange: (v: LichBonusElement | null) => void
+  readOnly: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
+        Bonus Element
+      </span>
+      <Select
+        items={LICH_BONUS_ITEMS}
+        value={value}
+        onValueChange={(v) => onChange(v as LichBonusElement | null)}
+        disabled={readOnly}
+      >
+        <SelectTrigger size="sm" className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {LICH_BONUS_ITEMS.map((item) => (
+              <SelectItem key={item.value ?? "none"} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
     </div>
   )
 }

--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -52,3 +52,14 @@ export function getMaxLevelCap(
   if (category === "necramechs") return 40
   return item.maxLevelCap
 }
+
+// Paracesis also carries maxLevelCap: 40 but has no Lich bonus element —
+// gate on the name prefix so it's excluded.
+const LICH_WEAPON_PREFIXES = ["Kuva ", "Tenet ", "Coda "]
+
+export function isLichWeapon(
+  item: Pick<DetailItem, "name" | "maxLevelCap">,
+): boolean {
+  if (item.maxLevelCap !== 40) return false
+  return LICH_WEAPON_PREFIXES.some((p) => item.name.startsWith(p))
+}

--- a/apps/web/src/lib/build-codec-adapter.ts
+++ b/apps/web/src/lib/build-codec-adapter.ts
@@ -2,6 +2,7 @@ import type {
   Arcane,
   BrowseCategory,
   BuildState,
+  LichBonusElement,
   Mod,
   ModSlot,
   PlacedArcane as SharedPlacedArcane,
@@ -25,6 +26,7 @@ type EditorState = {
   shards: (PlacedShard | null)[]
   helminth: Record<number, HelminthAbility>
   zawComponents?: { grip: string; link: string }
+  lichBonusElement?: LichBonusElement
   normalSlotCount: number
   auraSlotCount: number
 }
@@ -159,6 +161,7 @@ export function savedDataToBuildState(state: EditorState): BuildState {
     buildName: state.buildName,
     helminthAbility,
     zawComponents: state.zawComponents,
+    lichBonusElement: state.lichBonusElement,
   }
 }
 
@@ -218,6 +221,7 @@ export function buildStateToSavedData(
       hasReactor: state.hasReactor ?? true,
       helminth,
       zawComponents: state.zawComponents,
+      lichBonusElement: state.lichBonusElement,
     },
     buildName: state.buildName,
   }

--- a/apps/web/src/lib/build-query.ts
+++ b/apps/web/src/lib/build-query.ts
@@ -1,4 +1,4 @@
-import type { Polarity } from "@arsenyx/shared/warframe/types"
+import type { LichBonusElement, Polarity } from "@arsenyx/shared/warframe/types"
 import { queryOptions } from "@tanstack/react-query"
 import { notFound } from "@tanstack/react-router"
 
@@ -17,6 +17,7 @@ export type SavedBuildData = {
   hasReactor?: boolean
   helminth?: Record<number, HelminthAbility>
   zawComponents?: { grip: string; link: string }
+  lichBonusElement?: LichBonusElement
 }
 
 export type BuildDetail = {

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -194,6 +194,7 @@ function BuildViewerBodyInner({
   const helminth = saved.helminth ?? {}
   const hasReactor = saved.hasReactor ?? true
   const zawComponents = saved.zawComponents
+  const lichBonusElement = saved.lichBonusElement ?? null
 
   const auraInnates = useMemo(
     () => getAuraPolarities(item, auraSlotCount),
@@ -273,6 +274,7 @@ function BuildViewerBodyInner({
               helminth={helminth}
               onSetHelminth={() => {}}
               zawComponents={zawComponents}
+              lichBonusElement={lichBonusElement}
               placedMods={slots.placed}
               placedArcanes={arcanes.placed}
               readOnly

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -6,7 +6,7 @@ import {
   isRivenEligible,
   isRivenMod,
 } from "@arsenyx/shared/warframe/rivens"
-import type { Mod } from "@arsenyx/shared/warframe/types"
+import type { LichBonusElement, Mod } from "@arsenyx/shared/warframe/types"
 import {
   isZawStrike,
   ZAW_DEFAULT_GRIP,
@@ -336,6 +336,9 @@ function EditorShell() {
     })
   }, [item.name])
 
+  const [lichBonusElement, setLichBonusElement] =
+    useState<LichBonusElement | null>(() => savedData.lichBonusElement ?? null)
+
   const [helminth, setHelminth] = useState<Record<number, HelminthAbility>>(
     () => savedData.helminth ?? {},
   )
@@ -394,6 +397,7 @@ function EditorShell() {
       shards,
       helminth,
       zawComponents,
+      lichBonusElement: lichBonusElement ?? undefined,
       normalSlotCount,
       auraSlotCount,
     })
@@ -439,6 +443,7 @@ function EditorShell() {
           hasReactor,
           helminth,
           zawComponents,
+          lichBonusElement: lichBonusElement ?? undefined,
         },
         guide: {
           summary: guideSummary.trim() || null,
@@ -537,6 +542,8 @@ function EditorShell() {
               onSetHelminth={setHelminthAt}
               zawComponents={zawComponents}
               onSetZawComponents={setZawComponents}
+              lichBonusElement={lichBonusElement}
+              onSetLichBonusElement={setLichBonusElement}
               placedMods={slots.placed}
               placedArcanes={arcanes.placed}
             />

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -21,6 +21,7 @@ Never modify existing files in `apps/web/src/components/ui/` — override via `c
 
 - `Slider` — `onValueChange` / `onValueCommitted` receive `number | readonly number[]`.
 - `Select` — `onValueChange` receives `string | null`.
+- `Select` — for `SelectValue` to render a label for the current value, pass an `items={[{ value, label }]}` prop to `<Select>`. Without it, `SelectValue` falls back to showing the raw value string (so `value={null}` renders literally as `null`, `value="__none__"` renders as `__none__`). Use `value: null` for the "no selection" entry. Reference: [select-example.tsx](https://raw.githubusercontent.com/shadcn-ui/ui/refs/heads/main/apps/v4/registry/bases/base/examples/select-example.tsx).
 
 ## WFCD data quirks
 

--- a/packages/shared/src/warframe/build-codec.ts
+++ b/packages/shared/src/warframe/build-codec.ts
@@ -4,6 +4,7 @@ import { SHARD_COLORS, getStatByIndex, getStatIndex } from "./shards"
 import type {
   BrowseCategory,
   BuildState,
+  LichBonusElement,
   ModSlot,
   PlacedArcane,
   PlacedMod,
@@ -28,6 +29,7 @@ interface EncodedBuild {
   n?: string
   h?: EncodedHelminth
   zc?: { g: string; l: string }
+  lb?: string
 }
 
 interface EncodedHelminth {
@@ -115,6 +117,10 @@ export function encodeBuild(state: BuildState): string {
       g: state.zawComponents.grip,
       l: state.zawComponents.link,
     }
+  }
+
+  if (state.lichBonusElement) {
+    encoded.lb = state.lichBonusElement
   }
 
   const jsonString = JSON.stringify(encoded)
@@ -255,6 +261,10 @@ export function decodeBuild(base64String: string): Partial<BuildState> | null {
         grip: encoded.zc.g,
         link: encoded.zc.l,
       }
+    }
+
+    if (encoded.lb) {
+      state.lichBonusElement = encoded.lb as LichBonusElement
     }
 
     return state

--- a/packages/shared/src/warframe/types.ts
+++ b/packages/shared/src/warframe/types.ts
@@ -356,7 +356,22 @@ export interface BuildState {
     grip: string
     link: string
   }
+
+  // Bonus element on Kuva/Tenet/Coda weapons (maxLevelCap: 40).
+  lichBonusElement?: LichBonusElement
 }
+
+export const LICH_BONUS_ELEMENTS = [
+  "Heat",
+  "Cold",
+  "Electricity",
+  "Toxin",
+  "Radiation",
+  "Magnetic",
+  "Impact",
+] as const
+
+export type LichBonusElement = (typeof LICH_BONUS_ELEMENTS)[number]
 
 export interface HelminthAbility {
   uniqueName: string


### PR DESCRIPTION
## Summary

- Sidebar dropdown to pick the bonus damage element on Kuva/Tenet/Coda weapons. Value round-trips through the share URL and the saved build JSON.
- Extracts `isLichWeapon()` into `apps/web/src/components/build-editor/layout.ts` with a name-prefix guard so Paracesis (also `maxLevelCap: 40`) is correctly excluded.
- Documents the Base UI Select `items` prop requirement in `docs/gotchas.md` — without it, `SelectValue` renders the raw value string instead of a label.

Wiki confirms all three families (Kuva, Tenet, Coda) share the same 7 elements, so a single list works.

## Out of scope (tracked in TODO.md)

- Feeding the selected element into \`calculateWeaponStats\` so the damage numbers in the sidebar actually change. The dropdown is cosmetic until this lands.
- Lich rank scaling (bonus assumed flat 60%; in-game it is 25–60% across ranks 1–5).

## Test plan

- [ ] \`/create\` with a Kuva weapon (e.g. Kuva Bramma) → "Bonus Element" dropdown appears; selecting an element updates the share URL.
- [ ] \`/create\` with Paracesis → no dropdown.
- [ ] \`/create\` with a non-overleveled weapon (e.g. Braton) → no dropdown.
- [ ] Share URL → open in another tab → selection restored.
- [ ] \`/builds/:slug\` for a saved Lich-weapon build → dropdown visible but disabled, shows the saved value.
- [ ] Old share URLs / saved builds without the field still load cleanly.