### PR TITLE
Popover sidebar on intermediate widths + wiki embed mode

### DIFF
--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -6,7 +6,7 @@ export {
   type PlacedArcane,
 } from "./use-arcane-slots"
 export { GuideEditor } from "./guide-editor"
-export { ItemSidebar } from "./item-sidebar"
+export { ItemSidebar, ItemSidebarPopover } from "./item-sidebar"
 export {
   calculateCapacity,
   calculateFormaCount,

--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -7,7 +7,15 @@ import {
 } from "@arsenyx/shared/warframe/types"
 import { isZawStrike } from "@arsenyx/shared/warframe/zaw-data"
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { ChevronDown, ChevronLeft, Plus, Undo2, X, Zap } from "lucide-react"
+import {
+  ChevronDown,
+  ChevronLeft,
+  Plus,
+  SlidersHorizontal,
+  Undo2,
+  X,
+  Zap,
+} from "lucide-react"
 import { Suspense, useMemo, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -98,6 +106,13 @@ export interface ItemSidebarProps {
   placedMods: Partial<Record<SlotId, PlacedMod>>
   placedArcanes: (PlacedArcane | null)[]
   readOnly?: boolean
+  /**
+   * When true, render without the outer card chrome and without the mobile
+   * "Show stats" toggle. Used when ItemSidebar is hosted inside a popover
+   * (which provides its own surface and is already an explicit "show stats"
+   * action).
+   */
+  bare?: boolean
 }
 
 export function ItemSidebar({
@@ -118,6 +133,7 @@ export function ItemSidebar({
   placedMods,
   placedArcanes,
   readOnly = false,
+  bare = false,
 }: ItemSidebarProps) {
   const isZawItem = category === "melee" && isZawStrike(item.name)
   // Distinguish archwing *suits* (have health) from arch-guns / arch-melee
@@ -232,7 +248,14 @@ export function ItemSidebar({
 
   return (
     <>
-      <div className="bg-card flex h-full flex-col rounded-lg border xl:overflow-y-auto">
+      <div
+        className={cn(
+          "flex flex-col",
+          bare
+            ? "min-w-0"
+            : "bg-card h-full rounded-lg border xl:overflow-y-auto",
+        )}
+      >
         {isWarframe && abilities.length > 0 && (
           <>
             <div className="flex justify-around p-3">
@@ -334,20 +357,58 @@ export function ItemSidebar({
           </div>
         </div>
       </div>
-      <button
-        type="button"
-        onClick={() => setStatsExpanded((v) => !v)}
-        className="bg-card text-muted-foreground hover:bg-accent/40 hover:text-foreground mx-auto flex items-center gap-1.5 rounded-t-none rounded-b-md border border-t-0 px-3 py-1 text-xs transition-colors sm:hidden"
-      >
-        <span>{statsExpanded ? "Hide stats" : "Show stats"}</span>
-        <ChevronDown
-          className={cn(
-            "size-3.5 transition-transform",
-            statsExpanded && "rotate-180",
-          )}
-        />
-      </button>
+      {!bare && (
+        <button
+          type="button"
+          onClick={() => setStatsExpanded((v) => !v)}
+          className="bg-card text-muted-foreground hover:bg-accent/40 hover:text-foreground mx-auto flex items-center gap-1.5 rounded-t-none rounded-b-md border border-t-0 px-3 py-1 text-xs transition-colors sm:hidden"
+        >
+          <span>{statsExpanded ? "Hide stats" : "Show stats"}</span>
+          <ChevronDown
+            className={cn(
+              "size-3.5 transition-transform",
+              statsExpanded && "rotate-180",
+            )}
+          />
+        </button>
+      )}
     </>
+  )
+}
+
+/**
+ * Trigger + popover wrapper used at intermediate widths (sm to xl) where the
+ * stacked sidebar would leave awkward horizontal whitespace. Renders a small
+ * "Stats" button that opens the full ItemSidebar contents in a popover.
+ */
+export function ItemSidebarPopover({
+  className,
+  ...sidebarProps
+}: ItemSidebarProps & { className?: string }) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            className={cn(
+              "text-muted-foreground hover:bg-accent/40 hover:text-foreground inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors",
+              className,
+            )}
+          >
+            <SlidersHorizontal className="size-3.5" />
+            <span>Stats</span>
+          </button>
+        }
+      />
+      <PopoverContent
+        side="bottom"
+        align="start"
+        className="max-h-[85vh] w-[280px] overflow-y-auto p-3"
+      >
+        <ItemSidebar {...sidebarProps} bare />
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/apps/web/src/components/build-editor/mod-card.tsx
+++ b/apps/web/src/components/build-editor/mod-card.tsx
@@ -365,9 +365,13 @@ export function ModCard({
       onMouseEnter={() => {
         const r = compactRef.current?.getBoundingClientRect()
         if (r) {
+          // Use rect's own width/height (not DISPLAY_SIZE constants) so the
+          // center is correct under any ancestor `transform: scale()` —
+          // getBoundingClientRect already returns visual/transformed coords,
+          // so adding the unscaled width would overshoot.
           hoverCenter.current = {
-            x: r.left + DISPLAY_SIZE.compact.width / 2,
-            y: r.top + DISPLAY_SIZE.compact.height / 2,
+            x: r.left + r.width / 2,
+            y: r.top + r.height / 2,
           }
         }
         setIsHovered(true)

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -1,6 +1,7 @@
 import { isRivenMod } from "@arsenyx/shared/warframe/rivens"
 import type { Arcane, Polarity } from "@arsenyx/shared/warframe/types"
 
+import { cn } from "@/lib/utils"
 import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 
 import { ArcaneSlot } from "./arcane-slot"
@@ -76,6 +77,7 @@ export function ModGrid({
   onEditRiven,
   arcaneRow,
   readOnly = false,
+  embed = false,
 }: {
   item: DetailItem
   category: BrowseCategory
@@ -85,6 +87,9 @@ export function ModGrid({
   onEditRiven?: (id: SlotId) => void
   arcaneRow?: React.ReactNode
   readOnly?: boolean
+  /** When true, force the dense single-row mod layout (4 mods per row,
+   *  ignoring container queries) for the wiki embed. */
+  embed?: boolean
 }) {
   const auraSlotCount = getAuraSlotCount(category, item)
   const showExilus = hasExilusSlot(category)
@@ -127,9 +132,19 @@ export function ModGrid({
   }
 
   return (
-    <div className="flex flex-col gap-6 @min-[816px]/loadout:gap-4">
+    <div
+      className={cn(
+        "flex flex-col gap-6 @min-[816px]/loadout:gap-4",
+        embed && "gap-4",
+      )}
+    >
       {(auraSlotCount > 0 || showExilus) && (
-        <div className="flex w-full justify-center gap-2 @min-[816px]/loadout:gap-4">
+        <div
+          className={cn(
+            "flex w-full justify-center gap-2 @min-[816px]/loadout:gap-4",
+            embed && "gap-4",
+          )}
+        >
           {auraSlotCount > 0 && (
             <ModSlot
               kind="aura"
@@ -154,7 +169,12 @@ export function ModGrid({
       )}
 
       {isCompanion ? (
-        <div className="grid grid-cols-[repeat(2,minmax(0,184px))] justify-center gap-x-2 gap-y-6 @min-[1016px]/loadout:mx-auto @min-[1016px]/loadout:w-fit @min-[1016px]/loadout:grid-cols-5 @min-[1016px]/loadout:gap-4">
+        <div
+          className={cn(
+            "grid grid-cols-[repeat(2,minmax(0,184px))] justify-center gap-x-2 gap-y-6 @min-[1016px]/loadout:mx-auto @min-[1016px]/loadout:w-fit @min-[1016px]/loadout:grid-cols-5 @min-[1016px]/loadout:gap-4",
+            embed && "mx-auto w-fit grid-cols-5 gap-4",
+          )}
+        >
           {Array.from({ length: normalSlotCount }, (_, i) => {
             const id: SlotId = `normal-${i}`
             return (
@@ -166,7 +186,10 @@ export function ModGrid({
         normalRows.map((row, rowIdx) => (
           <div
             key={rowIdx}
-            className="grid grid-cols-[repeat(2,minmax(0,184px))] justify-center gap-x-2 gap-y-6 @min-[816px]/loadout:flex @min-[816px]/loadout:gap-4"
+            className={cn(
+              "grid grid-cols-[repeat(2,minmax(0,184px))] justify-center gap-x-2 gap-y-6 @min-[816px]/loadout:flex @min-[816px]/loadout:gap-4",
+              embed && "flex justify-center gap-4",
+            )}
           >
             {row.map((i) => {
               const id: SlotId = `normal-${i}`

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -33,6 +33,7 @@ import {
   getNormalSlotCount,
   hasExilusSlot,
   ItemSidebar,
+  ItemSidebarPopover,
   ModGrid,
   toPolarity,
   useArcaneSlots,
@@ -261,7 +262,7 @@ function BuildViewerBodyInner({
           data-screenshot-target
           className="flex flex-col gap-4 xl:relative xl:block"
         >
-          <div className="flex w-full flex-col xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:w-[260px]">
+          <div className="flex w-full flex-col sm:hidden xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:flex xl:w-[260px]">
             <ItemSidebar
               item={item}
               category={category}
@@ -281,7 +282,25 @@ function BuildViewerBodyInner({
             />
           </div>
 
-          <div className="bg-card @container/loadout min-w-0 flex-1 overflow-hidden rounded-lg border p-2 sm:p-4 xl:ml-[calc(260px+1rem)]">
+          <div className="bg-card @container/loadout flex min-w-0 flex-1 flex-col gap-3 overflow-hidden rounded-lg border p-2 sm:p-4 xl:ml-[calc(260px+1rem)]">
+            <ItemSidebarPopover
+              className="hidden self-start sm:inline-flex xl:hidden"
+              item={item}
+              category={category}
+              capacityUsed={capacity.used}
+              capacityMax={capacity.max}
+              hasReactor={hasReactor}
+              onToggleReactor={() => {}}
+              shards={shards}
+              onSetShard={() => {}}
+              helminth={helminth}
+              onSetHelminth={() => {}}
+              zawComponents={zawComponents}
+              lichBonusElement={lichBonusElement}
+              placedMods={slots.placed}
+              placedArcanes={arcanes.placed}
+              readOnly
+            />
             <ModGrid
               item={item}
               category={category}

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -17,7 +17,7 @@ import {
   Pencil,
   Trash2,
 } from "lucide-react"
-import { Suspense, useMemo, useState } from "react"
+import { Suspense, useEffect, useMemo, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
@@ -79,7 +79,43 @@ import {
   type BrowseCategory,
 } from "@/lib/warframe"
 
+interface BuildSearch {
+  /** When true, render a chrome-less view suitable for embedding (e.g. the
+   *  Profit-Taker wiki). Hides the site header/footer, viewer header, and
+   *  guide block. */
+  embed?: boolean
+  /** Visual scale factor applied to the embed. Defaults to 0.65 — sized to
+   *  fit comfortably in a ~700px iframe (the PT wiki's Nuxt embed width). */
+  scale?: number
+  /** Logical layout width (px) the embed renders at internally before
+   *  scaling. Kept ≥ 1024 by default so the dense single-row mod layout
+   *  triggers; the visible width is `layout * scale`. */
+  layout?: number
+}
+
 export const Route = createFileRoute("/builds/$slug")({
+  validateSearch: (s: Record<string, unknown>): BuildSearch => {
+    const embed = s.embed === true || s.embed === "1" || s.embed === "true"
+    const num = (v: unknown) => {
+      const n = typeof v === "string" ? Number(v) : v
+      return typeof n === "number" && Number.isFinite(n) ? n : undefined
+    }
+    const rawScale = num(s.scale)
+    const rawLayout = num(s.layout)
+    const scale =
+      rawScale !== undefined
+        ? Math.min(1.5, Math.max(0.3, rawScale))
+        : undefined
+    const layout =
+      rawLayout !== undefined
+        ? Math.min(2000, Math.max(640, Math.round(rawLayout)))
+        : undefined
+    return {
+      ...(embed && { embed }),
+      ...(scale !== undefined && { scale }),
+      ...(layout !== undefined && { layout }),
+    }
+  },
   loader: ({ context, params }) =>
     context.queryClient.ensureQueryData(buildQuery(params.slug)),
   component: BuildPage,
@@ -87,6 +123,20 @@ export const Route = createFileRoute("/builds/$slug")({
 })
 
 function BuildPage() {
+  const { embed, scale, layout } = Route.useSearch()
+
+  if (embed) {
+    return (
+      <EmbedShell scale={scale ?? 0.65} layoutWidth={layout ?? 1140}>
+        <Suspense
+          fallback={<p className="text-muted-foreground">Loading build…</p>}
+        >
+          <BuildViewer embed />
+        </Suspense>
+      </EmbedShell>
+    )
+  }
+
   return (
     <div className="relative flex min-h-screen flex-col">
       <Header />
@@ -104,7 +154,61 @@ function BuildPage() {
   )
 }
 
-function BuildViewer() {
+/**
+ * Embed wrapper that forces the build view to lay out at a fixed logical
+ * width (so the dense single-row mod layout triggers via container queries)
+ * then visually scales the result down to fit a smaller iframe. A
+ * ResizeObserver mirrors the inner element's height back to the wrapper so
+ * the iframe content doesn't have a giant whitespace gutter.
+ */
+function EmbedShell({
+  scale,
+  layoutWidth,
+  children,
+}: {
+  scale: number
+  layoutWidth: number
+  children: React.ReactNode
+}) {
+  const innerRef = useRef<HTMLDivElement | null>(null)
+  const [innerHeight, setInnerHeight] = useState<number | null>(null)
+
+  useEffect(() => {
+    const node = innerRef.current
+    if (!node) return
+    const ro = new ResizeObserver((entries) => {
+      const h = entries[0]?.contentRect.height
+      if (typeof h !== "number") return
+      const rounded = Math.ceil(h)
+      setInnerHeight((prev) => (prev === rounded ? prev : rounded))
+    })
+    ro.observe(node)
+    return () => ro.disconnect()
+  }, [])
+
+  return (
+    <div
+      className="bg-background overflow-hidden"
+      style={{
+        width: layoutWidth * scale,
+        height: innerHeight !== null ? innerHeight * scale : undefined,
+      }}
+    >
+      <div
+        ref={innerRef}
+        style={{
+          width: layoutWidth,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function BuildViewer({ embed = false }: { embed?: boolean }) {
   const { slug } = Route.useParams()
   const { data: build } = useSuspenseQuery(buildQuery(slug))
 
@@ -116,7 +220,12 @@ function BuildViewer() {
 
   return (
     <Suspense fallback={<p className="text-muted-foreground">Loading item…</p>}>
-      <BuildViewerBody build={build} category={category} itemSlug={itemSlug} />
+      <BuildViewerBody
+        build={build}
+        category={category}
+        itemSlug={itemSlug}
+        embed={embed}
+      />
     </Suspense>
   )
 }
@@ -125,6 +234,7 @@ function BuildViewerBody(props: {
   build: BuildDetail
   category: BrowseCategory
   itemSlug: string
+  embed: boolean
 }) {
   // New-format builds (SavedBuildData) carry full mod/arcane objects inline in
   // buildData, so we skip the ~1.35MB mods-all.json + arcanes-all.json fetches.
@@ -139,6 +249,7 @@ function BuildViewerBodyWithCatalog(props: {
   build: BuildDetail
   category: BrowseCategory
   itemSlug: string
+  embed: boolean
 }) {
   const { data: allArcanes } = useSuspenseQuery(arcanesQuery)
   const { data: allMods } = useSuspenseQuery(modsQuery)
@@ -157,12 +268,14 @@ function BuildViewerBodyInner({
   itemSlug,
   allMods,
   allArcanes,
+  embed,
 }: {
   build: BuildDetail
   category: BrowseCategory
   itemSlug: string
   allMods: Mod[]
   allArcanes: Arcane[]
+  embed: boolean
 }) {
   const { data: item } = useSuspenseQuery(itemQuery(category, itemSlug))
 
@@ -245,62 +358,69 @@ function BuildViewerBodyInner({
 
   const author = authorName(build.user)
 
+  const sidebarProps = {
+    item,
+    category,
+    capacityUsed: capacity.used,
+    capacityMax: capacity.max,
+    hasReactor,
+    onToggleReactor: () => {},
+    shards,
+    onSetShard: () => {},
+    helminth,
+    onSetHelminth: () => {},
+    zawComponents,
+    lichBonusElement,
+    placedMods: slots.placed,
+    placedArcanes: arcanes.placed,
+    readOnly: true as const,
+  }
+
   return (
     <>
-      <ViewerHeader
-        build={build}
-        categoryLabel={categoryLabel}
-        author={author}
-        totalEndoCost={totalEndoCost}
-        formaCount={formaCount}
-        category={category}
-        itemSlug={itemSlug}
-      />
+      {!embed && (
+        <ViewerHeader
+          build={build}
+          categoryLabel={categoryLabel}
+          author={author}
+          totalEndoCost={totalEndoCost}
+          formaCount={formaCount}
+          category={category}
+          itemSlug={itemSlug}
+        />
+      )}
 
       <div className="flex flex-col gap-4">
         <div
           data-screenshot-target
-          className="flex flex-col gap-4 xl:relative xl:block"
+          className={cn(
+            "flex flex-col gap-4",
+            embed ? "flex-row" : "xl:relative xl:block",
+          )}
         >
-          <div className="flex w-full flex-col sm:hidden xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:flex xl:w-[260px]">
-            <ItemSidebar
-              item={item}
-              category={category}
-              capacityUsed={capacity.used}
-              capacityMax={capacity.max}
-              hasReactor={hasReactor}
-              onToggleReactor={() => {}}
-              shards={shards}
-              onSetShard={() => {}}
-              helminth={helminth}
-              onSetHelminth={() => {}}
-              zawComponents={zawComponents}
-              lichBonusElement={lichBonusElement}
-              placedMods={slots.placed}
-              placedArcanes={arcanes.placed}
-              readOnly
-            />
+          <div
+            className={cn(
+              "flex w-full flex-col",
+              embed
+                ? "w-[260px] shrink-0"
+                : "sm:hidden xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:flex xl:w-[260px]",
+            )}
+          >
+            <ItemSidebar {...sidebarProps} />
           </div>
 
-          <div className="bg-card @container/loadout flex min-w-0 flex-1 flex-col gap-3 overflow-hidden rounded-lg border p-2 sm:p-4 xl:ml-[calc(260px+1rem)]">
-            <ItemSidebarPopover
-              className="hidden self-start sm:inline-flex xl:hidden"
-              item={item}
-              category={category}
-              capacityUsed={capacity.used}
-              capacityMax={capacity.max}
-              hasReactor={hasReactor}
-              onToggleReactor={() => {}}
-              shards={shards}
-              onSetShard={() => {}}
-              helminth={helminth}
-              onSetHelminth={() => {}}
-              zawComponents={zawComponents}
-              lichBonusElement={lichBonusElement}
-              placedMods={slots.placed}
-              placedArcanes={arcanes.placed}
-              readOnly
-            />
+          <div
+            className={cn(
+              "bg-card @container/loadout flex min-w-0 flex-1 flex-col gap-3 overflow-hidden rounded-lg border p-2 sm:p-4",
+              !embed && "xl:ml-[calc(260px+1rem)]",
+            )}
+          >
+            {!embed && (
+              <ItemSidebarPopover
+                {...sidebarProps}
+                className="hidden self-start sm:inline-flex xl:hidden"
+              />
+            )}
             <ModGrid
               item={item}
               category={category}
@@ -308,6 +428,7 @@ function BuildViewerBodyInner({
               normalSlotCount={normalSlotCount}
               slots={slots}
               readOnly
+              embed={embed}
               arcaneRow={
                 arcaneCount > 0 ? (
                   <ArcaneRow
@@ -322,7 +443,7 @@ function BuildViewerBodyInner({
           </div>
         </div>
 
-        {build.guide?.description || build.guide?.summary ? (
+        {!embed && (build.guide?.description || build.guide?.summary) ? (
           <div className="bg-card rounded-lg border p-4">
             {build.guide.summary ? (
               <p className="mb-3 font-medium">{build.guide.summary}</p>

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -14,6 +14,16 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-04-25",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "On tablets and smaller laptops, your stats and abilities now open in a popover so the mods get the full width of the page.",
+      },
+    ],
+  },
+  {
     date: "2026-04-24",
     changes: [
       {

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -48,6 +48,7 @@ import {
   GuideEditor,
   hasExilusSlot,
   ItemSidebar,
+  ItemSidebarPopover,
   ModGrid,
   ModSearchGrid,
   PublishDialog,
@@ -528,7 +529,7 @@ function EditorShell() {
 
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-4 xl:relative xl:block">
-          <div className="flex w-full flex-col xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:w-[260px]">
+          <div className="flex w-full flex-col sm:hidden xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:flex xl:w-[260px]">
             <ItemSidebar
               item={item}
               category={category}
@@ -550,7 +551,7 @@ function EditorShell() {
           </div>
 
           <div
-            className="bg-card @container/loadout min-w-0 flex-1 overflow-hidden rounded-lg border p-2 sm:p-4 xl:ml-[calc(260px+1rem)]"
+            className="bg-card @container/loadout flex min-w-0 flex-1 flex-col gap-3 overflow-hidden rounded-lg border p-2 sm:p-4 xl:ml-[calc(260px+1rem)]"
             onClick={(e) => {
               if (!(e.target instanceof HTMLElement)) return
               if (!e.target.closest("[data-build-slot]")) {
@@ -559,6 +560,25 @@ function EditorShell() {
               }
             }}
           >
+            <ItemSidebarPopover
+              className="hidden self-start sm:inline-flex xl:hidden"
+              item={item}
+              category={category}
+              capacityUsed={capacity.used}
+              capacityMax={capacity.max}
+              hasReactor={hasReactor}
+              onToggleReactor={() => setHasReactor((v) => !v)}
+              shards={shards}
+              onSetShard={setShard}
+              helminth={helminth}
+              onSetHelminth={setHelminthAt}
+              zawComponents={zawComponents}
+              onSetZawComponents={setZawComponents}
+              lichBonusElement={lichBonusElement}
+              onSetLichBonusElement={setLichBonusElement}
+              placedMods={slots.placed}
+              placedArcanes={arcanes.placed}
+            />
             <ModGrid
               item={item}
               category={category}


### PR DESCRIPTION
## Summary

Two related improvements to the build view page:

### 1. Popover sidebar at sm–xl widths (commit `abe928e`)
On tablets and smaller laptops, the stats sidebar now opens from a "Stats" trigger on the mod grid instead of stretching across the full content width. Mobile (<sm) and desktop (xl+) layouts are unchanged. Adds a `bare` mode to `ItemSidebar` and a new `ItemSidebarPopover` wrapper.

### 2. Wiki embed mode (commit `fa27261`)
Adds `?embed=1` to `/builds/$slug` for embedding builds in external guides — built specifically for the Profit-Taker wiki's Nuxt embed (~700px iframe).

- Renders at a fixed logical width (default 1140px, override via `?layout=`)
- Visually scales down to fit the iframe (default 0.65, override via `?scale=`)
- Forces the dense single-row mod layout (4 mods per row) regardless of viewport
- Hides site chrome: header, footer, viewer header (likes/edit), guide block
- ResizeObserver mirrors content height to wrapper so iframe content has no whitespace gutter
- Hover-to-expand mods still work; rounded ResizeObserver values + `setInnerHeight` dedupe avoid sub-pixel re-render churn

Also fixes a latent bug in `ModCard` hover-expand: the center calculation used unscaled `DISPLAY_SIZE` constants, but `getBoundingClientRect()` already returns visual coords — under any ancestor `transform: scale()` the expansion was off-center. Now uses the rect's own width/height.

### Embed usage example
```html
<iframe
  src=\"https://www.arsenyx.com/builds/<slug>?embed=1\"
  width=\"741\"
  height=\"900\"
  frameborder=\"0\"
></iframe>
```
Tune `?scale=` if 0.65 doesn't fit; tune `?layout=` if mods feel cramped.

## Test plan
- [x] Open a build at standard width and confirm desktop layout is unchanged
- [x] Resize between sm and xl: confirm sidebar collapses to popover trigger, mod grid takes full width
- [x] Visit `/builds/<slug>?embed=1` and confirm: no header/footer, no viewer header, sidebar in left column, 4-mod-per-row layout, iframe-friendly height
- [x] Hover a mod in embed mode: expansion centers on the cursor (not offset right)
- [x] Try `?scale=0.5` and `?layout=1300`: scale and layout adjust accordingly
- [x] Companion build embed: shards/abilities not shown, mods render in 5-col grid