### PR TITLE
mod search: alias common stat shorthand (cc, cd, sc, sd, …)

### DIFF
--- a/apps/web/src/components/build-editor/mod-search-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-search-grid.tsx
@@ -71,6 +71,22 @@ const UNCOMBINED_TAG_TO_COMBINED: ReadonlyArray<readonly [string, string[]]> =
     return [[tag, [...new Set(combos)]] as const]
   })
 
+// Community shorthand for common attributes — "cc" surfaces critical chance
+// mods, etc. Phrases match the lowercased plain-text stat lines, so the
+// canonical form (e.g. "critical chance") is already searchable on its own;
+// these aliases only add what isn't a substring of the phrase itself.
+const STAT_ALIASES: ReadonlyArray<readonly [string, string[]]> = [
+  ["critical chance", ["cc"]],
+  ["critical damage", ["cd"]],
+  ["status chance", ["sc"]],
+  ["status duration", ["sd"]],
+  ["multishot", ["ms"]],
+  ["punch through", ["pt"]],
+  ["fire rate", ["fr"]],
+  ["reload speed", ["rs"]],
+  ["health", ["hp"]],
+]
+
 function getSearchable(mod: Mod): string {
   const name = mod.name.toLowerCase()
   const desc = mod.description?.toLowerCase() ?? ""
@@ -85,8 +101,13 @@ function getSearchable(mod: Mod): string {
     .map((s) => s.replace(HTML_TAG_PATTERN, ""))
     .join(" ")
     .toLowerCase()
+  const aliases = new Set<string>()
+  for (const [phrase, shorts] of STAT_ALIASES) {
+    if (stats.includes(phrase)) for (const s of shorts) aliases.add(s)
+  }
   const combinedStr = combined.size > 0 ? ` ${[...combined].join(" ")}` : ""
-  return `${name} ${desc} ${stats}${combinedStr}`
+  const aliasStr = aliases.size > 0 ? ` ${[...aliases].join(" ")}` : ""
+  return `${name} ${desc} ${stats}${combinedStr}${aliasStr}`
 }
 
 function cap(s: string): string {


### PR DESCRIPTION
## Summary
Typing community shorthand in the mod search now surfaces mods carrying the matching attribute:

- `cc` → Critical Chance
- `cd` → Critical Damage
- `sc` → Status Chance
- `sd` → Status Duration
- `ms` → Multishot
- `pt` → Punch Through
- `fr` → Fire Rate
- `rs` → Reload Speed
- `hp` → Health

Same approach as the combined-element pass from #60: detect the canonical phrase in the cleaned last-level stat text, append the alias tokens to the searchable string. Aliases are only added where the shorthand isn't already a substring of the phrase itself (so `str` already matches `strength`, `dur` matches `duration`, `eff` matches `efficiency` — no entries needed).

Follow-up to #58.

## Test plan
- [ ] Type `cc` in mod search — Point Strike, True Steel, etc. surface
- [ ] Type `cd` — Vital Sense, Organ Shatter surface
- [ ] Type `sd` — Augur Seeker surfaces
- [ ] Type `ms` — Split Chamber, Barrel Diffusion surface
- [ ] Canonical names (`critical chance`, `multishot`) still work