### PR TITLE
chore(issue-templates): make steps to reproduce optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
         2.
         3.
     validations:
-      required: true
+      required: false
   - type: input
     id: build
     attributes:


### PR DESCRIPTION
## Summary
- Drops the required validation on the bug report's "Steps to reproduce" field

## Why
Most reported bugs are trivially reproducible from context, and a required field is friction that discourages reports.

## Test plan
- [ ] Open the bug report template after merge — steps field is present but no longer required