### PR TITLE
fix(builds): self-heal stale wfcd imageNames on saved builds

### DIFF
--- a/apps/api/scripts/backfill-image-names.ts
+++ b/apps/api/scripts/backfill-image-names.ts
@@ -14,10 +14,11 @@
  *
  * Usage:
  *   cd apps/api
- *   bun run scripts/backfill-image-names.ts          # dry run
- *   bun run scripts/backfill-image-names.ts --apply  # actually write
+ *   bun --env-file=.env run scripts/backfill-image-names.ts          # dry run
+ *   bun --env-file=.env run scripts/backfill-image-names.ts --apply  # actually write
  */
 
+import "dotenv/config"
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
@@ -45,7 +46,7 @@ async function loadLookup<T extends { uniqueName: string; imageName?: string }>(
   file: string,
 ): Promise<Lookup> {
   const body = await readFile(resolve(DATA_DIR, file), "utf8")
-  const list = (JSON.parse(body) as T[]) ?? []
+  const list = JSON.parse(body) as T[]
   const map: Lookup = new Map()
   for (const entry of list) {
     if (entry?.uniqueName) map.set(entry.uniqueName, entry.imageName)
@@ -137,32 +138,33 @@ function refreshBuildData(
     | undefined
   if (slots) {
     for (const placed of Object.values(slots)) {
-      if (placed?.mod && rewriteImageName(placed.mod, lookups.mods, "mod", stats)) {
+      if (
+        placed?.mod &&
+        rewriteImageName(placed.mod, lookups.mods, "mod", stats)
+      ) {
         stats.mods++
         changed = true
       }
     }
   }
 
-  // Legacy slot arrays (`auraSlots[]`, `normalSlots[]`, `exilusSlot`)
+  // Legacy slot arrays (`auraSlots[]`, `normalSlots[]`) + singular `exilusSlot`
+  const legacySlots: Array<{ mod?: Record<string, unknown> }> = []
   for (const key of ["auraSlots", "normalSlots"] as const) {
-    const arr = next[key] as Array<{ mod?: Record<string, unknown> }> | undefined
-    if (Array.isArray(arr)) {
-      for (const slot of arr) {
-        if (slot?.mod && rewriteImageName(slot.mod, lookups.mods, "mod", stats)) {
-          stats.mods++
-          changed = true
-        }
-      }
-    }
+    const arr = next[key] as
+      | Array<{ mod?: Record<string, unknown> }>
+      | undefined
+    if (Array.isArray(arr)) legacySlots.push(...arr)
   }
-  const exilus = next.exilusSlot as { mod?: Record<string, unknown> } | undefined
-  if (
-    exilus?.mod &&
-    rewriteImageName(exilus.mod, lookups.mods, "mod", stats)
-  ) {
-    stats.mods++
-    changed = true
+  const exilus = next.exilusSlot as
+    | { mod?: Record<string, unknown> }
+    | undefined
+  if (exilus) legacySlots.push(exilus)
+  for (const slot of legacySlots) {
+    if (slot?.mod && rewriteImageName(slot.mod, lookups.mods, "mod", stats)) {
+      stats.mods++
+      changed = true
+    }
   }
 
   // Modern arcane slots (`arcanes[]: { arcane, rank } | null`)
@@ -216,7 +218,12 @@ function refreshBuildData(
     | undefined
   if (
     legacyHelminth?.ability &&
-    rewriteImageName(legacyHelminth.ability, lookups.helminth, "helminth", stats)
+    rewriteImageName(
+      legacyHelminth.ability,
+      lookups.helminth,
+      "helminth",
+      stats,
+    )
   ) {
     stats.helminth++
     changed = true
@@ -293,8 +300,12 @@ async function main() {
       const k = `${u.kind}:${u.uniqueName}`
       counts.set(k, (counts.get(k) ?? 0) + 1)
     }
-    console.log(`\nUnresolved uniqueNames (left as-is): ${stats.unresolved.length}`)
-    for (const [k, n] of [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20)) {
+    console.log(
+      `\nUnresolved uniqueNames (left as-is): ${stats.unresolved.length}`,
+    )
+    for (const [k, n] of [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20)) {
       console.log(`  ${n}× ${k}`)
     }
   }

--- a/apps/api/scripts/backfill-image-names.ts
+++ b/apps/api/scripts/backfill-image-names.ts
@@ -1,0 +1,307 @@
+/**
+ * Backfill stale `imageName` values in every `Build` row.
+ *
+ * Older builds were saved when `@wfcd/items` shipped content-hashed image
+ * filenames (e.g. `roar-e206197372.png`). Newer wfcd uses canonical names
+ * (`RhinoRadialBlast.png`), and the upstream CDN no longer maps the old
+ * hashed slugs — they 404. This script walks every build, looks each
+ * `uniqueName` up in current static data under `apps/web/public/data/`, and
+ * rewrites both `Build.itemImageName` (column) and every `imageName` nested
+ * inside `Build.buildData` (mods, arcanes, helminth ability, plus legacy
+ * `itemImageName` at the JSON root).
+ *
+ * Idempotent. Safe to re-run after `bun run build:items`.
+ *
+ * Usage:
+ *   cd apps/api
+ *   bun run scripts/backfill-image-names.ts          # dry run
+ *   bun run scripts/backfill-image-names.ts --apply  # actually write
+ */
+
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+import { neon } from "@neondatabase/serverless"
+
+const APPLY = process.argv.includes("--apply")
+const DATA_DIR = resolve(import.meta.dirname, "../../web/public/data")
+
+type Lookup = Map<string, string | undefined>
+
+interface BrowseItem {
+  uniqueName: string
+  imageName?: string
+}
+interface ModLike {
+  uniqueName: string
+  imageName?: string
+}
+interface HelminthAbility {
+  uniqueName: string
+  imageName?: string
+}
+
+async function loadLookup<T extends { uniqueName: string; imageName?: string }>(
+  file: string,
+): Promise<Lookup> {
+  const body = await readFile(resolve(DATA_DIR, file), "utf8")
+  const list = (JSON.parse(body) as T[]) ?? []
+  const map: Lookup = new Map()
+  for (const entry of list) {
+    if (entry?.uniqueName) map.set(entry.uniqueName, entry.imageName)
+  }
+  return map
+}
+
+async function loadItemLookup(): Promise<Lookup> {
+  const body = await readFile(resolve(DATA_DIR, "items-index.json"), "utf8")
+  const raw = JSON.parse(body) as Record<string, BrowseItem[]>
+  const map: Lookup = new Map()
+  for (const list of Object.values(raw)) {
+    for (const item of list ?? []) {
+      if (item?.uniqueName) map.set(item.uniqueName, item.imageName)
+    }
+  }
+  return map
+}
+
+interface Lookups {
+  items: Lookup
+  mods: Lookup
+  arcanes: Lookup
+  helminth: Lookup
+}
+
+async function loadAllLookups(): Promise<Lookups> {
+  const [items, mods, arcanes, helminth] = await Promise.all([
+    loadItemLookup(),
+    loadLookup<ModLike>("mods-all.json"),
+    loadLookup<ModLike>("arcanes-all.json"),
+    loadLookup<HelminthAbility>("helminth-abilities.json"),
+  ])
+  return { items, mods, arcanes, helminth }
+}
+
+type RewriteKind = "mod" | "arcane" | "helminth" | "item"
+
+interface RewriteStats {
+  itemColumn: number
+  itemRoot: number
+  mods: number
+  arcanes: number
+  helminth: number
+  unresolved: { kind: RewriteKind; uniqueName: string }[]
+}
+
+function rewriteImageName(
+  obj: Record<string, unknown> | null | undefined,
+  lookup: Lookup,
+  kind: RewriteKind,
+  stats: RewriteStats,
+): boolean {
+  if (!obj || typeof obj !== "object") return false
+  const uniqueName = obj.uniqueName as string | undefined
+  if (!uniqueName) return false
+  const fresh = lookup.get(uniqueName)
+  if (fresh === undefined) {
+    if (obj.imageName) stats.unresolved.push({ kind, uniqueName })
+    return false
+  }
+  if (obj.imageName === fresh) return false
+  obj.imageName = fresh
+  return true
+}
+
+function refreshBuildData(
+  data: unknown,
+  lookups: Lookups,
+  stats: RewriteStats,
+): { changed: boolean; data: unknown } {
+  if (!data || typeof data !== "object") return { changed: false, data }
+  const next = structuredClone(data) as Record<string, unknown>
+  let changed = false
+
+  // Legacy BuildState root: itemImageName lives on the JSON.
+  if ("itemImageName" in next && typeof next.itemUniqueName === "string") {
+    const fresh = lookups.items.get(next.itemUniqueName as string)
+    if (fresh !== undefined && next.itemImageName !== fresh) {
+      next.itemImageName = fresh
+      stats.itemRoot++
+      changed = true
+    }
+  }
+
+  // Modern slot map (`slots[id]: { mod, rank }`)
+  const slots = next.slots as
+    | Record<string, { mod?: Record<string, unknown> } | undefined>
+    | undefined
+  if (slots) {
+    for (const placed of Object.values(slots)) {
+      if (placed?.mod && rewriteImageName(placed.mod, lookups.mods, "mod", stats)) {
+        stats.mods++
+        changed = true
+      }
+    }
+  }
+
+  // Legacy slot arrays (`auraSlots[]`, `normalSlots[]`, `exilusSlot`)
+  for (const key of ["auraSlots", "normalSlots"] as const) {
+    const arr = next[key] as Array<{ mod?: Record<string, unknown> }> | undefined
+    if (Array.isArray(arr)) {
+      for (const slot of arr) {
+        if (slot?.mod && rewriteImageName(slot.mod, lookups.mods, "mod", stats)) {
+          stats.mods++
+          changed = true
+        }
+      }
+    }
+  }
+  const exilus = next.exilusSlot as { mod?: Record<string, unknown> } | undefined
+  if (
+    exilus?.mod &&
+    rewriteImageName(exilus.mod, lookups.mods, "mod", stats)
+  ) {
+    stats.mods++
+    changed = true
+  }
+
+  // Modern arcane slots (`arcanes[]: { arcane, rank } | null`)
+  const arcanes = next.arcanes as
+    | Array<{ arcane?: Record<string, unknown> } | null>
+    | undefined
+  if (Array.isArray(arcanes)) {
+    for (const placed of arcanes) {
+      if (
+        placed?.arcane &&
+        rewriteImageName(placed.arcane, lookups.arcanes, "arcane", stats)
+      ) {
+        stats.arcanes++
+        changed = true
+      }
+    }
+  }
+
+  // Legacy arcane slots (`arcaneSlots[]: SharedPlacedArcane | null`) — flat shape
+  const legacyArcanes = next.arcaneSlots as
+    | Array<Record<string, unknown> | null>
+    | undefined
+  if (Array.isArray(legacyArcanes)) {
+    for (const a of legacyArcanes) {
+      if (a && rewriteImageName(a, lookups.arcanes, "arcane", stats)) {
+        stats.arcanes++
+        changed = true
+      }
+    }
+  }
+
+  // Modern helminth (`helminth[slotIndex]: HelminthAbility`)
+  const helminthMap = next.helminth as
+    | Record<string, Record<string, unknown>>
+    | undefined
+  if (helminthMap) {
+    for (const ability of Object.values(helminthMap)) {
+      if (
+        ability &&
+        rewriteImageName(ability, lookups.helminth, "helminth", stats)
+      ) {
+        stats.helminth++
+        changed = true
+      }
+    }
+  }
+
+  // Legacy helminth (`helminthAbility.ability`)
+  const legacyHelminth = next.helminthAbility as
+    | { ability?: Record<string, unknown> }
+    | undefined
+  if (
+    legacyHelminth?.ability &&
+    rewriteImageName(legacyHelminth.ability, lookups.helminth, "helminth", stats)
+  ) {
+    stats.helminth++
+    changed = true
+  }
+
+  return { changed, data: next }
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is not set")
+  const sql = neon(process.env.DATABASE_URL)
+
+  const lookups = await loadAllLookups()
+  console.log(
+    `Loaded lookups: ${lookups.items.size} items, ${lookups.mods.size} mods, ` +
+      `${lookups.arcanes.size} arcanes, ${lookups.helminth.size} helminth abilities`,
+  )
+
+  const builds = (await sql`
+    SELECT id, slug, "itemUniqueName", "itemImageName", "buildData"
+    FROM builds
+  `) as Array<{
+    id: string
+    slug: string
+    itemUniqueName: string
+    itemImageName: string | null
+    buildData: unknown
+  }>
+
+  console.log(`Scanning ${builds.length} builds (apply=${APPLY})…`)
+
+  const stats: RewriteStats = {
+    itemColumn: 0,
+    itemRoot: 0,
+    mods: 0,
+    arcanes: 0,
+    helminth: 0,
+    unresolved: [],
+  }
+  let buildsChanged = 0
+
+  for (const b of builds) {
+    const freshItemImage = lookups.items.get(b.itemUniqueName)
+    const itemColumnChanged =
+      freshItemImage !== undefined && b.itemImageName !== freshItemImage
+    const { changed: dataChanged, data: nextData } = refreshBuildData(
+      b.buildData,
+      lookups,
+      stats,
+    )
+    if (!itemColumnChanged && !dataChanged) continue
+    buildsChanged++
+    if (itemColumnChanged) stats.itemColumn++
+    if (APPLY) {
+      await sql`
+        UPDATE builds
+        SET "itemImageName" = ${freshItemImage ?? b.itemImageName},
+            "buildData" = ${JSON.stringify(nextData)}::jsonb
+        WHERE id = ${b.id}
+      `
+    }
+  }
+
+  console.log(`\n--- Summary ---`)
+  console.log(`Builds touched: ${buildsChanged} / ${builds.length}`)
+  console.log(`  itemImageName column rewrites: ${stats.itemColumn}`)
+  console.log(`  buildData root itemImageName:  ${stats.itemRoot}`)
+  console.log(`  mod imageName rewrites:        ${stats.mods}`)
+  console.log(`  arcane imageName rewrites:     ${stats.arcanes}`)
+  console.log(`  helminth imageName rewrites:   ${stats.helminth}`)
+  if (stats.unresolved.length > 0) {
+    const counts = new Map<string, number>()
+    for (const u of stats.unresolved) {
+      const k = `${u.kind}:${u.uniqueName}`
+      counts.set(k, (counts.get(k) ?? 0) + 1)
+    }
+    console.log(`\nUnresolved uniqueNames (left as-is): ${stats.unresolved.length}`)
+    for (const [k, n] of [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20)) {
+      console.log(`  ${n}× ${k}`)
+    }
+  }
+  console.log(APPLY ? "\nApplied." : "\nDry run. Pass --apply to write.")
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/web/src/components/build-editor/mod-search-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-search-grid.tsx
@@ -294,7 +294,6 @@ export function ModSearchGrid({
   const GRID_ROWS = 2
   const moveFromDisplayedIndex = (from: number, dir: Dir): number | null => {
     const row = from % GRID_ROWS
-    const col = Math.floor(from / GRID_ROWS)
     const focusable = (i: number) =>
       i >= 0 &&
       i < displayed.length &&

--- a/apps/web/src/lib/build-codec-adapter.ts
+++ b/apps/web/src/lib/build-codec-adapter.ts
@@ -262,8 +262,8 @@ export function normalizeBuildData(
 // (e.g. `roar-e206197372.png`); the newer `@wfcd/items` package uses canonical
 // names and the upstream CDN no longer maps the old hashed slugs. Mods and
 // arcanes are already re-resolved via `toEditorPlacedMod` upstream, but
-// `buildStateToSavedData` copies helminth fields verbatim — so refresh that
-// one shape from `helminthAbilities` to self-heal stale legacy rows.
+// `buildStateToSavedData` copies helminth fields verbatim — so refresh just
+// the imageName from `helminthAbilities` to self-heal stale legacy rows.
 function refreshHelminthImage(
   data: SavedBuildData,
   helminthAbilities: HelminthAbility[],
@@ -272,7 +272,10 @@ function refreshHelminthImage(
   const byUnique = new Map(helminthAbilities.map((h) => [h.uniqueName, h]))
   const next: Record<number, HelminthAbility> = {}
   for (const [slotIndex, ability] of Object.entries(data.helminth)) {
-    next[Number(slotIndex)] = byUnique.get(ability.uniqueName) ?? ability
+    const fresh = byUnique.get(ability.uniqueName)
+    next[Number(slotIndex)] = fresh
+      ? { ...ability, imageName: fresh.imageName }
+      : ability
   }
   return { ...data, helminth: next }
 }

--- a/apps/web/src/lib/build-codec-adapter.ts
+++ b/apps/web/src/lib/build-codec-adapter.ts
@@ -249,12 +249,32 @@ export function normalizeBuildData(
   raw: unknown,
   mods: Mod[],
   arcanes: Arcane[],
+  helminthAbilities: HelminthAbility[] = [],
 ): SavedBuildData {
   const r = (raw ?? {}) as LegacyOrSaved
-  if (isLegacyBuildData(r)) {
-    return buildStateToSavedData(r, mods, arcanes).data
+  const base = isLegacyBuildData(r)
+    ? buildStateToSavedData(r, mods, arcanes).data
+    : migrateLegacyAuraKey(r as SavedBuildData)
+  return refreshHelminthImage(base, helminthAbilities)
+}
+
+// Older builds were saved when wfcd shipped content-hashed image filenames
+// (e.g. `roar-e206197372.png`); the newer `@wfcd/items` package uses canonical
+// names and the upstream CDN no longer maps the old hashed slugs. Mods and
+// arcanes are already re-resolved via `toEditorPlacedMod` upstream, but
+// `buildStateToSavedData` copies helminth fields verbatim — so refresh that
+// one shape from `helminthAbilities` to self-heal stale legacy rows.
+function refreshHelminthImage(
+  data: SavedBuildData,
+  helminthAbilities: HelminthAbility[],
+): SavedBuildData {
+  if (!data.helminth || helminthAbilities.length === 0) return data
+  const byUnique = new Map(helminthAbilities.map((h) => [h.uniqueName, h]))
+  const next: Record<number, HelminthAbility> = {}
+  for (const [slotIndex, ability] of Object.entries(data.helminth)) {
+    next[Number(slotIndex)] = byUnique.get(ability.uniqueName) ?? ability
   }
-  return migrateLegacyAuraKey(r as SavedBuildData)
+  return { ...data, helminth: next }
 }
 
 /**

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -137,7 +137,7 @@ function BrowseContent() {
     return () => window.removeEventListener("keydown", onKey)
   }, [])
 
-  const items = data[category] ?? []
+  const items = useMemo(() => data[category] ?? [], [data, category])
 
   const visible = useMemo(
     () =>
@@ -149,15 +149,7 @@ function BrowseContent() {
         incarnonOnly,
         sort,
       }),
-    [
-      items,
-      deferredQ,
-      masteryMax,
-      primeOnly,
-      hideVaulted,
-      incarnonOnly,
-      sort,
-    ],
+    [items, deferredQ, masteryMax, primeOnly, hideVaulted, incarnonOnly, sort],
   )
 
   return (

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -67,8 +67,8 @@ import {
   normalizeBuildData,
 } from "@/lib/build-codec-adapter"
 import { buildQuery, type BuildDetail } from "@/lib/build-query"
-import { helminthQuery, type HelminthAbility } from "@/lib/helminth-query"
 import { useToggleBookmark, useToggleLike } from "@/lib/build-social"
+import { helminthQuery, type HelminthAbility } from "@/lib/helminth-query"
 import { itemQuery } from "@/lib/item-query"
 import { modsQuery } from "@/lib/mods-query"
 import { padShards } from "@/lib/shards"
@@ -342,7 +342,7 @@ function BuildViewerBodyInner({
       Array.from({ length: normalSlotCount }, (_, i) =>
         toPolarity(item.polarities?.[i]),
       ),
-    [item.polarities],
+    [item.polarities, normalSlotCount],
   )
 
   const totalEndoCost = useMemo(
@@ -378,7 +378,7 @@ function BuildViewerBodyInner({
       normalInnates,
       hasReactor,
       category,
-      item.maxLevelCap,
+      item,
     ],
   )
 

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -67,6 +67,7 @@ import {
   normalizeBuildData,
 } from "@/lib/build-codec-adapter"
 import { buildQuery, type BuildDetail } from "@/lib/build-query"
+import { helminthQuery, type HelminthAbility } from "@/lib/helminth-query"
 import { useToggleBookmark, useToggleLike } from "@/lib/build-social"
 import { itemQuery } from "@/lib/item-query"
 import { modsQuery } from "@/lib/mods-query"
@@ -239,11 +240,19 @@ function BuildViewerBody(props: {
 }) {
   // New-format builds (SavedBuildData) carry full mod/arcane objects inline in
   // buildData, so we skip the ~1.35MB mods-all.json + arcanes-all.json fetches.
-  // Only legacy BuildState-shape builds need the catalogs for uniqueName lookup.
+  // Only legacy BuildState-shape builds need the catalogs for uniqueName lookup
+  // and image refresh (older wfcd hashed-slug filenames now 404 on the CDN).
   if (isLegacyBuildData(props.build.buildData)) {
     return <BuildViewerBodyWithCatalog {...props} />
   }
-  return <BuildViewerBodyInner {...props} allMods={[]} allArcanes={[]} />
+  return (
+    <BuildViewerBodyInner
+      {...props}
+      allMods={[]}
+      allArcanes={[]}
+      helminthAbilities={[]}
+    />
+  )
 }
 
 function BuildViewerBodyWithCatalog(props: {
@@ -254,11 +263,13 @@ function BuildViewerBodyWithCatalog(props: {
 }) {
   const { data: allArcanes } = useSuspenseQuery(arcanesQuery)
   const { data: allMods } = useSuspenseQuery(modsQuery)
+  const { data: helminthAbilities } = useSuspenseQuery(helminthQuery)
   return (
     <BuildViewerBodyInner
       {...props}
       allMods={allMods}
       allArcanes={allArcanes}
+      helminthAbilities={helminthAbilities}
     />
   )
 }
@@ -269,6 +280,7 @@ function BuildViewerBodyInner({
   itemSlug,
   allMods,
   allArcanes,
+  helminthAbilities,
   embed,
 }: {
   build: BuildDetail
@@ -276,13 +288,20 @@ function BuildViewerBodyInner({
   itemSlug: string
   allMods: Mod[]
   allArcanes: Arcane[]
+  helminthAbilities: HelminthAbility[]
   embed: boolean
 }) {
   const { data: item } = useSuspenseQuery(itemQuery(category, itemSlug))
 
   const saved = useMemo(
-    () => normalizeBuildData(build.buildData, allMods, allArcanes),
-    [build.buildData, allMods, allArcanes],
+    () =>
+      normalizeBuildData(
+        build.buildData,
+        allMods,
+        allArcanes,
+        helminthAbilities,
+      ),
+    [build.buildData, allMods, allArcanes, helminthAbilities],
   )
 
   const categoryLabel =

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -76,6 +76,7 @@ import { arcanesQuery } from "@/lib/arcanes-query"
 import { authClient } from "@/lib/auth-client"
 import {
   buildStateToSavedData,
+  normalizeBuildData,
   savedDataToBuildState,
 } from "@/lib/build-codec-adapter"
 import { buildQuery, type SavedBuildData } from "@/lib/build-query"
@@ -177,6 +178,7 @@ function EditorShell() {
   })
   const { data: allMods } = useSuspenseQuery(modsQuery)
   const { data: allArcanes } = useSuspenseQuery(arcanesQuery)
+  const { data: helminthAbilities } = useSuspenseQuery(helminthQuery)
   const [draft] = useState(() => consumeDraft(draftId))
   const [shareHydrated] = useState(() => {
     if (!shareEncoded) return null
@@ -184,13 +186,25 @@ function EditorShell() {
     if (!decoded) return null
     return buildStateToSavedData(decoded, allMods, allArcanes)
   })
-  const savedData: SavedBuildData = draft
-    ? draft.data
-    : existingBuild
-      ? (existingBuild.buildData as SavedBuildData)
-      : shareHydrated
-        ? shareHydrated.data
-        : ({} as SavedBuildData)
+  const savedData: SavedBuildData = useMemo(() => {
+    if (draft) return draft.data
+    if (existingBuild)
+      return normalizeBuildData(
+        existingBuild.buildData,
+        allMods,
+        allArcanes,
+        helminthAbilities,
+      )
+    if (shareHydrated) return shareHydrated.data
+    return {} as SavedBuildData
+  }, [
+    draft,
+    existingBuild,
+    shareHydrated,
+    allMods,
+    allArcanes,
+    helminthAbilities,
+  ])
 
   const categoryLabel =
     CATEGORIES.find((c) => c.id === category)?.label ?? category
@@ -532,7 +546,7 @@ function EditorShell() {
       normalInnates,
       hasReactor,
       category,
-      item.maxLevelCap,
+      item,
     ],
   )
 
@@ -930,7 +944,7 @@ function SearchPanel({
       return [createSyntheticRiven(), ...mods]
     }
     return mods
-  }, [allMods, item.type, item.category, item.name, category, helminth])
+  }, [allMods, item, category, helminth])
 
   return (
     <ModSearchGrid


### PR DESCRIPTION
## Summary

Older builds were saved when `@wfcd/items` shipped content-hashed image filenames (e.g. `roar-e206197372.png`, `sprint-boost-794bd62f5f.jpg`). The newer package uses canonical names (`RhinoRadialBlast.png`, `PlayerSprintBuff.jpg`) and the upstream CDN no longer maps the old hashed slugs, so they 404 on every saved row touched before the rename — Roar's subsumed-ability tile, mod thumbnails, arcanes.

Two-part fix:

1. **One-shot backfill** (`apps/api/scripts/backfill-image-names.ts`) — reads the four static JSON catalogs under `apps/web/public/data/` and rewrites `Build.itemImageName` + every nested `imageName` inside `Build.buildData` JSON via `uniqueName` lookup. Handles legacy (`auraSlots`/`normalSlots`/`exilusSlot`/`arcaneSlots`/`helminthAbility`) and modern (`slots`/`arcanes`/`helminth`) shapes. Idempotent. Dry-run by default; `--apply` to write. Already run once against prod (19 builds, 220 imageName rewrites).
2. **Client-side belt** (`apps/web/src/lib/build-codec-adapter.ts`) — `refreshHelminthImage` re-resolves the helminth ability's `imageName` from current static data on every render of the build view. Mods/arcanes are already refreshed by `toEditorPlacedMod` upstream, so we only need this for helminth (which `buildStateToSavedData` copies verbatim). Self-heals any future drift between deploys without a re-run of the backfill.

Re-run the backfill after future `bun run build:items` if wfcd renames anything again.

## Test plan

- [x] Dry-run backfill against Neon — confirmed 19/19 builds touched, 220 imageName rewrites
- [x] `--apply` against prod — broken Roar / Hornet Strike thumbnails now load
- [ ] Open an old build URL in browser → confirm subsumed ability + mod images render
- [ ] Open the build editor on an old build → confirm same
- [ ] Modern (post-rename) builds unaffected