### PR TITLE
docs: slim README, move bearer-token API into /docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for poking around. Arsenyx is a Bun workspaces monorepo — no npm, no npx.
+
+## Repo layout
+
+- [`apps/web/`](apps/web/) — the SPA (Vite + React 19 + TanStack Router)
+- [`apps/api/`](apps/api/) — the Hono API (Cloudflare Workers + Prisma 7)
+- [`packages/shared/`](packages/shared/) — types and codecs shared by both
+- [`services/screenshot/`](services/screenshot/) — Playwright screenshot worker
+
+Game data is **static** and served as JSON from `apps/web/public/data/`. User data (builds, votes, favorites, guides) is **dynamic** and lives in Postgres behind the API.
+
+## Running locally
+
+Requires Bun 1.2+, [just](https://github.com/casey/just), and a free Neon Postgres project ([neon.tech](https://neon.tech) — 1 minute signup).
+
+```bash
+bun install
+just setup    # interactive — asks for your Neon DATABASE_URL, generates
+              # an auth secret, pushes the schema, and seeds a dev user.
+just dev      # web on :5173, api on :8787
+```
+
+Sign in at `http://localhost:5173` with **`admin@admin.com`** / **`admin`**.
+
+GitHub OAuth is optional locally — fill `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` in `apps/api/.env` if you want to test the real OAuth flow. **In production, GitHub OAuth is the only sign-in method**; email+password is dev-only.
+
+The full command list is in the [justfile](justfile); [docs/commands.md](docs/commands.md) covers build, database, and data-sync workflows.
+
+## Agent-assisted work
+
+Start with [CLAUDE.md](CLAUDE.md) — it points to the per-app guides in [`apps/web/CLAUDE.md`](apps/web/CLAUDE.md) and [`apps/api/CLAUDE.md`](apps/api/CLAUDE.md). Open work is tracked in [TODO.md](TODO.md).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Live at **[www.arsenyx.com](https://www.arsenyx.com)**.
 - **Social layer** — vote, favorite, fork, and follow other players' builds
 - **Overframe import** — paste an Overframe URL and get a first-class Arsenyx build
 - **Shareable by link** — every build encodes to a short URL, no account needed to view
-- **Bearer-token API** — publish builds from scripts, bots, or external tools
+- **Bearer-token API** — publish builds from scripts, bots, or external tools — see [arsenyx.com/docs](https://www.arsenyx.com/docs)
 
 ## Stack
 
@@ -26,107 +26,6 @@ Live at **[www.arsenyx.com](https://www.arsenyx.com)**.
 | Screenshot service | Standalone Playwright worker behind a Cloudflare Tunnel |
 | Game data | [`@wfcd/items`](https://www.npmjs.com/package/@wfcd/items), precomputed to static JSON at build time |
 
-Bun workspaces throughout. No npm, no npx.
+## Contributing
 
-## Repo layout
-
-- [`apps/web/`](apps/web/) — the SPA
-- [`apps/api/`](apps/api/) — the Hono API
-- [`packages/shared/`](packages/shared/) — types and codecs shared by both
-- [`services/screenshot/`](services/screenshot/) — Playwright screenshot worker
-
-Game data is **static** and served as JSON from `apps/web/public/data/`. User data (builds, votes, favorites, guides) is **dynamic** and lives in Postgres behind the API.
-
-## Running locally
-
-Requires Bun 1.2+, [just](https://github.com/casey/just), and a free Neon Postgres project ([neon.tech](https://neon.tech) — 1 minute signup).
-
-```bash
-bun install
-just setup    # interactive — asks for your Neon DATABASE_URL, generates
-              # an auth secret, pushes the schema, and seeds a dev user.
-just dev      # web on :5173, api on :8787
-```
-
-Sign in at `http://localhost:5173` with **`admin@admin.com`** / **`admin`**.
-
-GitHub OAuth is optional locally — fill `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` in `apps/api/.env` if you want to test the real OAuth flow. **In production, GitHub OAuth is the only sign-in method**; email+password is dev-only.
-
-The full command list is in the [justfile](justfile); [docs/commands.md](docs/commands.md) covers build, database, and data-sync workflows.
-
-For agent-assisted work, start with [CLAUDE.md](CLAUDE.md) — it points to the per-app guides in [`apps/web/CLAUDE.md`](apps/web/CLAUDE.md) and [`apps/api/CLAUDE.md`](apps/api/CLAUDE.md). Open work is tracked in [TODO.md](TODO.md).
-
----
-
-## Build Upload API
-
-Arsenyx supports bearer-token build publishing, so you can push builds from a script or bot instead of clicking through the editor.
-
-1. Sign in, open the user menu, and head to **Settings**.
-2. Create a personal access token with the `build:write` scope.
-3. Send it as `Authorization: Bearer <token>`.
-
-### Endpoints
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| `POST` | `/api/v1/builds` | Create a build |
-| `PUT` | `/api/v1/builds/:slug` | Update a build you own |
-| `POST` | `/api/v1/imports/overframe` | Import an Overframe build by URL |
-
-### Creating a build
-
-`POST /api/v1/builds` and `PUT /api/v1/builds/:slug` accept a thin JSON payload:
-
-```json
-{
-  "name": "Rhino Tank",
-  "visibility": "PUBLIC",
-  "itemUniqueName": "/Lotus/Powersuits/Rhino/Rhino",
-  "itemCategory": "warframes",
-  "organizationSlug": null,
-  "guide": {
-    "summary": "Optional short summary",
-    "description": "Optional markdown guide"
-  },
-  "partnerBuildSlugs": [],
-  "build": {
-    "hasReactor": true,
-    "slots": [
-      {
-        "slotId": "aura-0",
-        "mod": {
-          "uniqueName": "/Lotus/Upgrades/Mods/Aura/SteelCharge",
-          "rank": 5
-        }
-      }
-    ],
-    "arcanes": [],
-    "shards": [],
-    "helminthAbility": null
-  }
-}
-```
-
-The server resolves canonical item / mod / arcane / shard data, recomputes derived capacity and forma fields, and rejects invalid writes with structured `4xx` JSON errors.
-
-### Importing from Overframe
-
-`POST /api/v1/imports/overframe` takes just a URL (plus optional overrides):
-
-```json
-{
-  "url": "https://overframe.gg/build/935570/",
-  "visibility": "PUBLIC",
-  "organizationSlug": null,
-  "nameOverride": "Optional custom title",
-  "description": "Optional build description",
-  "guide": {
-    "summary": "Optional short summary",
-    "description": "Optional markdown guide"
-  },
-  "partnerBuildSlugs": []
-}
-```
-
-If `nameOverride`, `description`, or `guide` are omitted, Arsenyx preserves the Overframe metadata: the Overframe title becomes the build name, the page description becomes the guide summary, and the Overframe guide markdown becomes the guide body. Newlines in imported guides are stored as Markdown hard breaks so line-oriented text keeps its layout. Explicit `null` values still clear nullable fields. The response returns the created build plus any import warnings.
+Setup, repo layout, and local dev workflow live in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/apps/web/src/routes/docs.tsx
+++ b/apps/web/src/routes/docs.tsx
@@ -12,11 +12,61 @@ export const Route = createFileRoute("/docs")({
 })
 
 type Endpoint = {
-  method: "GET"
+  method: "GET" | "POST" | "PUT"
   path: string
   summary: string
   example: string
 }
+
+const WRITE_ENDPOINTS: Endpoint[] = [
+  {
+    method: "POST",
+    path: "/api/v1/builds",
+    summary:
+      "Create a build. Body specifies item, slots, arcanes, shards, and optional guide. Server resolves canonical refs and recomputes derived fields.",
+    example: `{
+  "name": "Rhino Tank",
+  "visibility": "PUBLIC",
+  "itemUniqueName": "/Lotus/Powersuits/Rhino/Rhino",
+  "itemCategory": "warframes",
+  "guide": { "summary": "...", "description": "..." },
+  "build": {
+    "hasReactor": true,
+    "slots": [
+      {
+        "slotId": "aura-0",
+        "mod": {
+          "uniqueName": "/Lotus/Upgrades/Mods/Aura/SteelCharge",
+          "rank": 5
+        }
+      }
+    ],
+    "arcanes": [],
+    "shards": [],
+    "helminthAbility": null
+  }
+}`,
+  },
+  {
+    method: "PUT",
+    path: "/api/v1/builds/:slug",
+    summary: "Update a build you own. Same payload shape as create.",
+    example: `{ "name": "...", "build": { ... } }`,
+  },
+  {
+    method: "POST",
+    path: "/api/v1/imports/overframe",
+    summary:
+      "Import an Overframe build by URL. If nameOverride / description / guide are omitted, Arsenyx preserves the Overframe metadata. Explicit null clears nullable fields.",
+    example: `{
+  "url": "https://overframe.gg/build/935570/",
+  "visibility": "PUBLIC",
+  "nameOverride": null,
+  "description": null,
+  "guide": null
+}`,
+  },
+]
 
 const PUBLIC_ENDPOINTS: Endpoint[] = [
   {
@@ -134,6 +184,39 @@ function DocsPage() {
           <p className="text-sm opacity-75">
             Fields abbreviated. Responses are subject to change while Arsenyx
             is in beta — pin to the commit you tested against.
+          </p>
+
+          <h2>Authenticated write API</h2>
+          <p>
+            Arsenyx supports bearer-token build publishing, so you can push
+            builds from a script or bot instead of clicking through the editor.
+            Sign in, open the user menu, head to <strong>Settings</strong>, and
+            create a personal access token with the <code>build:write</code>{" "}
+            scope. Send it as <code>Authorization: Bearer &lt;token&gt;</code>.
+          </p>
+          <ul className="not-prose flex list-none flex-col gap-4 pl-0">
+            {WRITE_ENDPOINTS.map((ep) => (
+              <li
+                key={`${ep.method} ${ep.path}`}
+                className="border-border bg-card flex flex-col gap-2 rounded-lg border p-4"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="bg-muted rounded px-2 py-0.5 font-mono text-xs font-semibold">
+                    {ep.method}
+                  </span>
+                  <code className="text-sm font-medium">{ep.path}</code>
+                </div>
+                <p className="text-muted-foreground text-sm">{ep.summary}</p>
+                <pre className="bg-muted/50 overflow-x-auto rounded p-3 text-xs leading-relaxed">
+                  <code>{ep.example}</code>
+                </pre>
+              </li>
+            ))}
+          </ul>
+          <p className="text-sm opacity-75">
+            The server resolves canonical item / mod / arcane / shard data,
+            recomputes derived capacity and forma fields, and rejects invalid
+            writes with structured <code>4xx</code> JSON errors.
           </p>
 
           <h2>Game data</h2>


### PR DESCRIPTION
## Summary

The README had grown into a mix of product pitch and contributor onboarding, with a full Build Upload API reference dropped in the middle. This splits it three ways:

- **README** — product blurb only: tagline, features, stack table, links out
- **CONTRIBUTING.md** (new) — repo layout, local Bun/Neon setup, justfile and CLAUDE.md pointers
- **`/docs` page** — gains an **Authenticated write API** section covering `POST /api/v1/builds`, `PUT /api/v1/builds/:slug`, and `POST /api/v1/imports/overframe` so the bearer-token API lives next to the public GET endpoints instead of buried in the README

Also fixed a pre-existing bug in `.claude/launch.json` where `--cwd apps/web` was being parsed as a script name (bun's `--cwd` requires the `=<val>` form). Not committed since `.claude/` is gitignored, but flagging for awareness.

## Test plan

- [x] `bun run build` in `apps/web` passes
- [x] `/docs` renders with new "Authenticated write API" section between "Public API" and "Game data" — verified in dev preview
- [x] All three write endpoints visible with example payloads