### PR TITLE
fix(org-builds): scope to org profile, allow member edits

### DIFF
--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -162,10 +162,10 @@ builds.patch("/:slug", async (c) => {
 
   const existing = await prisma.build.findUnique({
     where: { slug },
-    select: { id: true, userId: true },
+    select: { id: true, userId: true, organizationId: true },
   })
   if (!existing) return c.json({ error: "not_found" }, 404)
-  if (existing.userId !== session.user.id) {
+  if (!(await canMutateBuild(existing, session.user.id))) {
     return c.json({ error: "forbidden" }, 403)
   }
 
@@ -235,10 +235,10 @@ builds.delete("/:slug", async (c) => {
 
   const existing = await prisma.build.findUnique({
     where: { slug },
-    select: { id: true, userId: true },
+    select: { id: true, userId: true, organizationId: true },
   })
   if (!existing) return c.json({ error: "not_found" }, 404)
-  if (existing.userId !== session.user.id) {
+  if (!(await canMutateBuild(existing, session.user.id))) {
     return c.json({ error: "forbidden" }, 403)
   }
 
@@ -593,7 +593,12 @@ builds.get("/:slug", async (c) => {
     user: build.user,
     organization: build.organization,
     guide: build.buildGuide,
-    isOwner: viewerId != null && build.userId === viewerId,
+    isOwner:
+      viewerId != null &&
+      (await canMutateBuild(
+        { userId: build.userId, organizationId: build.organizationId },
+        viewerId,
+      )),
     viewerHasLiked,
     viewerHasBookmarked,
   })
@@ -624,6 +629,16 @@ async function maybeIncrementView(
     sameSite: isProd ? "None" : "Lax",
     secure: isProd,
   })
+}
+
+async function canMutateBuild(
+  existing: { userId: string; organizationId: string | null },
+  sessionUserId: string,
+) {
+  if (existing.userId === sessionUserId) return true
+  if (existing.organizationId)
+    return isOrgMember(existing.organizationId, sessionUserId)
+  return false
 }
 
 async function isOrgMember(organizationId: string, userId: string) {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -36,10 +36,18 @@ users.get("/:username", async (c) => {
 
   const [buildCount, agg] = await Promise.all([
     prisma.build.count({
-      where: { userId: user.id, visibility: BuildVisibility.PUBLIC },
+      where: {
+        userId: user.id,
+        visibility: BuildVisibility.PUBLIC,
+        organizationId: null,
+      },
     }),
     prisma.build.aggregate({
-      where: { userId: user.id, visibility: BuildVisibility.PUBLIC },
+      where: {
+        userId: user.id,
+        visibility: BuildVisibility.PUBLIC,
+        organizationId: null,
+      },
       _sum: { likeCount: true, bookmarkCount: true, viewCount: true },
     }),
   ])
@@ -77,8 +85,12 @@ users.get("/:username/builds", async (c) => {
 
   const result = await runList({
     filters: parseListQuery(c),
-    baseWhere: { userId: user.id, visibility: BuildVisibility.PUBLIC },
-    baseFilter: Prisma.sql`"userId" = ${user.id} AND visibility = 'PUBLIC'`,
+    baseWhere: {
+      userId: user.id,
+      visibility: BuildVisibility.PUBLIC,
+      organizationId: null,
+    },
+    baseFilter: Prisma.sql`"userId" = ${user.id} AND visibility = 'PUBLIC' AND "organizationId" IS NULL`,
     defaultSort: "newest",
   })
   return c.json(result)

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -357,7 +357,18 @@ function ViewerHeader({
               {build.name}
             </h1>
             <span className="text-muted-foreground text-sm">
-              {build.item.name} · {categoryLabel} · by {author}
+              {build.item.name} · {categoryLabel} ·{" "}
+              {build.organization ? (
+                <RouterLink
+                  to="/org/$slug"
+                  params={{ slug: build.organization.slug }}
+                  className="text-[#a78bfa] hover:underline"
+                >
+                  {build.organization.name}
+                </RouterLink>
+              ) : (
+                <>by {author}</>
+              )}
             </span>
             <div className="flex flex-wrap items-center gap-2">
               <Badge


### PR DESCRIPTION
## Summary
- **User profile leak** — org builds no longer appear on the creator's profile. `GET /users/:username` stats and `GET /users/:username/builds` both now filter `organizationId: null`.
- **Edit permissions** — any org member can PATCH/DELETE builds owned by their org, not just the original author. New `canMutateBuild` helper in `builds.ts` reuses the existing `isOrgMember` lookup. `isOwner` on the detail response uses the same check so the Edit button and delete menu render for members.
- **Detail header attribution** — org builds now show a purple link to the org (`/org/$slug`) instead of "by {author}". Build cards already had this behavior; only the detail-page header was missing it.

## Why
Reported bug: org-owned builds were leaking onto the creator's user profile, org members (non-authors) got 403 on edit/delete, and the build detail header mis-labelled org builds as user builds.

## Test plan
- [ ] Visit `/@hampter`: expect 0 public builds (all 12 belong to Profit-Taker Community).
- [ ] As a Profit-Taker Community member who isn't the author: Edit button appears, save succeeds, delete works.
- [ ] As a non-member: PATCH/DELETE still return 403.
- [ ] Org build detail page header shows the org name (purple link) instead of "by {author}"; non-org builds unchanged.
- [ ] Cards on `/browse` and org profile still render correctly (regression check).