### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Something broken on arsenyx.com
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug.
+      placeholder: |
+        - What I did:
+        - What I expected:
+        - What actually happened:
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: input
+    id: build
+    attributes:
+      label: Build ID or URL
+      description: If the bug is tied to a specific build, paste the link or ID.
+    validations:
+      required: false
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot
+      description: Drag and drop an image, or paste a URL.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem you're trying to solve
+      description: What's the underlying need? Focus on the problem, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Optional. If you have an idea for how to solve it, describe it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/game_data.yml
+++ b/.github/ISSUE_TEMPLATE/game_data.yml
@@ -1,0 +1,47 @@
+name: Game data correction
+description: Wrong stat, missing item, mislabeled mod or arcane
+labels: ["data"]
+body:
+  - type: dropdown
+    id: item-type
+    attributes:
+      label: Item type
+      options:
+        - Warframe
+        - Primary
+        - Secondary
+        - Melee
+        - Companion
+        - Archwing
+        - Mod
+        - Arcane
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: item-name
+    attributes:
+      label: Item name
+      placeholder: e.g. Braton Prime
+    validations:
+      required: true
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: What's wrong?
+      options:
+        - Wrong stat
+        - Missing item
+        - Wrong icon
+        - Wrong polarity
+        - Wrong mastery requirement
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Correct value + source
+      description: What should it be, and where can we verify? (Wiki link, in-game screenshot, etc.)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/ui_ux.yml
+++ b/.github/ISSUE_TEMPLATE/ui_ux.yml
@@ -1,0 +1,34 @@
+name: UI/UX feedback
+description: Something looks off or feels hard to use
+labels: ["ui"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Page or component
+      placeholder: e.g. Build page header, settings tab, mobile nav
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: What feels off?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot
+      description: Strongly encouraged — drag and drop an image.
+    validations:
+      required: false
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      options:
+        - Desktop
+        - Tablet
+        - Mobile
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Adds four issue form templates under `.github/ISSUE_TEMPLATE/`: bug report, feature request, game data correction, UI/UX feedback
- Each template auto-applies a label (`bug`, `enhancement`, `data`, `ui`) for triage
- Disables blank issues via `config.yml` so reports follow a uniform structure

## Why
The repo had no issue templates — anyone filing a GitHub issue got a blank textarea, which produced inconsistent reports and missing context.

## Test plan
- [ ] Visit `/issues/new/choose` after merge — all four templates appear, blank-issue option is gone
- [ ] Open each template, confirm fields render with correct required/optional state and dropdown options