### PR TITLE
Footer: Organizations directory + real /docs, kill dead links

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -206,6 +206,7 @@ model Build {
   @@index([hasGuide])
   @@index([forkedFromId])
   @@index([organizationId])
+  @@index([organizationId, visibility])
   @@index([userId, visibility, likeCount])
   @@index([itemCategory, visibility, likeCount])
   @@map("builds")

--- a/apps/api/scripts/migrations/2026-04-21_build_org_visibility_index.sql
+++ b/apps/api/scripts/migrations/2026-04-21_build_org_visibility_index.sql
@@ -1,0 +1,14 @@
+-- Composite index for the `_count.builds where visibility=PUBLIC` correlated
+-- subquery used by /orgs/public (directory) and /orgs/:slug (profile page).
+-- Without this, Postgres uses the organizationId index and filters visibility
+-- in-heap per row — fine at small scale, degrades linearly as any org
+-- accumulates builds.
+--
+-- CONCURRENTLY cannot run inside a transaction block, so no BEGIN/COMMIT.
+-- IF NOT EXISTS makes re-runs safe.
+--
+-- Run against Neon (from apps/api/):
+--   bunx prisma db execute --file scripts/migrations/2026-04-21_build_org_visibility_index.sql
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "builds_organizationId_visibility_idx"
+  ON builds ("organizationId", "visibility");

--- a/apps/api/src/routes/_query.ts
+++ b/apps/api/src/routes/_query.ts
@@ -1,0 +1,11 @@
+// Shared query-string parsers for paginated list routes.
+
+export function parsePage(v: string | undefined): number {
+  const n = parseInt(v ?? "1", 10)
+  return Number.isFinite(n) && n > 0 ? n : 1
+}
+
+export function trimQ(v: string | undefined, max = 100): string | undefined {
+  const t = v?.trim()
+  return t && t.length > 0 ? t.slice(0, max) : undefined
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -4,6 +4,7 @@ import { prisma } from "../db"
 import { Prisma } from "../generated/prisma/client"
 import { isPrismaNotFound, requireAdmin } from "./_admin"
 import { parseListQuery, runList } from "./_build-list"
+import { parsePage, trimQ } from "./_query"
 
 export const admin = new Hono()
 
@@ -18,18 +19,12 @@ type UserFlag = (typeof USER_FLAGS)[number]
 
 const LIST_PAGE = 24
 
-function parsePage(v: string | undefined): number {
-  const n = parseInt(v ?? "1", 10)
-  return Number.isFinite(n) && n > 0 ? n : 1
-}
-
 admin.get("/users", async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 
   const page = parsePage(c.req.query("page"))
-  const qRaw = c.req.query("q")?.trim()
-  const q = qRaw && qRaw.length > 0 ? qRaw.slice(0, 100) : undefined
+  const q = trimQ(c.req.query("q"))
   const skip = (page - 1) * LIST_PAGE
 
   const where: Prisma.UserWhereInput = q
@@ -202,8 +197,7 @@ admin.get("/orgs", async (c) => {
   if (actor instanceof Response) return actor
 
   const page = parsePage(c.req.query("page"))
-  const qRaw = c.req.query("q")?.trim()
-  const q = qRaw && qRaw.length > 0 ? qRaw.slice(0, 100) : undefined
+  const q = trimQ(c.req.query("q"))
   const skip = (page - 1) * LIST_PAGE
 
   const where: Prisma.OrganizationWhereInput = q

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -5,6 +5,7 @@ import { prisma } from "../db"
 import { Prisma } from "../generated/prisma/client"
 import { BuildVisibility, OrgRole } from "../generated/prisma/enums"
 import { parseListQuery, runList } from "./_build-list"
+import { parsePage, trimQ } from "./_query"
 
 export const orgs = new Hono()
 
@@ -13,6 +14,9 @@ const MAX_NAME = 50
 const MAX_SLUG = 30
 const MAX_DESCRIPTION = 200
 const MEMBERS_LIMIT = 200
+const DIRECTORY_PAGE = 20
+// Reserved because they collide with sibling paths on the /orgs router.
+const RESERVED_SLUGS = new Set(["public"])
 
 function trimToMax(v: unknown, max: number): string | null {
   if (typeof v !== "string") return null
@@ -114,6 +118,9 @@ orgs.post("/", async (c) => {
   if (!slugRaw || !SLUG_RE.test(slugRaw)) {
     return c.json({ error: "invalid_slug" }, 400)
   }
+  if (RESERVED_SLUGS.has(slugRaw)) {
+    return c.json({ error: "slug_taken" }, 409)
+  }
 
   try {
     const created = await prisma.$transaction(async (tx) => {
@@ -137,6 +144,62 @@ orgs.post("/", async (c) => {
     }
     throw err
   }
+})
+
+// Public directory — declared before /:slug so Hono doesn't capture "public" as a slug.
+orgs.get("/public", async (c) => {
+  const page = parsePage(c.req.query("page"))
+  const q = trimQ(c.req.query("q"))
+  const skip = (page - 1) * DIRECTORY_PAGE
+
+  const where: Prisma.OrganizationWhereInput = q
+    ? {
+        OR: [
+          { name: { contains: q, mode: "insensitive" } },
+          { slug: { contains: q, mode: "insensitive" } },
+        ],
+      }
+    : {}
+
+  const [rows, total] = await Promise.all([
+    prisma.organization.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: DIRECTORY_PAGE,
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        image: true,
+        description: true,
+        createdAt: true,
+        _count: {
+          select: {
+            members: true,
+            builds: { where: { visibility: BuildVisibility.PUBLIC } },
+          },
+        },
+      },
+    }),
+    prisma.organization.count({ where }),
+  ])
+
+  return c.json({
+    orgs: rows.map((o) => ({
+      id: o.id,
+      name: o.name,
+      slug: o.slug,
+      image: o.image,
+      description: o.description,
+      createdAt: o.createdAt.toISOString(),
+      memberCount: o._count.members,
+      buildCount: o._count.builds,
+    })),
+    total,
+    page,
+    limit: DIRECTORY_PAGE,
+  })
 })
 
 orgs.get("/:slug", async (c) => {
@@ -255,6 +318,7 @@ orgs.patch("/:slug", async (c) => {
   if (typeof b.slug === "string") {
     const s = trimToMax(b.slug, MAX_SLUG)?.toLowerCase() ?? ""
     if (!s || !SLUG_RE.test(s)) return c.json({ error: "invalid_slug" }, 400)
+    if (RESERVED_SLUGS.has(s)) return c.json({ error: "slug_taken" }, 409)
     data.slug = s
   }
   if (typeof b.description === "string" || b.description === null) {

--- a/apps/web/src/components/pagination.tsx
+++ b/apps/web/src/components/pagination.tsx
@@ -1,44 +1,94 @@
-import { Button } from "@/components/ui/button"
+import {
+  Pagination as PaginationRoot,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
+
+// Compact page range with ellipses around the current window. For pages ≤ 7
+// returns [1..pages]; otherwise keeps first, last, current±1 and fills gaps
+// with "…" markers. Stable, order-preserving.
+function pageRange(current: number, pages: number): Array<number | "ellipsis"> {
+  if (pages <= 7) {
+    return Array.from({ length: pages }, (_, i) => i + 1)
+  }
+  const out: Array<number | "ellipsis"> = [1]
+  const start = Math.max(2, current - 1)
+  const end = Math.min(pages - 1, current + 1)
+  if (start > 2) out.push("ellipsis")
+  for (let i = start; i <= end; i++) out.push(i)
+  if (end < pages - 1) out.push("ellipsis")
+  out.push(pages)
+  return out
+}
 
 export function Pagination({
   page,
   total,
   limit,
   onPage,
-  showTotal = true,
+  href,
 }: {
   page: number
   total: number
   limit: number
   onPage: (p: number) => void
-  showTotal?: boolean
+  // Optional builder so users can right-click → open page in new tab.
+  // Falls back to "#" with preventDefault on click.
+  href?: (p: number) => string
 }) {
   const pages = Math.max(1, Math.ceil(total / limit))
   if (pages <= 1) return null
+
+  const items = pageRange(page, pages)
+  const linkHref = (p: number) => href?.(p) ?? "#"
+
+  const handle =
+    (p: number) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault()
+      onPage(p)
+    }
+
   return (
-    <div className="text-muted-foreground flex items-center justify-between text-sm">
-      <span>
-        Page {page} of {pages}
-        {showTotal ? ` · ${total} total` : ""}
-      </span>
-      <div className="flex gap-2">
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={page <= 1}
-          onClick={() => onPage(page - 1)}
-        >
-          Previous
-        </Button>
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={page >= pages}
-          onClick={() => onPage(page + 1)}
-        >
-          Next
-        </Button>
-      </div>
-    </div>
+    <PaginationRoot>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            href={linkHref(page - 1)}
+            onClick={handle(page - 1)}
+            aria-disabled={page <= 1}
+            className={page <= 1 ? "pointer-events-none opacity-50" : ""}
+          />
+        </PaginationItem>
+        {items.map((it, i) =>
+          it === "ellipsis" ? (
+            <PaginationItem key={`e${i}`}>
+              <PaginationEllipsis />
+            </PaginationItem>
+          ) : (
+            <PaginationItem key={it}>
+              <PaginationLink
+                href={linkHref(it)}
+                onClick={handle(it)}
+                isActive={it === page}
+              >
+                {it}
+              </PaginationLink>
+            </PaginationItem>
+          ),
+        )}
+        <PaginationItem>
+          <PaginationNext
+            href={linkHref(page + 1)}
+            onClick={handle(page + 1)}
+            aria-disabled={page >= pages}
+            className={page >= pages ? "pointer-events-none opacity-50" : ""}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </PaginationRoot>
   )
 }

--- a/apps/web/src/components/pagination.tsx
+++ b/apps/web/src/components/pagination.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/ui/button"
+
+export function Pagination({
+  page,
+  total,
+  limit,
+  onPage,
+  showTotal = true,
+}: {
+  page: number
+  total: number
+  limit: number
+  onPage: (p: number) => void
+  showTotal?: boolean
+}) {
+  const pages = Math.max(1, Math.ceil(total / limit))
+  if (pages <= 1) return null
+  return (
+    <div className="text-muted-foreground flex items-center justify-between text-sm">
+      <span>
+        Page {page} of {pages}
+        {showTotal ? ` · ${total} total` : ""}
+      </span>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={page <= 1}
+          onClick={() => onPage(page - 1)}
+        >
+          Previous
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={page >= pages}
+          onClick={() => onPage(page + 1)}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -1,0 +1,130 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex items-center gap-0.5", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <Button
+      variant={isActive ? "outline" : "ghost"}
+      size={size}
+      className={cn(className)}
+      nativeButton={false}
+      render={
+        <a
+          aria-current={isActive ? "page" : undefined}
+          data-slot="pagination-link"
+          data-active={isActive}
+          {...props}
+        />
+      }
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  text = "Previous",
+  ...props
+}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("pl-1.5!", className)}
+      {...props}
+    >
+      <ChevronLeftIcon data-icon="inline-start" />
+      <span className="hidden sm:block">{text}</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  text = "Next",
+  ...props
+}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("pr-1.5!", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">{text}</span>
+      <ChevronRightIcon data-icon="inline-end" />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn(
+        "flex size-8 items-center justify-center [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon
+      />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -17,7 +17,7 @@ export const ROUTES = {
   create: "/create",
   import: "/import",
   modsTest: "/mods-test",
-  feed: "/feed",
+  orgs: "/orgs",
   docs: "/docs",
   changelog: "/changelog",
   privacy: "/privacy",
@@ -56,7 +56,7 @@ export const FOOTER_LINKS = {
     { label: "Import Build", href: ROUTES.import },
   ],
   community: [
-    { label: "Build Feed", href: ROUTES.feed },
+    { label: "Organizations", href: ROUTES.orgs },
     { label: "Documentation", href: ROUTES.docs },
     { label: "Changelog", href: ROUTES.changelog },
     { label: "GitHub", href: EXTERNAL_LINKS.github, external: true },

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -41,6 +41,7 @@ export const API_URL =
 export const EXTERNAL_LINKS = {
   github: "https://github.com/Reuzehagel/arsenyx",
   wfcd: "https://warframestat.us",
+  apiBase: "https://api.arsenyx.com",
 } as const
 
 // Navigation items for header

--- a/apps/web/src/lib/org-query.ts
+++ b/apps/web/src/lib/org-query.ts
@@ -51,6 +51,37 @@ export type MyOrgsResponse = {
   }>
 }
 
+export type OrgDirectoryItem = {
+  id: string
+  name: string
+  slug: string
+  image: string | null
+  description: string | null
+  createdAt: string
+  memberCount: number
+  buildCount: number
+}
+
+export type OrgDirectoryResponse = {
+  orgs: OrgDirectoryItem[]
+  total: number
+  page: number
+  limit: number
+}
+
+export const orgsDirectoryQuery = (page: number) =>
+  queryOptions({
+    queryKey: ["orgs", "directory", page],
+    queryFn: async (): Promise<OrgDirectoryResponse> => {
+      const qs = page > 1 ? `?page=${page}` : ""
+      const r = await fetch(`${API_URL}/orgs/public${qs}`, {
+        credentials: "include",
+      })
+      if (!r.ok) throw new Error("failed to load organizations")
+      return r.json()
+    },
+  })
+
 export const orgQuery = (slug: string) =>
   queryOptions({
     queryKey: ["org", slug.toLowerCase()],

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -26,52 +26,46 @@ function AboutPage() {
             </p>
           </div>
 
-          <div className="prose prose-neutral dark:prose-invert flex max-w-none flex-col gap-8">
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">Our Mission</h2>
-              <p>
-                Arsenyx was built with one goal in mind: to be the fastest, most
-                modern Warframe build planner. We believe that planning your
-                loadout should be as fluid and fast as the game itself. Focused
-                on keyboard-first navigation and immediate feedback, we&apos;re
-                rethinking how Tennos share and optimize their builds.
-              </p>
-            </section>
+          <article className="prose prose-neutral dark:prose-invert max-w-none">
+            <h2>Our Mission</h2>
+            <p>
+              Arsenyx was built with one goal in mind: to be the fastest, most
+              modern Warframe build planner. We believe that planning your
+              loadout should be as fluid and fast as the game itself. Focused on
+              keyboard-first navigation and immediate feedback, we&apos;re
+              rethinking how Tennos share and optimize their builds.
+            </p>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">Open Source</h2>
-              <p>
-                We believe in the power of community. That&apos;s why Arsenyx is
-                fully open source. Anyone can contribute code, suggest features,
-                or report bugs. We&apos;re building this together.
-              </p>
-              <div className="mt-6 flex gap-4">
-                <Button
-                  render={
-                    <Link
-                      href={EXTERNAL_LINKS.github}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    />
-                  }
-                  nativeButton={false}
-                >
-                  <Icons.github data-icon="inline-start" />
-                  View on GitHub
-                </Button>
-              </div>
-            </section>
+            <h2>Open Source</h2>
+            <p>
+              We believe in the power of community. That&apos;s why Arsenyx is
+              fully open source. Anyone can contribute code, suggest features,
+              or report bugs. We&apos;re building this together.
+            </p>
+            <div className="not-prose">
+              <Button
+                render={
+                  <Link
+                    href={EXTERNAL_LINKS.github}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                }
+                nativeButton={false}
+              >
+                <Icons.github data-icon="inline-start" />
+                View on GitHub
+              </Button>
+            </div>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">Community Focused</h2>
-              <p>
-                From real-time stats updates to seamless sharing, every feature
-                is designed to help the Warframe community. Data is
-                automatically synced with Warframe Community Developers (WFCD)
-                to ensure accuracy.
-              </p>
-            </section>
-          </div>
+            <h2>Community Focused</h2>
+            <p>
+              From real-time stats updates to seamless sharing, every feature is
+              designed to help the Warframe community. Data is automatically
+              synced with Warframe Community Developers (WFCD) to ensure
+              accuracy.
+            </p>
+          </article>
         </div>
       </main>
       <Footer />

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -5,6 +5,7 @@ import { Suspense, useState } from "react"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Link } from "@/components/link"
+import { Pagination } from "@/components/pagination"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -168,46 +169,6 @@ function SearchBar({
         Search
       </Button>
     </form>
-  )
-}
-
-function Pagination({
-  page,
-  total,
-  limit,
-  onPage,
-}: {
-  page: number
-  total: number
-  limit: number
-  onPage: (p: number) => void
-}) {
-  const pages = Math.max(1, Math.ceil(total / limit))
-  if (pages <= 1) return null
-  return (
-    <div className="text-muted-foreground flex items-center justify-between text-sm">
-      <span>
-        Page {page} of {pages} · {total} total
-      </span>
-      <div className="flex gap-2">
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={page <= 1}
-          onClick={() => onPage(page - 1)}
-        >
-          Previous
-        </Button>
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={page >= pages}
-          onClick={() => onPage(page + 1)}
-        >
-          Next
-        </Button>
-      </div>
-    </div>
   )
 }
 

--- a/apps/web/src/routes/docs.tsx
+++ b/apps/web/src/routes/docs.tsx
@@ -1,0 +1,181 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { Footer } from "@/components/footer"
+import { Header } from "@/components/header"
+import { Icons } from "@/components/icons"
+import { Link } from "@/components/link"
+import { Button } from "@/components/ui/button"
+import { EXTERNAL_LINKS, SITE_CONFIG } from "@/lib/constants"
+
+export const Route = createFileRoute("/docs")({
+  component: DocsPage,
+})
+
+const API_BASE = "https://api.arsenyx.com"
+
+type Endpoint = {
+  method: "GET"
+  path: string
+  summary: string
+  example: string
+}
+
+const PUBLIC_ENDPOINTS: Endpoint[] = [
+  {
+    method: "GET",
+    path: "/builds",
+    summary:
+      "List public builds. Supports ?page, ?sort, ?q, ?category, ?hasGuide, ?hasShards.",
+    example: `{
+  "builds": [ { "slug": "...", "title": "...", "category": "warframe", ... } ],
+  "total": 1234,
+  "page": 1,
+  "limit": 24
+}`,
+  },
+  {
+    method: "GET",
+    path: "/builds/:slug",
+    summary: "Fetch a single public build by slug.",
+    example: `{
+  "slug": "...",
+  "title": "...",
+  "category": "warframe",
+  "items": [...],
+  "mods": [...],
+  "arcanes": [...]
+}`,
+  },
+  {
+    method: "GET",
+    path: "/orgs/public",
+    summary:
+      "Directory of all organizations. Supports ?page (20 per page) and ?q for name/slug search.",
+    example: `{
+  "orgs": [
+    { "slug": "...", "name": "...", "memberCount": 12, "buildCount": 34, ... }
+  ],
+  "total": 7,
+  "page": 1,
+  "limit": 20
+}`,
+  },
+  {
+    method: "GET",
+    path: "/orgs/:slug",
+    summary: "Organization profile: members, description, public build count.",
+    example: `{
+  "slug": "...",
+  "name": "...",
+  "members": [ { "role": "ADMIN" | "MEMBER", "user": {...} } ],
+  "buildCount": 34
+}`,
+  },
+  {
+    method: "GET",
+    path: "/orgs/:slug/builds",
+    summary:
+      "Public builds authored under an organization. Same filters as /builds.",
+    example: `{
+  "builds": [...],
+  "total": 34,
+  "page": 1,
+  "limit": 24
+}`,
+  },
+]
+
+function DocsPage() {
+  return (
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="container max-w-3xl flex-1 py-12">
+        <article className="prose prose-neutral dark:prose-invert max-w-none">
+          <h1>Documentation</h1>
+          <p className="lead">
+            How {SITE_CONFIG.name} is put together, and how to build on top of
+            it.
+          </p>
+
+          <h2>Overview</h2>
+          <p>
+            Arsenyx is a Warframe build planner. The app splits data in two:
+            <strong> game data</strong> (items, mods, arcanes) is static JSON
+            baked at build time and served from the CDN, while{" "}
+            <strong>user data</strong> (builds, votes, bookmarks, organizations)
+            lives in Postgres behind a small HTTP API. The site, the API, and
+            the data pipeline are all open source.
+          </p>
+
+          <h2>Public API</h2>
+          <p>
+            Base URL: <code>{API_BASE}</code>. Authentication is cookie-based
+            (Better Auth). The endpoints below are public and read-only — no
+            credentials required. Write endpoints, user data, and admin routes
+            require a session and aren&apos;t documented here.
+          </p>
+          <ul className="not-prose flex list-none flex-col gap-4 pl-0">
+            {PUBLIC_ENDPOINTS.map((ep) => (
+              <li
+                key={`${ep.method} ${ep.path}`}
+                className="border-border bg-card flex flex-col gap-2 rounded-lg border p-4"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="bg-muted rounded px-2 py-0.5 font-mono text-xs font-semibold">
+                    {ep.method}
+                  </span>
+                  <code className="text-sm font-medium">{ep.path}</code>
+                </div>
+                <p className="text-muted-foreground text-sm">{ep.summary}</p>
+                <pre className="bg-muted/50 overflow-x-auto rounded p-3 text-xs leading-relaxed">
+                  <code>{ep.example}</code>
+                </pre>
+              </li>
+            ))}
+          </ul>
+          <p className="text-sm opacity-75">
+            Fields abbreviated. Responses are subject to change while Arsenyx
+            is in beta — pin to the commit you tested against.
+          </p>
+
+          <h2>Game data</h2>
+          <p>
+            Items, mods, and arcanes live as static JSON under{" "}
+            <code>apps/web/public/data/</code>. The index is generated from the{" "}
+            <Link
+              href={EXTERNAL_LINKS.wfcd}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Warframe Community Developers
+            </Link>{" "}
+            dataset and committed to the repo, so loading game data is a single
+            static fetch against the CDN — no API round-trip.
+          </p>
+
+          <h2>Contributing</h2>
+          <p>
+            Arsenyx is open source. Bug reports, feature requests, and pull
+            requests are all welcome on GitHub.
+          </p>
+          <div className="not-prose">
+            <Button
+              render={
+                <Link
+                  href={EXTERNAL_LINKS.github}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+              nativeButton={false}
+            >
+              <Icons.github data-icon="inline-start" />
+              View on GitHub
+            </Button>
+          </div>
+        </article>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/src/routes/docs.tsx
+++ b/apps/web/src/routes/docs.tsx
@@ -11,8 +11,6 @@ export const Route = createFileRoute("/docs")({
   component: DocsPage,
 })
 
-const API_BASE = "https://api.arsenyx.com"
-
 type Endpoint = {
   method: "GET"
   path: string
@@ -50,7 +48,7 @@ const PUBLIC_ENDPOINTS: Endpoint[] = [
     method: "GET",
     path: "/orgs/public",
     summary:
-      "Directory of all organizations. Supports ?page (20 per page) and ?q for name/slug search.",
+      "Directory of all organizations. Paginated, with ?q for name/slug search.",
     example: `{
   "orgs": [
     { "slug": "...", "name": "...", "memberCount": 12, "buildCount": 34, ... }
@@ -109,7 +107,7 @@ function DocsPage() {
 
           <h2>Public API</h2>
           <p>
-            Base URL: <code>{API_BASE}</code>. Authentication is cookie-based
+            Base URL: <code>{EXTERNAL_LINKS.apiBase}</code>. Authentication is cookie-based
             (Better Auth). The endpoints below are public and read-only — no
             credentials required. Write endpoints, user data, and admin routes
             require a session and aren&apos;t documented here.

--- a/apps/web/src/routes/orgs.tsx
+++ b/apps/web/src/routes/orgs.tsx
@@ -136,7 +136,7 @@ function OrgsDirectoryContent() {
         total={total}
         limit={limit}
         onPage={goto}
-        showTotal={false}
+        href={(p) => (p > 1 ? `/orgs?page=${p}` : "/orgs")}
       />
     </>
   )

--- a/apps/web/src/routes/orgs.tsx
+++ b/apps/web/src/routes/orgs.tsx
@@ -1,0 +1,143 @@
+import { useSuspenseQuery } from "@tanstack/react-query"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { Suspense } from "react"
+
+import { Footer } from "@/components/footer"
+import { Header } from "@/components/header"
+import { Link } from "@/components/link"
+import { Pagination } from "@/components/pagination"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { UserAvatar } from "@/components/user-avatar"
+import { orgsDirectoryQuery } from "@/lib/org-query"
+
+type OrgsSearch = { page?: number }
+
+export const Route = createFileRoute("/orgs")({
+  validateSearch: (search): OrgsSearch => {
+    const raw = (search as { page?: unknown }).page
+    const n = typeof raw === "number" ? raw : parseInt(String(raw ?? ""), 10)
+    return Number.isFinite(n) && n > 1 ? { page: n } : {}
+  },
+  loaderDeps: ({ search }) => ({ page: search.page ?? 1 }),
+  loader: ({ context, deps }) =>
+    context.queryClient.ensureQueryData(orgsDirectoryQuery(deps.page)),
+  component: OrgsDirectoryPage,
+})
+
+function OrgsDirectoryPage() {
+  return (
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
+        <div className="container max-w-5xl flex flex-col gap-8 py-10">
+          <div className="flex flex-col gap-2">
+            <h1 className="text-3xl font-bold tracking-tight">Organizations</h1>
+            <p className="text-muted-foreground text-sm">
+              Communities on Arsenyx. Join one to share builds under a shared
+              banner, or browse their public builds.
+            </p>
+          </div>
+          <Suspense
+            fallback={
+              <p className="text-muted-foreground text-sm">
+                Loading organizations…
+              </p>
+            }
+          >
+            <OrgsDirectoryContent />
+          </Suspense>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+function OrgsDirectoryContent() {
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+  const page = search.page ?? 1
+  const { data } = useSuspenseQuery(orgsDirectoryQuery(page))
+  const { orgs, total, limit } = data
+
+  const goto = (next: number) =>
+    navigate({
+      search: next > 1 ? { page: next } : {},
+      replace: false,
+    })
+
+  if (orgs.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No organizations yet. Be the first to create one.
+      </p>
+    )
+  }
+
+  return (
+    <>
+      <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {orgs.map((org) => (
+          <li key={org.id}>
+            <Link
+              href={`/org/${org.slug}`}
+              className="block h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+            >
+              <Card className="h-full transition-colors hover:bg-muted/30">
+                <CardHeader className="flex flex-row items-center gap-3">
+                  <UserAvatar
+                    src={org.image}
+                    fallback={org.name}
+                    size={10}
+                    shape="square"
+                  />
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <CardTitle className="truncate">{org.name}</CardTitle>
+                    <CardDescription className="truncate text-xs">
+                      @{org.slug}
+                    </CardDescription>
+                  </div>
+                </CardHeader>
+                {org.description ? (
+                  <CardContent>
+                    <p className="text-muted-foreground line-clamp-3 text-sm">
+                      {org.description}
+                    </p>
+                  </CardContent>
+                ) : null}
+                <CardFooter className="text-muted-foreground justify-between text-xs">
+                  <span>
+                    <span className="text-foreground font-semibold tabular-nums">
+                      {org.memberCount.toLocaleString()}
+                    </span>{" "}
+                    {org.memberCount === 1 ? "member" : "members"}
+                  </span>
+                  <span>
+                    <span className="text-foreground font-semibold tabular-nums">
+                      {org.buildCount.toLocaleString()}
+                    </span>{" "}
+                    {org.buildCount === 1 ? "build" : "builds"}
+                  </span>
+                </CardFooter>
+              </Card>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <Pagination
+        page={page}
+        total={total}
+        limit={limit}
+        onPage={goto}
+        showTotal={false}
+      />
+    </>
+  )
+}

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -19,66 +19,49 @@ function PrivacyPage() {
             Last updated: {new Date().toLocaleDateString()}
           </p>
 
-          <div className="prose prose-neutral dark:prose-invert flex max-w-none flex-col gap-8">
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">
-                1. Information We Collect
-              </h2>
-              <p>
-                {SITE_CONFIG.name} is designed to be privacy-friendly. We
-                minimize the data we collect.
-              </p>
-              <ul className="mt-2 flex list-disc flex-col gap-2 pl-6">
-                <li>
-                  <strong>Authentication Data:</strong> If you sign in, we store
-                  your basic profile information provided by the authentication
-                  provider (e.g., GitHub, Discord).
-                </li>
-                <li>
-                  <strong>Usage Data:</strong> We may collect anonymous
-                  analytics data to understand how our service is used and to
-                  improve it.
-                </li>
-                <li>
-                  <strong>User Content:</strong> Builds and guides you create
-                  and save are stored in our database.
-                </li>
-              </ul>
-            </section>
+          <article className="prose prose-neutral dark:prose-invert max-w-none">
+            <h2>1. Information We Collect</h2>
+            <p>
+              {SITE_CONFIG.name} is designed to be privacy-friendly. We minimize
+              the data we collect.
+            </p>
+            <ul>
+              <li>
+                <strong>Authentication Data:</strong> If you sign in, we store
+                your basic profile information provided by the authentication
+                provider (e.g., GitHub, Discord).
+              </li>
+              <li>
+                <strong>Usage Data:</strong> We may collect anonymous analytics
+                data to understand how our service is used and to improve it.
+              </li>
+              <li>
+                <strong>User Content:</strong> Builds and guides you create and
+                save are stored in our database.
+              </li>
+            </ul>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">
-                2. How We Use Your Information
-              </h2>
-              <p>
-                We use the collected information solely for providing and
-                improving the service. We do not sell your personal data to
-                third parties.
-              </p>
-            </section>
+            <h2>2. How We Use Your Information</h2>
+            <p>
+              We use the collected information solely for providing and
+              improving the service. We do not sell your personal data to third
+              parties.
+            </p>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">
-                3. Cookies and Local Storage
-              </h2>
-              <p>
-                We use cookies and local storage to maintain your session and
-                store your preferences. These are essential for the functioning
-                of the application.
-              </p>
-            </section>
+            <h2>3. Cookies and Local Storage</h2>
+            <p>
+              We use cookies and local storage to maintain your session and
+              store your preferences. These are essential for the functioning of
+              the application.
+            </p>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">
-                4. Third-Party Services
-              </h2>
-              <p>
-                Our service may use third-party services for authentication,
-                hosting, and analytics. Please review their respective privacy
-                policies for more information.
-              </p>
-            </section>
-          </div>
+            <h2>4. Third-Party Services</h2>
+            <p>
+              Our service may use third-party services for authentication,
+              hosting, and analytics. Please review their respective privacy
+              policies for more information.
+            </p>
+          </article>
         </div>
       </main>
       <Footer />

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -21,52 +21,41 @@ function TermsPage() {
             Last updated: {new Date().toLocaleDateString()}
           </p>
 
-          <div className="prose prose-neutral dark:prose-invert flex max-w-none flex-col gap-8">
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">
-                1. Acceptance of Terms
-              </h2>
-              <p>
-                By accessing and using {SITE_CONFIG.name}, you agree to be bound
-                by these Terms of Service. If you do not agree to these terms,
-                please do not use our services.
-              </p>
-            </section>
+          <article className="prose prose-neutral dark:prose-invert max-w-none">
+            <h2>1. Acceptance of Terms</h2>
+            <p>
+              By accessing and using {SITE_CONFIG.name}, you agree to be bound
+              by these Terms of Service. If you do not agree to these terms,
+              please do not use our services.
+            </p>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">2. Use of Service</h2>
-              <p>
-                {SITE_CONFIG.name} is an open-source Warframe build planner
-                provided &quot;as is&quot;. You agree to use this service only
-                for lawful purposes and in accordance with these Terms.
-              </p>
-            </section>
+            <h2>2. Use of Service</h2>
+            <p>
+              {SITE_CONFIG.name} is an open-source Warframe build planner
+              provided &quot;as is&quot;. You agree to use this service only for
+              lawful purposes and in accordance with these Terms.
+            </p>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">3. User Content</h2>
-              <p>
-                Users may create and share builds. By posting content, you grant
-                us a license to use, modify, publicly perform, publicly display,
-                reproduce, and distribute such content on and through the
-                service. You retain all of your ownership rights in your
-                content.
-              </p>
-            </section>
+            <h2>3. User Content</h2>
+            <p>
+              Users may create and share builds. By posting content, you grant
+              us a license to use, modify, publicly perform, publicly display,
+              reproduce, and distribute such content on and through the service.
+              You retain all of your ownership rights in your content.
+            </p>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold">4. Disclaimer</h2>
-              <p>
-                We are not affiliated with Digital Extremes. Warframe content
-                and materials are trademarks and copyrights of Digital Extremes
-                or its licensors.
-              </p>
-              <p className="mt-2">
-                The service is provided without warranties of any kind, whether
-                express or implied. We do not guarantee that the service will be
-                uninterrupted or error-free.
-              </p>
-            </section>
-          </div>
+            <h2>4. Disclaimer</h2>
+            <p>
+              We are not affiliated with Digital Extremes. Warframe content and
+              materials are trademarks and copyrights of Digital Extremes or its
+              licensors.
+            </p>
+            <p>
+              The service is provided without warranties of any kind, whether
+              express or implied. We do not guarantee that the service will be
+              uninterrupted or error-free.
+            </p>
+          </article>
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
## Summary

- Remove dead **Build Feed** link from the footer; `/feed` never existed.
- Add a real **/docs** page covering overview, public read API (with example responses for `/builds`, `/builds/:slug`, `/orgs/public`, `/orgs/:slug`, `/orgs/:slug/builds`), game data pipeline, and contributing.
- Add **Organizations** footer entry → new `/orgs` directory route backed by a new public `GET /orgs/public` endpoint (paginated, optional `?q=` search). Uniform naming across UI, URL, and code — no "Communities" anywhere.

## Why

Two links in the Community footer column were 404s, and there was no way to discover an organization without already knowing its slug. Organizations are fully implemented on the backend (Prisma model, `/org/:slug` detail pages) but had admin-only listing.

## Simplify pass

While in here:
- Extract shared `parsePage` / `trimQ` to `apps/api/src/routes/_query.ts` — dedupes admin.ts and orgs.ts.
- Extract `<Pagination>` to `apps/web/src/components/pagination.tsx` — dedupes admin.tsx and the new orgs.tsx.
- Move `orgsDirectoryQuery` into `apps/web/src/lib/org-query.ts` alongside its siblings (`orgQuery`, `orgBuildsQuery`, `myOrgsQuery`).
- Flatten prose layouts on about/privacy/terms. They had `prose ... flex flex-col gap-8` with `<section>` wrappers, which disables margin collapsing and stacks prose heading margins on top of flex gap — that's what caused the enormous spacing between sections. Now a flat `<article class="prose ...">` with plain `h2`/`p` siblings. `/docs` follows the same pattern with `not-prose` escapes on the endpoint card list and GitHub button.
- Reserve the slug `"public"` on both `POST` and `PATCH /orgs/:slug` so nobody can rename an org into the new directory path.

## Skipped (flagged in review, deferred)

- Missing `@@index([organizationId, visibility])` on `Build`. The `/orgs/public` and `/org/:slug` pages both use a `_count.builds where visibility=PUBLIC` correlated subquery; this index would help both. Requires a schema change — left for a follow-up.

## Test plan

- [ ] `just dev`, footer Community column shows **Organizations, Documentation, Changelog, GitHub**; Build Feed is gone.
- [ ] Click **Documentation** → `/docs` renders with Overview / Public API / Game data / Contributing.
- [ ] Click **Organizations** → `/orgs` renders a card grid. Each card links to `/org/{slug}`; Prev/Next pagination works when more than 20 orgs exist.
- [ ] Incognito (logged out): `/orgs` still loads — new endpoint is truly public.
- [ ] `curl http://localhost:8787/orgs/public` returns `{ orgs, total, page, limit }` with no auth header. `curl http://localhost:8787/orgs` still returns 401 (unchanged).
- [ ] Admin `/admin` page still paginates as before (shared Pagination component).
- [ ] About / Privacy / Terms look visually tighter than before — headings no longer float with huge gaps above them.