### PR TITLE
fix(overframe): correct polarity code map (5=penjaga, 9=zenurik)

### DIFF
--- a/apps/api/src/lib/overframe/polarity.ts
+++ b/apps/api/src/lib/overframe/polarity.ts
@@ -1,27 +1,25 @@
 import type { Polarity } from "@arsenyx/shared/warframe/types"
 
-// Overframe numeric codes observed in pageProps.data.slots[].polarity
-// Based on empirical testing with a build that applied each polarity.
+// Overframe numeric codes observed in pageProps.data.slots[].polarity.
+// Verified empirically by cross-referencing slots where polarity_match === 2
+// (slot polarity == mod's known polarity) across 7 sample builds.
 //
 // 0 = none/unchanged
 // 1 = madurai
 // 2 = vazarin
 // 3 = naramon
-// 4 = zenurik
-// 5 = unairu
-// 7 = penjaga
-// 8 = umbra
-// 9 = any ("Any" / Universal / Omni Forma)
+// 5 = penjaga
+// 9 = zenurik
+//
+// Codes 4, 6, 7, 8 are not yet observed; unairu / umbra / any mappings
+// remain unknown. Add them once a build with a confirmed match surfaces.
 const OVERFRAME_POLARITY_CODE_MAP: Record<number, Polarity | undefined> = {
   0: undefined,
   1: "madurai",
   2: "vazarin",
   3: "naramon",
-  4: "zenurik",
-  5: "unairu",
-  7: "penjaga",
-  8: "umbra",
-  9: "any",
+  5: "penjaga",
+  9: "zenurik",
 }
 
 export function mapOverframePolarityCode(code: number | null | undefined): {


### PR DESCRIPTION
## Summary

The Overframe importer's polarity-code map had wrong values for codes 4–9. They were guesses; the wiki order doesn't match what Overframe actually emits. Verified empirically across 7 sample builds by cross-referencing slots where `polarity_match === 2` (slot polarity equals the mod's known polarity from WFCD data):

| code | was        | actual    | hits |
| ---- | ---------- | --------- | ---- |
| 1    | madurai    | madurai   | 19   |
| 2    | vazarin    | vazarin   | 8    |
| 3    | naramon    | naramon   | 14   |
| 5    | unairu     | **penjaga**   | 4    |
| 9    | any        | **zenurik**   | 1    |

Codes 4, 6, 7, 8 don't appear in any of the sample builds, so the prior guesses (zenurik / penjaga / umbra / —) couldn't be verified and have been dropped. They'll fall through to `undefined` until a confirming build surfaces, which is safer than a wrong mapping silently corrupting forma counts.

## Effect on bug reports

For [Adarza Kavat build 771341](https://overframe.gg/build/771341/) (the import on issue #57), Cat's Eye is a penjaga mod that sits in an innate-penjaga slot (matches WFCD `polarities[0]`). With code 5 incorrectly meaning unairu, the importer counted that as a forma; with the correction it doesn't. Forma count comes down from 6 → 5 (still 1 above OF's reported 4 — likely a separate WFCD data gap on companion innate polarities; not addressed here).

## Test plan

- [ ] Re-import https://overframe.gg/build/771341/ and confirm the editor's forma badge drops to 5 (or 4 if WFCD picks up the extra innate polarities later).
- [ ] Spot-check a build with a penjaga or zenurik mod to confirm the slot polarity lines up with the mod's polarity in the editor.