### PR TITLE
Mobile responsive pass: build page, tabs, nav, settings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,5 +12,5 @@
 
 ## Polish
 
-- [ ] Mobile nav (hamburger + sheet)
+- [x] Mobile nav (hamburger + sheet)
 - [x] Split frontend bundle — route-level code splitting to get under the 500KB Vite warning

--- a/apps/web/src/components/browse/category-tabs.tsx
+++ b/apps/web/src/components/browse/category-tabs.tsx
@@ -1,3 +1,4 @@
+import { TabScroller } from "@/components/tab-scroller"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CATEGORIES, type BrowseCategory } from "@/lib/warframe"
 
@@ -8,17 +9,19 @@ interface CategoryTabsProps {
 
 export function CategoryTabs({ activeCategory, onChange }: CategoryTabsProps) {
   return (
-    <Tabs
-      value={activeCategory}
-      onValueChange={(v) => onChange(v as BrowseCategory)}
-    >
-      <TabsList>
-        {CATEGORIES.map((c) => (
-          <TabsTrigger key={c.id} value={c.id}>
-            {c.label}
-          </TabsTrigger>
-        ))}
-      </TabsList>
-    </Tabs>
+    <TabScroller activeKey={activeCategory}>
+      <Tabs
+        value={activeCategory}
+        onValueChange={(v) => onChange(v as BrowseCategory)}
+      >
+        <TabsList>
+          {CATEGORIES.map((c) => (
+            <TabsTrigger key={c.id} value={c.id}>
+              {c.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+    </TabScroller>
   )
 }

--- a/apps/web/src/components/build-editor/arcane-slot.tsx
+++ b/apps/web/src/components/build-editor/arcane-slot.tsx
@@ -69,7 +69,7 @@ export function ArcaneSlot({
         }
         onContextMenu={handleContextMenu}
         className={cn(
-          "group relative flex h-[80px] w-full flex-col items-center justify-center transition-colors",
+          "group relative flex h-[80px] w-full max-w-[140px] flex-col items-center justify-center transition-colors",
           "sm:h-[90px] sm:w-[120px] sm:flex-none md:h-[100px] md:w-[140px]",
           !readOnly && "cursor-pointer",
           !placed && "rounded-md border",

--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -304,8 +304,10 @@ export function ItemSidebar({
           <CapacityBar used={capacityUsed} max={capacityMax} />
         </div>
 
+        {/* `sm:flex` is unconditional so desktop visibility never depends on
+            `statsExpanded` — the toggle that flips it is `sm:hidden`. */}
         <div
-          className={cn("flex-col", statsExpanded ? "flex" : "hidden sm:flex")}
+          className={cn("flex-col sm:flex", statsExpanded ? "flex" : "hidden")}
         >
           <Separator />
           <div className="flex flex-col gap-3 p-3">

--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -7,7 +7,7 @@ import {
 } from "@arsenyx/shared/warframe/types"
 import { isZawStrike } from "@arsenyx/shared/warframe/zaw-data"
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { ChevronLeft, Plus, Undo2, X, Zap } from "lucide-react"
+import { ChevronDown, ChevronLeft, Plus, Undo2, X, Zap } from "lucide-react"
 import { Suspense, useMemo, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -155,6 +155,12 @@ export function ItemSidebar({
   )
 
   const [showMaxStacks, setShowMaxStacks] = useState(false)
+
+  // Stats panels fold on phones only. On sm+ (≥640px) the `sm:flex` rule
+  // below forces the panel visible regardless of this state, so we default
+  // to collapsed: the toggle button is sm:hidden and only flips this on
+  // actual phones.
+  const [statsExpanded, setStatsExpanded] = useState(false)
   const hasConditional = useMemo(
     () => hasConditionalStats(modList, arcaneList),
     [modList, arcaneList],
@@ -225,103 +231,121 @@ export function ItemSidebar({
   }, [isCompanion, item, modList, arcaneList, showMaxStacks])
 
   return (
-    <div className="flex h-full flex-col">
-      {isWarframe && abilities.length > 0 && (
-        <>
-          <div className="flex justify-around p-3">
-            {abilities.slice(0, 4).map((a, i) => {
-              const replaced = helminth[i]
-              const displayed = replaced
-                ? {
-                    uniqueName: replaced.uniqueName,
-                    name: replaced.name,
-                    description: replaced.description,
-                    imageName: replaced.imageName,
-                  }
-                : a
-              return (
-                <AbilityIcon
-                  key={i}
-                  ability={displayed}
-                  isHelminth={Boolean(replaced)}
-                  canSubsume={isPureWarframe && !readOnly}
-                  onSelectHelminth={(ab) => onSetHelminth(i, ab)}
-                />
-              )
-            })}
-          </div>
-          <Separator />
-        </>
-      )}
+    <>
+      <div className="bg-card flex h-full flex-col rounded-lg border xl:overflow-y-auto">
+        {isWarframe && abilities.length > 0 && (
+          <>
+            <div className="flex justify-around p-3">
+              {abilities.slice(0, 4).map((a, i) => {
+                const replaced = helminth[i]
+                const displayed = replaced
+                  ? {
+                      uniqueName: replaced.uniqueName,
+                      name: replaced.name,
+                      description: replaced.description,
+                      imageName: replaced.imageName,
+                    }
+                  : a
+                return (
+                  <AbilityIcon
+                    key={i}
+                    ability={displayed}
+                    isHelminth={Boolean(replaced)}
+                    canSubsume={isPureWarframe && !readOnly}
+                    onSelectHelminth={(ab) => onSetHelminth(i, ab)}
+                  />
+                )
+              })}
+            </div>
+            <Separator />
+          </>
+        )}
 
-      {isZawItem && zawComponents && (
-        <>
-          <div className="flex justify-center p-3">
-            <ZawComponentSelector
-              components={zawComponents}
-              onChange={onSetZawComponents}
-              readOnly={readOnly}
-            />
-          </div>
-          <Separator />
-        </>
-      )}
-
-      {showShards && (
-        <>
-          <div className="flex justify-around p-3">
-            {Array.from({ length: SHARD_SLOTS }).map((_, i) => (
-              <ShardSlot
-                key={i}
-                shard={shards[i] ?? null}
-                onPick={(s) => onSetShard(i, s)}
+        {isZawItem && zawComponents && (
+          <>
+            <div className="flex justify-center p-3">
+              <ZawComponentSelector
+                components={zawComponents}
+                onChange={onSetZawComponents}
                 readOnly={readOnly}
               />
-            ))}
-          </div>
-          <Separator />
-        </>
-      )}
+            </div>
+            <Separator />
+          </>
+        )}
 
-      <div className="flex flex-col gap-2 p-3">
-        <div className="flex items-center justify-between text-xs">
-          <span className="font-medium">{boosterLabel}</span>
-          <Switch
-            size="sm"
-            checked={hasReactor}
-            onCheckedChange={onToggleReactor}
-            disabled={readOnly}
-          />
-        </div>
+        {showShards && (
+          <>
+            <div className="flex justify-around p-3">
+              {Array.from({ length: SHARD_SLOTS }).map((_, i) => (
+                <ShardSlot
+                  key={i}
+                  shard={shards[i] ?? null}
+                  onPick={(s) => onSetShard(i, s)}
+                  readOnly={readOnly}
+                />
+              ))}
+            </div>
+            <Separator />
+          </>
+        )}
 
-        <CapacityBar used={capacityUsed} max={capacityMax} />
-      </div>
-
-      <Separator />
-
-      <div className="flex flex-col gap-3 p-3">
-        {hasConditional && (
+        <div className="flex flex-col gap-2 p-3">
           <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Max stacks</span>
+            <span className="font-medium">{boosterLabel}</span>
             <Switch
               size="sm"
-              checked={showMaxStacks}
-              onCheckedChange={setShowMaxStacks}
+              checked={hasReactor}
+              onCheckedChange={onToggleReactor}
+              disabled={readOnly}
             />
           </div>
-        )}
-        {showLichBonus && (
-          <LichBonusElementPicker
-            value={lichBonusElement ?? null}
-            onChange={(v) => onSetLichBonusElement?.(v)}
-            readOnly={readOnly}
-          />
-        )}
-        {warframeStats && <WarframeStatsPanel stats={warframeStats} />}
-        {weaponStats && <WeaponStatsPanel stats={weaponStats} />}
-        {companionStats && <CompanionStatsPanel stats={companionStats} />}
+
+          <CapacityBar used={capacityUsed} max={capacityMax} />
+        </div>
+
+        <div
+          className={cn("flex-col", statsExpanded ? "flex" : "hidden sm:flex")}
+        >
+          <Separator />
+          <div className="flex flex-col gap-3 p-3">
+            {hasConditional && (
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">Max stacks</span>
+                <Switch
+                  size="sm"
+                  checked={showMaxStacks}
+                  onCheckedChange={setShowMaxStacks}
+                />
+              </div>
+            )}
+            {showLichBonus && (
+              <LichBonusElementPicker
+                value={lichBonusElement ?? null}
+                onChange={(v) => onSetLichBonusElement?.(v)}
+                readOnly={readOnly}
+              />
+            )}
+            {warframeStats && <WarframeStatsPanel stats={warframeStats} />}
+            {weaponStats && <WeaponStatsPanel stats={weaponStats} />}
+            {companionStats && <CompanionStatsPanel stats={companionStats} />}
+          </div>
+        </div>
       </div>
-    </div>
+      <button
+        type="button"
+        onClick={() => setStatsExpanded((v) => !v)}
+        className="bg-card text-muted-foreground hover:bg-accent/40 hover:text-foreground mx-auto flex items-center gap-1.5 rounded-t-none rounded-b-md border border-t-0 px-3 py-1 text-xs transition-colors sm:hidden"
+      >
+        <span>{statsExpanded ? "Hide stats" : "Show stats"}</span>
+        <ChevronDown
+          className={cn(
+            "size-3.5 transition-transform",
+            statsExpanded && "rotate-180",
+          )}
+        />
+      </button>
+    </>
   )
 }
 

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -127,9 +127,9 @@ export function ModGrid({
   }
 
   return (
-    <div className="flex flex-col gap-6 sm:gap-4">
+    <div className="flex flex-col gap-6 @min-[816px]/loadout:gap-4">
       {(auraSlotCount > 0 || showExilus) && (
-        <div className="flex w-full justify-center gap-2 sm:gap-4">
+        <div className="flex w-full justify-center gap-2 @min-[816px]/loadout:gap-4">
           {auraSlotCount > 0 && (
             <ModSlot
               kind="aura"
@@ -154,7 +154,7 @@ export function ModGrid({
       )}
 
       {isCompanion ? (
-        <div className="grid grid-cols-2 gap-x-2 gap-y-6 lg:mx-auto lg:w-fit lg:grid-cols-5 lg:gap-4">
+        <div className="grid grid-cols-[repeat(2,minmax(0,184px))] justify-center gap-x-2 gap-y-6 @min-[1016px]/loadout:mx-auto @min-[1016px]/loadout:w-fit @min-[1016px]/loadout:grid-cols-5 @min-[1016px]/loadout:gap-4">
           {Array.from({ length: normalSlotCount }, (_, i) => {
             const id: SlotId = `normal-${i}`
             return (
@@ -166,12 +166,15 @@ export function ModGrid({
         normalRows.map((row, rowIdx) => (
           <div
             key={rowIdx}
-            className="grid grid-cols-2 justify-center gap-x-2 gap-y-6 sm:flex sm:gap-4"
+            className="grid grid-cols-[repeat(2,minmax(0,184px))] justify-center gap-x-2 gap-y-6 @min-[816px]/loadout:flex @min-[816px]/loadout:gap-4"
           >
             {row.map((i) => {
               const id: SlotId = `normal-${i}`
               return (
-                <ModSlot key={i} {...slotProps(id, toPolarity(polarities[i]))} />
+                <ModSlot
+                  key={i}
+                  {...slotProps(id, toPolarity(polarities[i]))}
+                />
               )
             })}
           </div>

--- a/apps/web/src/components/build-editor/mod-slot.tsx
+++ b/apps/web/src/components/build-editor/mod-slot.tsx
@@ -99,8 +99,14 @@ export function ModSlot({
         className={cn(
           // Identical dimensions for empty and filled states so a row's
           // height/width never shifts based on how many mods are placed.
-          "group relative flex h-[80px] w-full flex-col items-center justify-center transition-colors",
-          "sm:h-[90px] sm:w-[150px] md:h-[100px] md:w-[184px]",
+          // Sizes respond to the loadout container (@container/loadout on the
+          // grid wrapper), not the viewport — so the sidebar's width never
+          // squeezes the grid into overflow. ModCard itself is fixed 184px
+          // (see mod-card-config.ts DISPLAY_SIZE), so there's no intermediate
+          // slot size — either we have room for a 184px card, or we fall back
+          // to the 2-col stacked layout.
+          "group relative flex h-[80px] w-full max-w-[184px] flex-col items-center justify-center transition-colors",
+          "@min-[816px]/loadout:h-[100px] @min-[816px]/loadout:w-[184px]",
           !readOnly && "cursor-pointer",
           !mod && "rounded-md border",
           !mod &&

--- a/apps/web/src/components/builds/builds-category-tabs.tsx
+++ b/apps/web/src/components/builds/builds-category-tabs.tsx
@@ -1,3 +1,4 @@
+import { TabScroller } from "@/components/tab-scroller"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CATEGORIES, type BrowseCategory } from "@/lib/warframe"
 
@@ -10,22 +11,25 @@ export function BuildsCategoryTabs({
   value: BrowseCategory | undefined
   onChange: (value: BrowseCategory | undefined) => void
 }) {
+  const activeKey = value ?? ALL
   return (
-    <Tabs
-      value={value ?? ALL}
-      onValueChange={(v) => {
-        if (v === ALL) onChange(undefined)
-        else onChange(v as BrowseCategory)
-      }}
-    >
-      <TabsList>
-        <TabsTrigger value={ALL}>All</TabsTrigger>
-        {CATEGORIES.map((c) => (
-          <TabsTrigger key={c.id} value={c.id}>
-            {c.label}
-          </TabsTrigger>
-        ))}
-      </TabsList>
-    </Tabs>
+    <TabScroller activeKey={activeKey}>
+      <Tabs
+        value={activeKey}
+        onValueChange={(v) => {
+          if (v === ALL) onChange(undefined)
+          else onChange(v as BrowseCategory)
+        }}
+      >
+        <TabsList>
+          <TabsTrigger value={ALL}>All</TabsTrigger>
+          {CATEGORIES.map((c) => (
+            <TabsTrigger key={c.id} value={c.id}>
+              {c.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+    </TabScroller>
   )
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,15 +1,23 @@
-import { Search } from "lucide-react"
+import { Menu, Search } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import { CommandPalette } from "@/components/command-palette"
 import { Link } from "@/components/link"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
 import { UserMenu } from "@/components/user-menu"
 import { SITE_CONFIG, NAV_ITEMS, ROUTES } from "@/lib/constants"
 
 export function Header() {
   const [paletteOpen, setPaletteOpen] = useState(false)
+  const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -26,6 +34,41 @@ export function Header() {
     <header className="bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 w-full border-b backdrop-blur">
       <div className="container flex h-14 items-center justify-between">
         <div className="flex items-center gap-2 md:gap-6">
+          <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+            <SheetTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="md:hidden"
+                  aria-label="Open navigation menu"
+                />
+              }
+            >
+              <Menu />
+            </SheetTrigger>
+            <SheetContent side="left" className="w-64">
+              <SheetHeader>
+                <SheetTitle>{SITE_CONFIG.name}</SheetTitle>
+              </SheetHeader>
+              <nav className="flex flex-col gap-1 px-2">
+                {NAV_ITEMS.map((item) => (
+                  <Button
+                    key={item.href}
+                    variant="ghost"
+                    size="sm"
+                    render={<Link href={item.href} />}
+                    nativeButton={false}
+                    onClick={() => setMobileNavOpen(false)}
+                    className="justify-start"
+                  >
+                    {item.label}
+                  </Button>
+                ))}
+              </nav>
+            </SheetContent>
+          </Sheet>
+
           <Link href={ROUTES.home} className="flex items-center gap-2">
             <span className="text-lg font-bold tracking-tight md:text-xl">
               {SITE_CONFIG.name}

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -105,6 +105,11 @@ const SECTIONS: Section[] = [
   { id: "advanced", name: "Advanced", icon: SettingsIcon },
 ]
 
+const SECTION_SELECT_ITEMS = SECTIONS.map((s) => ({
+  value: s.id,
+  label: s.name,
+}))
+
 const THEMES = [
   { value: "light" as const, label: "Light" },
   { value: "dark" as const, label: "Dark" },
@@ -144,7 +149,7 @@ export function SettingsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 md:max-h-[500px] md:max-w-[700px] lg:max-w-[800px]">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-hidden p-0 md:max-h-[500px] md:max-w-[700px] lg:max-w-[800px]">
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">
           Customize your Arsenyx experience.
@@ -177,15 +182,17 @@ export function SettingsDialog({
               </SidebarGroup>
             </SidebarContent>
           </Sidebar>
-          <main className="flex h-[480px] flex-1 flex-col overflow-hidden">
-            <header className="flex h-16 shrink-0 items-center gap-2">
-              <div className="flex items-center gap-2 px-4">
-                <Breadcrumb>
+          <main className="flex min-h-0 flex-1 flex-col overflow-hidden md:h-[480px]">
+            <header className="flex h-14 shrink-0 items-center gap-2 md:h-16">
+              {/* `pr-12` on mobile leaves room for the dialog's X close
+                  button which sits absolute top-right. */}
+              <div className="flex w-full items-center gap-2 pr-12 pl-4 md:w-auto md:pr-4">
+                <Breadcrumb className="hidden md:block">
                   <BreadcrumbList>
-                    <BreadcrumbItem className="hidden md:block">
+                    <BreadcrumbItem>
                       <BreadcrumbLink href="#">Settings</BreadcrumbLink>
                     </BreadcrumbItem>
-                    <BreadcrumbSeparator className="hidden md:block" />
+                    <BreadcrumbSeparator />
                     <BreadcrumbItem>
                       <BreadcrumbPage>
                         {SECTIONS.find((s) => s.id === active)?.name}
@@ -193,6 +200,26 @@ export function SettingsDialog({
                     </BreadcrumbItem>
                   </BreadcrumbList>
                 </Breadcrumb>
+                <Select
+                  items={SECTION_SELECT_ITEMS}
+                  value={active}
+                  onValueChange={(v) => {
+                    if (v) setActive(v as SectionId)
+                  }}
+                >
+                  <SelectTrigger className="w-full md:hidden">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {SECTIONS.map((s) => (
+                        <SelectItem key={s.id} value={s.id}>
+                          {s.name}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
               </div>
             </header>
             <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 pt-0">
@@ -681,8 +708,7 @@ function CreateApiKeyForm({ disabled }: { disabled: boolean }) {
   const user = session?.user as
     | { isAdmin?: boolean; isModerator?: boolean }
     | undefined
-  const canUsePrivileged =
-    user?.isAdmin === true || user?.isModerator === true
+  const canUsePrivileged = user?.isAdmin === true || user?.isModerator === true
 
   const [name, setName] = React.useState("")
   const [expiry, setExpiry] = React.useState<ExpiryValue>("never")
@@ -805,18 +831,18 @@ function CreateApiKeyForm({ disabled }: { disabled: boolean }) {
           Controls which endpoints this key can access.
         </FieldDescription>
         <div className="flex flex-col gap-1.5">
-          {SCOPE_OPTIONS.filter(
-            (s) => !s.privileged || canUsePrivileged,
-          ).map((s) => (
-            <ScopeCheckbox
-              key={s.value}
-              id={`scope-${s.value}`}
-              label={s.label}
-              description={s.description}
-              checked={scopes.has(s.value)}
-              onChange={() => toggleScope(s.value)}
-            />
-          ))}
+          {SCOPE_OPTIONS.filter((s) => !s.privileged || canUsePrivileged).map(
+            (s) => (
+              <ScopeCheckbox
+                key={s.value}
+                id={`scope-${s.value}`}
+                label={s.label}
+                description={s.description}
+                checked={scopes.has(s.value)}
+                onChange={() => toggleScope(s.value)}
+              />
+            ),
+          )}
         </div>
       </Field>
       {create.error ? (

--- a/apps/web/src/components/tab-scroller.tsx
+++ b/apps/web/src/components/tab-scroller.tsx
@@ -32,6 +32,10 @@ export function TabScroller({
   const [edge, setEdge] = useState<Edge>("none")
 
   useEffect(() => {
+    // `aria-selected="true"` is what Base UI's Tabs primitive sets on the
+    // active tab; `[data-state="active"]` covers the Radix-style convention
+    // in case the underlying primitive swaps. If neither attribute is
+    // present (custom children), the scroll-into-view is a no-op.
     const active = wrapperRef.current?.querySelector<HTMLElement>(
       '[aria-selected="true"], [data-state="active"]',
     )

--- a/apps/web/src/components/tab-scroller.tsx
+++ b/apps/web/src/components/tab-scroller.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState, type ReactNode } from "react"
+
+type Edge = "start" | "middle" | "end" | "none"
+
+const MASK_IMAGES: Record<Exclude<Edge, "none">, string> = {
+  start: "linear-gradient(to right, black calc(100% - 24px), transparent)",
+  end: "linear-gradient(to right, transparent, black 24px)",
+  middle:
+    "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)",
+}
+
+/**
+ * Horizontal scroll wrapper for tab lists that are wider than narrow
+ * viewports. Handles:
+ *
+ *  - edge-to-edge scroll under the page's 16px container padding (via `-mx-4`)
+ *  - 16px leading/trailing gap inside the scroll area (via an inner `w-max`
+ *    box), since `padding-right` on an `overflow-x` container isn't counted
+ *    in most browsers' scroll-end calculation
+ *  - scrolling the active tab into view when `activeKey` changes
+ *  - a fade mask on the edge that has hidden content (right when more lives
+ *    to the right, left when scrolled past the start, both in the middle)
+ */
+export function TabScroller({
+  activeKey,
+  children,
+}: {
+  activeKey: string
+  children: ReactNode
+}) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [edge, setEdge] = useState<Edge>("none")
+
+  useEffect(() => {
+    const active = wrapperRef.current?.querySelector<HTMLElement>(
+      '[aria-selected="true"], [data-state="active"]',
+    )
+    active?.scrollIntoView({
+      inline: "nearest",
+      block: "nearest",
+      behavior: "smooth",
+    })
+  }, [activeKey])
+
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el
+      const atStart = scrollLeft <= 1
+      const atEnd = scrollLeft + clientWidth >= scrollWidth - 1
+      if (atStart && atEnd) setEdge("none")
+      else if (atStart) setEdge("start")
+      else if (atEnd) setEdge("end")
+      else setEdge("middle")
+    }
+    update()
+    el.addEventListener("scroll", update, { passive: true })
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => {
+      el.removeEventListener("scroll", update)
+      ro.disconnect()
+    }
+  }, [])
+
+  return (
+    <div
+      ref={wrapperRef}
+      className="-mx-4 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      style={edge === "none" ? undefined : { maskImage: MASK_IMAGES[edge] }}
+    >
+      <div className="w-max px-4">{children}</div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -54,6 +54,7 @@ export const NAV_ITEMS = [
 export const FOOTER_LINKS = {
   build: [
     { label: "Browse Items", href: ROUTES.browse },
+    { label: "Browse Builds", href: ROUTES.builds },
     { label: "Import Build", href: ROUTES.import },
   ],
   community: [

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -259,9 +259,9 @@ function BuildViewerBodyInner({
       <div className="flex flex-col gap-4">
         <div
           data-screenshot-target
-          className="flex flex-col gap-4 lg:relative lg:block"
+          className="flex flex-col gap-4 xl:relative xl:block"
         >
-          <div className="bg-card w-full rounded-lg border lg:absolute lg:top-0 lg:bottom-0 lg:left-0 lg:w-[260px] lg:overflow-y-auto">
+          <div className="flex w-full flex-col xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:w-[260px]">
             <ItemSidebar
               item={item}
               category={category}
@@ -281,7 +281,7 @@ function BuildViewerBodyInner({
             />
           </div>
 
-          <div className="bg-card min-w-0 flex-1 overflow-hidden rounded-lg border p-2 sm:p-4 lg:ml-[calc(260px+1rem)]">
+          <div className="bg-card @container/loadout min-w-0 flex-1 overflow-hidden rounded-lg border p-2 sm:p-4 xl:ml-[calc(260px+1rem)]">
             <ModGrid
               item={item}
               category={category}

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -14,6 +14,15 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-04-24",
+    changes: [
+      {
+        type: "feat",
+        description: "Mobile compatibility pass across the app.",
+      },
+    ],
+  },
+  {
     date: "2026-04-19",
     changes: [
       {

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -527,8 +527,8 @@ function EditorShell() {
       />
 
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-4 lg:relative lg:block">
-          <div className="bg-card w-full rounded-lg border lg:absolute lg:top-0 lg:bottom-0 lg:left-0 lg:w-[260px] lg:overflow-y-auto">
+        <div className="flex flex-col gap-4 xl:relative xl:block">
+          <div className="flex w-full flex-col xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:w-[260px]">
             <ItemSidebar
               item={item}
               category={category}
@@ -550,7 +550,7 @@ function EditorShell() {
           </div>
 
           <div
-            className="bg-card min-w-0 flex-1 overflow-hidden rounded-lg border p-2 sm:p-4 lg:ml-[calc(260px+1rem)]"
+            className="bg-card @container/loadout min-w-0 flex-1 overflow-hidden rounded-lg border p-2 sm:p-4 xl:ml-[calc(260px+1rem)]"
             onClick={(e) => {
               if (!(e.target instanceof HTMLElement)) return
               if (!e.target.closest("[data-build-slot]")) {


### PR DESCRIPTION
## Summary

A broad mobile-responsiveness pass across the app — fixing overflow on the build page, adding primary mobile navigation, making the settings dialog usable on phones, and making category tabs scrollable.

## What changed

### Build page (`/builds/:slug` + `/create`)
- **Mod grid uses `@container/loadout`** instead of viewport breakpoints. `ModCard` is a fixed 184px element, so the grid now has two clean states: 2-col capped at `repeat(2, minmax(0, 184px))` (so empty outlines match the card) or 4-col at native 184px. No intermediate size — the 150px slot attempt caused overlap because the card wouldn't shrink with it.
- **Sidebar-beside breakpoint moved from `lg` (1024px) to `xl` (1280px)** — 1024px viewport doesn't actually leave room for sidebar + 4×184 cards without overlap.
- **Aura/Exilus + Arcane slots capped at their card widths** (`max-w-[184px]` / `max-w-[140px]`) so empty outlines no longer stretch to 50% of the row on tablets.
- **ItemSidebar owns its card styling now** — allows a bottom toggle button to sit flush below as a tab (bottom-only rounded corners, `border-t-0`). Stats panel + separator hide together when collapsed so the card doesn't leave dead space on phones.

### Navigation
- **Header hamburger Sheet on `<md`** — Browse and Builds links accessible without scrolling to the footer.
- **"Browse Builds" added to footer** alongside "Browse Items" and "Import Build".

### Category tabs
- New **`<TabScroller>`** wrapper: edge-to-edge horizontal scroll, directional fade mask based on scroll position (fade right when more to the right, left when scrolled past start, both in the middle), auto-scrolls the active tab into view.
- Used by both `CategoryTabs` (browse) and `BuildsCategoryTabs`.
- Inner `w-max px-4` spacer works around the browser quirk where `padding-right` on an `overflow-x` container isn't included in the scroll extent.

### Settings dialog
- Sidebar is hidden on `<md`; replaced with a **`<Select>` section picker** in the header so all sections are reachable on phones.
- **`max-h-[calc(100dvh-2rem)]`** constrains dialog height on mobile (fixes the dialog touching viewport edges and the jumpy repositioning when opening the Select).
- Header row padded `pr-12` on mobile so the Select doesn't overlap the dialog's X close button.

## Test plan

- [ ] Build viewer at 360px, 640px, 820px, 1024px, 1200px, 1280px, 1440px — no horizontal overflow at any width; sidebar stacks above grid below 1280px, beside grid at/above 1280px
- [ ] Empty and filled mod slots are the same visual width on tablet widths
- [ ] Aura/Exilus row on phones: slots don't stretch wider than a placed mod card
- [ ] Arcane row on phones: empty outline matches placed arcane width
- [ ] "Show stats" toggle on phones: appears flush below the sidebar card with only bottom corners rounded; collapsed state has no dead space above the toggle
- [ ] Header hamburger opens nav sheet on `<md`; clicking a link navigates and closes the sheet
- [ ] Browse & Builds pages: category tabs scroll horizontally on mobile; active tab scrolls into view on load / change; edge fade hints correctly as you scroll
- [ ] Settings on phones: can switch sections via the dropdown; dialog has top/bottom breathing room; Select doesn't overlap X; no jumpy repositioning when opening the Select
- [ ] Footer shows "Browse Builds" linking to `/builds`

Closes the "Mobile nav (hamburger + sheet)" item in [TODO.md](TODO.md).