### PR TITLE
fix(builds): include innate exilus polarity in forma count and capacity

### DIFF
--- a/apps/web/src/components/build-editor/calculations.ts
+++ b/apps/web/src/components/build-editor/calculations.ts
@@ -137,6 +137,7 @@ export interface CapacityInput {
   placed: Partial<Record<SlotId, PlacedMod>>
   formaPolarities: Partial<Record<SlotId, Polarity>>
   auraInnates: (Polarity | undefined)[]
+  exilusInnate?: Polarity
   normalInnates: (Polarity | undefined)[]
   hasReactor: boolean
   maxLevelCap?: number
@@ -154,6 +155,7 @@ export function calculateCapacity(input: CapacityInput): CapacityResult {
     placed,
     formaPolarities,
     auraInnates,
+    exilusInnate,
     normalInnates,
     hasReactor,
     maxLevelCap,
@@ -180,7 +182,7 @@ export function calculateCapacity(input: CapacityInput): CapacityResult {
     used += effectiveDrainForMod(
       exilus.mod,
       exilus.rank,
-      effectivePolarity(undefined, formaPolarities.exilus),
+      effectivePolarity(exilusInnate, formaPolarities.exilus),
     )
   }
   for (let i = 0; i < normalInnates.length; i++) {

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -21,7 +21,13 @@ export {
   hasExilusSlot,
   isLichWeapon,
 } from "./layout"
-export { ArcaneRow, getAuraPolarities, ModGrid, toPolarity } from "./mod-grid"
+export {
+  ArcaneRow,
+  getAuraPolarities,
+  getExilusInnatePolarity,
+  ModGrid,
+  toPolarity,
+} from "./mod-grid"
 export { ModCard } from "./mod-card"
 export { ModSearchGrid } from "./mod-search-grid"
 export { RivenDialog, type RivenDialogValues } from "./riven-dialog"

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -35,6 +35,17 @@ export function getAuraPolarities(
   return Array.from({ length: count }, (_, i) => toPolarity(raws[i]))
 }
 
+/**
+ * Innate exilus polarity, sourced from WFCD's `exilusPolarity` field
+ * (extracted from the Warframe wiki's `Module:Weapons/data` /
+ * `Module:Warframes/data` Lua tables).
+ */
+export function getExilusInnatePolarity(
+  item: Pick<DetailItem, "exilusPolarity">,
+): Polarity | undefined {
+  return toPolarity(item.exilusPolarity)
+}
+
 export function ArcaneRow({
   count,
   arcanes,
@@ -152,7 +163,10 @@ export function ModGrid({
             />
           )}
           {showExilus && (
-            <ModSlot kind="exilus" {...slotProps("exilus", undefined)} />
+            <ModSlot
+              kind="exilus"
+              {...slotProps("exilus", getExilusInnatePolarity(item))}
+            />
           )}
           {Array.from({ length: Math.max(0, auraSlotCount - 1) }, (_, i) => {
             const idx = i + 1

--- a/apps/web/src/lib/warframe.ts
+++ b/apps/web/src/lib/warframe.ts
@@ -70,9 +70,11 @@ export interface ItemAbility {
 export interface DetailItem extends BrowseItem {
   description?: string
   // slot polarities (from WFCD): `aura` is warframe-only, `polarities` lists
-  // innate polarities on normal slots in slot order.
+  // innate polarities on normal slots in slot order, `exilusPolarity` is the
+  // innate polarity on the exilus slot (weapons + warframes).
   aura?: string | string[]
   polarities?: string[]
+  exilusPolarity?: string
   // warframe
   health?: number
   shield?: number

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -29,6 +29,7 @@ import {
   getArcaneSlotCount,
   getAuraPolarities,
   getAuraSlotCount,
+  getExilusInnatePolarity,
   getMaxLevelCap,
   getNormalSlotCount,
   hasExilusSlot,
@@ -316,6 +317,7 @@ function BuildViewerBodyInner({
     () => getAuraPolarities(item, auraSlotCount),
     [item, auraSlotCount],
   )
+  const exilusInnate = useMemo(() => getExilusInnatePolarity(item), [item])
   const normalInnates = useMemo(
     () =>
       Array.from({ length: normalSlotCount }, (_, i) =>
@@ -332,10 +334,11 @@ function BuildViewerBodyInner({
     () =>
       calculateFormaCount({
         auraInnates,
+        exilusInnate,
         normalInnates,
         formaPolarities: slots.formaPolarities,
       }),
-    [auraInnates, normalInnates, slots.formaPolarities],
+    [auraInnates, exilusInnate, normalInnates, slots.formaPolarities],
   )
   const capacity = useMemo(
     () =>
@@ -343,6 +346,7 @@ function BuildViewerBodyInner({
         placed: slots.placed,
         formaPolarities: slots.formaPolarities,
         auraInnates,
+        exilusInnate,
         normalInnates,
         hasReactor,
         maxLevelCap: getMaxLevelCap(category, item),
@@ -351,6 +355,7 @@ function BuildViewerBodyInner({
       slots.placed,
       slots.formaPolarities,
       auraInnates,
+      exilusInnate,
       normalInnates,
       hasReactor,
       category,

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -47,6 +47,7 @@ import {
   getArcaneSlotCount,
   getAuraPolarities,
   getAuraSlotCount,
+  getExilusInnatePolarity,
   getMaxLevelCap,
   getNormalSlotCount,
   GuideEditor,
@@ -383,6 +384,7 @@ function EditorShell() {
     () => getAuraPolarities(item, auraSlotCount),
     [item, auraSlotCount],
   )
+  const exilusInnate = useMemo(() => getExilusInnatePolarity(item), [item])
   const normalInnates = useMemo(
     () =>
       Array.from({ length: normalSlotCount }, (_, i) =>
@@ -399,10 +401,11 @@ function EditorShell() {
     () =>
       calculateFormaCount({
         auraInnates,
+        exilusInnate,
         normalInnates,
         formaPolarities: slots.formaPolarities,
       }),
-    [auraInnates, normalInnates, slots.formaPolarities],
+    [auraInnates, exilusInnate, normalInnates, slots.formaPolarities],
   )
   const isUpdate = !!existingBuild && existingBuild.isOwner
 
@@ -516,6 +519,7 @@ function EditorShell() {
         placed: slots.placed,
         formaPolarities: slots.formaPolarities,
         auraInnates,
+        exilusInnate,
         normalInnates,
         hasReactor,
         maxLevelCap: getMaxLevelCap(category, item),
@@ -524,6 +528,7 @@ function EditorShell() {
       slots.placed,
       slots.formaPolarities,
       auraInnates,
+      exilusInnate,
       normalInnates,
       hasReactor,
       category,

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -254,8 +254,7 @@ function ImportPage() {
                                   detailItem,
                                 ),
                               ),
-                              exilusInnate:
-                                getExilusInnatePolarity(detailItem),
+                              exilusInnate: getExilusInnatePolarity(detailItem),
                               normalInnates: Array.from(
                                 {
                                   length: getNormalSlotCount(

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -7,6 +7,7 @@ import {
   calculateFormaCount,
   getAuraPolarities,
   getAuraSlotCount,
+  getExilusInnatePolarity,
   getNormalSlotCount,
   toPolarity,
 } from "@/components/build-editor"
@@ -253,6 +254,8 @@ function ImportPage() {
                                   detailItem,
                                 ),
                               ),
+                              exilusInnate:
+                                getExilusInnatePolarity(detailItem),
                               normalInnates: Array.from(
                                 {
                                   length: getNormalSlotCount(


### PR DESCRIPTION
## Summary

Forma counts were off by 1 for any weapon or warframe with an innate exilus polarity. We treated the exilus slot as always unpolarized, which silently inflated the displayed forma cost. Concrete repro: the Laetum showed **6 forma**, while Overframe and the in-game arsenal both report **5** — the difference being its innate naramon exilus, which the user doesn't pay forma for.

This wasn't an arsenyx bug originally — `@wfcd/items` didn't ship the `exilusPolarity` field at all, despite the wiki carrying it for ~95% of weapons and warframes. The upstream gap is now fixed in [WFCD/warframe-items#917](https://github.com/WFCD/warframe-items/pull/917) (merged + released in `1.1274.2`, which #74 just bumped us to). This PR consumes the new field.

## What changed

- `DetailItem.exilusPolarity?: string` on the type and a `getExilusInnatePolarity` helper in `mod-grid`
- `calculateCapacity` now accepts `exilusInnate` and uses it in the exilus-slot drain math (`calculateFormaCount` already accepted it; the param was dead until now)
- Exilus slot renders its innate polarity in `ModGrid`, matching how aura/normal slots already do
- Threaded `exilusInnate` through the three callers: `builds.$slug`, `create`, `import`

## Verified

- Laetum's per-item JSON now carries `"exilusPolarity":"naramon"`; 335+ weapons/frames have the field after `bun run build:items`
- Forma count for the Laetum reproduces **5**, matching Overframe
- `bun run lint` → 0 new errors (8 pre-existed on main, unrelated)
- `vite build` → clean

## Test plan

- [ ] Open a Laetum / Phenmor / Felarx / Soma Prime build — exilus slot shows its innate polarity icon
- [ ] Forma counts match Overframe / in-game on a few sample builds
- [ ] Mod drain in the exilus slot uses innate polarity (halved drain when the mod's polarity matches, full drain when it doesn't)
- [ ] Builds for items without an innate exilus polarity are unchanged (Excalibur, Volt, etc.)

## Notes

`@wfcd/items` already populates this field as of `1.1274.2`, so no further data work needed. The 8 pre-existing lint errors are exhaustive-deps warnings on hooks unrelated to this change.