### PR TITLE
fix(overframe import): companion/necramech slots + pinned forma path

### DIFF
--- a/apps/api/src/lib/overframe/import.ts
+++ b/apps/api/src/lib/overframe/import.ts
@@ -175,6 +175,10 @@ export async function scrapeOverframeBuild(
       const decoded = decodeOverframeBuildString(extracted.buildString)
       slots = decoded.slots.map((s) => {
         // Map (slotType, slotIndex) back to slot_id for a uniform shape.
+        // TODO: warframe-shaped only — companion/necramech buildstring fallbacks
+        // will emit wrong slot_ids here. Mirror of the decoder in
+        // apps/web/src/lib/overframe/index.ts `interpretSlot`; share once a
+        // second case forces the abstraction. Related: #57.
         const slot_id =
           s.slotType === "normal"
             ? 8 - s.slotIndex

--- a/apps/api/src/lib/overframe/next-data.ts
+++ b/apps/api/src/lib/overframe/next-data.ts
@@ -107,41 +107,15 @@ function findFirstArray(
   return walk(obj, "")
 }
 
-function findFirstNumber(
-  obj: unknown,
-  keyNames: string[],
-): { keyPath: string; value: number } | null {
-  const seen = new Set<unknown>()
-  const keySet = new Set(keyNames)
-
-  function walk(
-    value: unknown,
-    path: string,
-  ): { keyPath: string; value: number } | null {
-    if (value && typeof value === "object") {
-      if (seen.has(value)) return null
-      seen.add(value)
-
-      if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          const res = walk(value[i], `${path}[${i}]`)
-          if (res) return res
-        }
-        return null
-      }
-
-      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-        if (keySet.has(k) && typeof v === "number" && Number.isFinite(v)) {
-          return { keyPath: path ? `${path}.${k}` : k, value: v }
-        }
-        const res = walk(v, path ? `${path}.${k}` : k)
-        if (res) return res
-      }
-    }
-    return null
+function readNumberAtPath(obj: unknown, path: string[]): number | undefined {
+  let current: unknown = obj
+  for (const segment of path) {
+    if (!current || typeof current !== "object") return undefined
+    current = (current as Record<string, unknown>)[segment]
   }
-
-  return walk(obj, "")
+  return typeof current === "number" && Number.isFinite(current)
+    ? current
+    : undefined
 }
 
 function readStringAtPath(obj: unknown, path: string[]): string | undefined {
@@ -287,15 +261,11 @@ export function extractOverframeDataFromHtml(
   })
   if (itemNameRes) extractedKeys.push(itemNameRes.keyPath)
 
-  const formaRes = findFirstNumber(nextData, [
-    "forma",
-    "formaCount",
-    "forma_count",
-    "formas",
-    "numForma",
-    "num_forma",
-  ])
-  if (formaRes) extractedKeys.push(formaRes.keyPath)
+  // Pinned path — Overframe embeds many `formas` numbers in __NEXT_DATA__
+  // (sibling builds, related builds), so a tree walk picks the wrong one.
+  const formaPath = ["props", "pageProps", "data", "formas"]
+  const formaCount = readNumberAtPath(nextData, formaPath)
+  if (formaCount !== undefined) extractedKeys.push(formaPath.join("."))
 
   const pageTitle = readStringAtPath(nextData, [
     "props",
@@ -332,7 +302,7 @@ export function extractOverframeDataFromHtml(
     buildString: buildStringRes?.value,
     slots: slotsRes?.value,
     itemName: itemNameRes?.value,
-    formaCount: formaRes?.value,
+    formaCount,
     pageTitle,
     pageDescription,
     guideDescription,

--- a/apps/web/src/lib/overframe/index.ts
+++ b/apps/web/src/lib/overframe/index.ts
@@ -7,6 +7,10 @@ import {
 import type { Arcane, Mod, Polarity } from "@arsenyx/shared/warframe/types"
 
 import type { SlotId } from "@/components/build-editor"
+import {
+  getNormalSlotCount,
+  hasExilusSlot,
+} from "@/components/build-editor/layout"
 import type { SavedBuildData } from "@/lib/build-query"
 import type { HelminthAbility } from "@/lib/helminth-query"
 import type {
@@ -134,6 +138,15 @@ function interpretSlot(
   slot_id: number,
   category: BrowseCategory,
 ): { kind: "mod"; id: SlotId } | { kind: "arcane"; index: number } | null {
+  // Highest slot_id is leftmost (normal-0), matching the warframe convention
+  // where slot_id 8 → normal-0; we just stretch the inversion to N.
+  if (!isWarframeLike(category) && !hasExilusSlot(category)) {
+    const normalCount = getNormalSlotCount(category)
+    if (slot_id >= 1 && slot_id <= normalCount) {
+      return { kind: "mod", id: `normal-${normalCount - slot_id}` as SlotId }
+    }
+    return null
+  }
   if (slot_id >= 1 && slot_id <= 8) {
     return { kind: "mod", id: `normal-${8 - slot_id}` as SlotId }
   }

--- a/bun.lock
+++ b/bun.lock
@@ -790,7 +790,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -866,7 +866,7 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
-    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1654,6 +1654,8 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "arsenyx-screenshot/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
     "c12/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "cssstudio/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1691,6 +1693,8 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "arsenyx-screenshot/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "c12/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 


### PR DESCRIPTION
## Summary

- Fix Overframe importer for companions and necramechs: slot_ids 9 and 10 were being routed to exilus/arcane, but those categories have no exilus or arcane slots — Tek Enhance was silently dropped and Cat's Eye produced `arcane_not_found`. Now any category without aura/exilus/arcanes maps slot_ids 1..N onto `normal-${N - slot_id}` using `getNormalSlotCount` from `apps/web/src/components/build-editor/layout.ts`, preserving the warframe convention that the highest slot_id is leftmost.
- Pin the `formas` lookup in `__NEXT_DATA__` to `props.pageProps.data.formas`. The previous `findFirstNumber` walker traversed the whole tree and could pick a `formas` value off a sibling build (`itemBuilds[]`) or a related build (`authorBuilds[]`); verified the canonical path on 7 sample builds.

Closes #57.

## Test plan

- [ ] Import https://overframe.gg/build/771341/ — Cat's Eye and Tek Enhance both placed, no warnings, forma count matches OF.
- [ ] Spot-check a warframe import (e.g. Saryn) and a weapon import to confirm the existing aura/exilus/arcane paths still work.
- [ ] Spot-check a necramech build if one is handy — same fix applies.