### PR TITLE
fix(editor): drain rounding + subsumed augment picker

### DIFF
--- a/apps/web/src/components/build-editor/calculations.ts
+++ b/apps/web/src/components/build-editor/calculations.ts
@@ -116,7 +116,7 @@ export function effectiveDrainForMod(
     return mod.polarity === "umbra" ? base : Math.ceil(base / 2)
   }
   if (mod.polarity === slotPolarity) return Math.ceil(base / 2)
-  return Math.ceil(base * 1.25)
+  return Math.round(base * 1.25)
 }
 
 export function auraBonusForMod(
@@ -130,7 +130,7 @@ export function auraBonusForMod(
     return mod.polarity === "umbra" ? base : base * 2
   }
   if (mod.polarity === slotPolarity) return base * 2
-  return Math.floor(base / 2)
+  return Math.round(base * 0.75)
 }
 
 export interface CapacityInput {

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -578,6 +578,7 @@ function EditorShell() {
             category={category}
             usedModNames={slots.usedNames}
             onSelect={handleModSelect}
+            helminth={helminth}
             selectedSlotKind={
               slots.selected === "aura" || slots.selected === "exilus"
                 ? slots.selected
@@ -818,16 +819,18 @@ function SearchPanel({
   usedModNames,
   onSelect,
   selectedSlotKind,
+  helminth,
 }: {
   item: DetailItem
   category: BrowseCategory
   usedModNames: Set<string>
   onSelect: (mod: Mod) => void
   selectedSlotKind?: ModSlotKind
+  helminth: Record<number, HelminthAbility>
 }) {
   const { data: allMods } = useSuspenseQuery(modsQuery)
   const compatible = useMemo(() => {
-    const mods = getModsForItem(
+    const base = getModsForItem(
       {
         type: item.type,
         category: item.category,
@@ -835,11 +838,30 @@ function SearchPanel({
       },
       allMods,
     )
+    // Augments for subsumed abilities belong to a different warframe's
+    // `compatName`, so `getModsForItem` filters them out. Stitch them back
+    // in by matching source warframe + "<Ability> Augment:" description prefix.
+    const seen = new Set(base.map((m) => m.uniqueName))
+    const extras: Mod[] = []
+    for (const ability of Object.values(helminth)) {
+      const source = ability.source.toLowerCase()
+      const prefix = `${ability.name.toLowerCase()} augment:`
+      for (const m of allMods) {
+        if (!m.isAugment) continue
+        if (seen.has(m.uniqueName)) continue
+        if ((m.compatName ?? "").toLowerCase() !== source) continue
+        const desc = (m.levelStats?.[0]?.stats?.[0] ?? "").toLowerCase()
+        if (!desc.startsWith(prefix)) continue
+        seen.add(m.uniqueName)
+        extras.push(m)
+      }
+    }
+    const mods = extras.length ? [...base, ...extras] : base
     if (isRivenEligible(category, item)) {
       return [createSyntheticRiven(), ...mods]
     }
     return mods
-  }, [allMods, item.type, item.category, item.name, category])
+  }, [allMods, item.type, item.category, item.name, category, helminth])
 
   return (
     <ModSearchGrid

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -841,22 +841,19 @@ function SearchPanel({
     // Augments for subsumed abilities belong to a different warframe's
     // `compatName`, so `getModsForItem` filters them out. Stitch them back
     // in by matching source warframe + "<Ability> Augment:" description prefix.
-    const seen = new Set(base.map((m) => m.uniqueName))
     const extras: Mod[] = []
     for (const ability of Object.values(helminth)) {
       const source = ability.source.toLowerCase()
       const prefix = `${ability.name.toLowerCase()} augment:`
       for (const m of allMods) {
         if (!m.isAugment) continue
-        if (seen.has(m.uniqueName)) continue
         if ((m.compatName ?? "").toLowerCase() !== source) continue
         const desc = (m.levelStats?.[0]?.stats?.[0] ?? "").toLowerCase()
         if (!desc.startsWith(prefix)) continue
-        seen.add(m.uniqueName)
         extras.push(m)
       }
     }
-    const mods = extras.length ? [...base, ...extras] : base
+    const mods = [...base, ...extras]
     if (isRivenEligible(category, item)) {
       return [createSyntheticRiven(), ...mods]
     }


### PR DESCRIPTION
## Summary

Two independent editor fixes on the same branch:

### 1. Mathematical rounding for polarity-mismatch drain (closes #50)

Per the [Warframe wiki's Mods page](https://wiki.warframe.com/w/Mods), non-matching polarity increases normal-slot drain by 25% and reduces aura-slot bonus by 25%, both **rounded mathematically** (round-half-up). The editor was using `Math.ceil` / `Math.floor`.

On odd base drains this over-counted by 1 — the reporter's Shock Trooper (base 9, rank 3) showed **12** instead of the in-game **11**. Even-base mods were already correct since `base * 1.25` lands on an integer or `.5` where `ceil` and `round` agree.

Spot-checked against the wiki's bracket table:

| base | old `ceil(×1.25)` | new `round(×1.25)` | wiki |
| --- | --- | --- | --- |
| 2 | 3 | 3 | 2+1=3 ✓ |
| 6 | 8 | 8 | 6+2=8 ✓ |
| 9 | 12 ❌ | **11** ✓ | 9+2=11 ✓ |
| 10 | 13 | 13 | 10+3=13 ✓ |
| 14 | 18 | 18 | 14+4=18 ✓ |

Aura mismatch was more broken: `floor(base / 2)` (halving) instead of `round(base * 0.75)` (25% reduction). Fixed in the same pass.

### 2. Subsumed ability's augment in mod picker

When a Helminth-subsumed ability is installed on a warframe, the picker now surfaces that ability's augment (e.g. *Shock Trooper* on a Chroma with Volt's *Shock* subsumed). Previously the picker's augment filter only matched the current warframe's own `compatName`, so cross-frame augments never appeared.

Matched by source warframe `compatName` plus the `"<Ability> Augment:"` description prefix that's conventionally used on every true ability augment in the WFCD data. Confirmed against all 394 warframe augments: the 187 without the prefix are exilus/stat-only mods with generic `compatName: "WARFRAME"` — not what we want anyway. Simulated the filter against `helminth-abilities.json`:

- Subsuming *Shock* → *Shock Trooper* appears ✓
- Subsuming *Elemental Ward* → *Everlasting Ward* appears ✓

Filter lives inline in `SearchPanel` (route-level) rather than moved to the shared `packages/shared/src/warframe/mods.ts` — kept local since there's only one caller today.

## Test plan

- [ ] Load reporter's Chroma Vex Armor build: Shock Trooper drain drops 12 → **11**, capacity 79/78 → **78/78**.
- [ ] Edit a Chroma Prime build. Before subsuming: search "shock troop" → 0 results. Subsume Shock (Volt) via the helminth picker → "shock troop" matches *Shock Trooper* and is placeable. Remove subsume → it disappears.
- [ ] Spot-check a rank-10 even-base mod (Hornet Strike, base 4 → 14) in a mismatching slot: unchanged at 18.