### PR TITLE
mod search: match combined elements (closes #58)

### DIFF
--- a/apps/web/src/components/build-editor/mod-search-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-search-grid.tsx
@@ -18,6 +18,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  BASE_ELEMENTS,
+  DAMAGE_TYPE_COLORS,
+  ELEMENTAL_COMBINATIONS,
+} from "@/lib/stats/types"
 import { cn, isEditableTarget } from "@/lib/utils"
 
 import { ModCard } from "./mod-card"
@@ -57,15 +62,31 @@ const RARITY_ORDER: Record<Exclude<RarityFilter, "All">, number> = {
 
 const HTML_TAG_PATTERN = /<[^>]+>/g
 
+const UNCOMBINED_TAG_TO_COMBINED: ReadonlyArray<readonly [string, string[]]> =
+  Object.entries(DAMAGE_TYPE_COLORS).flatMap(([tag, element]) => {
+    if (!BASE_ELEMENTS.includes(element)) return []
+    const combos = BASE_ELEMENTS.filter((other) => other !== element)
+      .map((other) => ELEMENTAL_COMBINATIONS[`${element}+${other}`])
+      .filter((c): c is string => Boolean(c))
+    return [[tag, [...new Set(combos)]] as const]
+  })
+
 function getSearchable(mod: Mod): string {
   const name = mod.name.toLowerCase()
   const desc = mod.description?.toLowerCase() ?? ""
-  const stats =
-    mod.levelStats?.[mod.levelStats.length - 1]?.stats
-      ?.map((s) => s.replace(HTML_TAG_PATTERN, ""))
-      .join(" ")
-      .toLowerCase() ?? ""
-  return `${name} ${desc} ${stats}`
+  const rawStats = mod.levelStats?.[mod.levelStats.length - 1]?.stats ?? []
+  const combined = new Set<string>()
+  for (const stat of rawStats) {
+    for (const [tag, combos] of UNCOMBINED_TAG_TO_COMBINED) {
+      if (stat.includes(tag)) for (const c of combos) combined.add(c)
+    }
+  }
+  const stats = rawStats
+    .map((s) => s.replace(HTML_TAG_PATTERN, ""))
+    .join(" ")
+    .toLowerCase()
+  const combinedStr = combined.size > 0 ? ` ${[...combined].join(" ")}` : ""
+  return `${name} ${desc} ${stats}${combinedStr}`
 }
 
 function cap(s: string): string {


### PR DESCRIPTION
## Summary

Closes [#58](https://github.com/Reuzehagel/arsenyx/issues/58). In Warframe, typing a combined element like "radiation" should surface not just innate-radiation mods but also mods carrying either component element (heat or electricity), since those combine in-game. Today the picker only does a literal substring match, so component-element mods are invisible to combined-element queries.

## What changed

- Augmented `getSearchable()` in `apps/web/src/components/build-editor/mod-search-grid.tsx` to scan the last-level stats for `DT_*_COLOR` tags and append the names of every combined element each base element can form.
- The tag→combined-elements table is **derived** at module-init from the existing `DAMAGE_TYPE_COLORS` + `ELEMENTAL_COMBINATIONS` + `BASE_ELEMENTS` constants in `apps/web/src/lib/stats/types.ts`, so the canonical Warframe element knowledge stays in one place. Alias tags (`DT_HEAT_COLOR`, `DT_TOXIN_COLOR`, …) are picked up automatically.
- No UI change, no API change, no new data file.

## Test plan

- [x] `bun run build` (apps/web) passes
- [ ] Open a build editor, search "radiation" → expect Heat and Electricity mods alongside innate-radiation mods
- [ ] Search "blast" → expect Heat + Cold mods
- [ ] Search "gas" → expect Heat + Toxin mods
- [ ] Sanity: searching "heat" still only returns Heat mods (no reverse leak from combined → component)
- [ ] Sanity: searching "magnetic" still returns innate-magnetic mods directly