### PR TITLE
fix(import preview): use calculateFormaCount to dedupe vs innate

### DIFF
--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -3,6 +3,13 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Check, Copy, UploadCloud } from "lucide-react"
 import { useMemo, useState } from "react"
 
+import {
+  calculateFormaCount,
+  getAuraPolarities,
+  getAuraSlotCount,
+  getNormalSlotCount,
+  toPolarity,
+} from "@/components/build-editor"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Button } from "@/components/ui/button"
@@ -237,7 +244,28 @@ function ImportPage() {
                       </dd>
                       <dt className="text-muted-foreground">Forma</dt>
                       <dd>
-                        {Object.keys(applied.data.formaPolarities ?? {}).length}
+                        {detailItem
+                          ? calculateFormaCount({
+                              auraInnates: getAuraPolarities(
+                                detailItem,
+                                getAuraSlotCount(
+                                  matchedItem.category,
+                                  detailItem,
+                                ),
+                              ),
+                              normalInnates: Array.from(
+                                {
+                                  length: getNormalSlotCount(
+                                    matchedItem.category,
+                                  ),
+                                },
+                                (_, i) => toPolarity(detailItem.polarities?.[i]),
+                              ),
+                              formaPolarities:
+                                applied.data.formaPolarities ?? {},
+                            })
+                          : Object.keys(applied.data.formaPolarities ?? {})
+                              .length}
                         {result.formaCount != null &&
                           ` (OF reports ${result.formaCount})`}
                       </dd>


### PR DESCRIPTION
## Summary

The Overframe import preview showed `Object.keys(formaPolarities).length` as its forma count. The editor uses `calculateFormaCount`, which (a) cancels innate polarities against effective ones via `groupForma`, and (b) collapses same-polarity additions onto the same forma. The two diverge any time the build has innate polarities or repeats a polarity across normal slots.

For [Adarza Kavat build 771341](https://overframe.gg/build/771341/) (the import on issue #57): 5 `formaPolarities` entries → 4 actual forma after grouping. The editor already showed 4; only the preview was wrong. After this fix the preview matches.

Wires the preview to the same `calculateFormaCount` call the editor uses, sourcing innates from the matched detail item exactly the way `routes/builds.$slug.tsx` does.

## Test plan

- [x] Re-import https://overframe.gg/build/771341/ — preview shows `Forma 4 (OF reports 4)`.
- [x] Import a warframe build with innate polarities and confirm the preview no longer over-counts forma when a polarity matches innate.