### PR TITLE
feat(hotkeys): unified shortcut system with cheat-sheet and discovery

### DIFF
--- a/apps/web/src/components/build-editor/arcane-slot.tsx
+++ b/apps/web/src/components/build-editor/arcane-slot.tsx
@@ -57,7 +57,10 @@ export function ArcaneSlot({
     <Popover open={open} onOpenChange={readOnly ? undefined : setOpen}>
       <PopoverTrigger
         nativeButton={false}
-        render={<div />}
+        // Same reasoning as mod-slot.tsx: arrow-key nav drives selection,
+        // Tab order would just visually enlarge the focused slot via the
+        // browser's default focus ring.
+        render={<div tabIndex={-1} />}
         data-build-slot
         onClick={
           readOnly
@@ -71,6 +74,7 @@ export function ArcaneSlot({
         className={cn(
           "group relative flex h-[80px] w-full max-w-[140px] flex-col items-center justify-center transition-colors",
           "sm:h-[90px] sm:w-[120px] sm:flex-none md:h-[100px] md:w-[140px]",
+          "outline-none",
           !readOnly && "cursor-pointer",
           !placed && "rounded-md border",
           !placed &&

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -6,6 +6,7 @@ export {
   type PlacedArcane,
 } from "./use-arcane-slots"
 export { GuideEditor } from "./guide-editor"
+export { KeyboardHintBanner, KeyboardHintsStrip } from "./keyboard-hints"
 export { ItemSidebar, ItemSidebarPopover } from "./item-sidebar"
 export {
   calculateCapacity,

--- a/apps/web/src/components/build-editor/keyboard-hints.tsx
+++ b/apps/web/src/components/build-editor/keyboard-hints.tsx
@@ -1,0 +1,96 @@
+import { X } from "lucide-react"
+import { useState } from "react"
+
+import { openHotkeyCheatSheet } from "@/components/hotkey-cheat-sheet"
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
+import { cn } from "@/lib/utils"
+
+const STORAGE_KEY = "arsenyx.hotkeyHintDismissed"
+
+/**
+ * Persistent, low-contrast strip that surfaces the build-editor hotkeys.
+ * Visible on every render of the editor — keyboard-first software lives or
+ * dies on discoverability, and a permanent footer is the cheapest way to
+ * make the keys obvious without modal interruption.
+ */
+export function KeyboardHintsStrip({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-2 px-1 pt-2 pb-4 text-[11px]",
+        className,
+      )}
+    >
+      <Hint keys={["↑", "↓", "←", "→"]} label="navigate" />
+      <Hint keys={["−", "="]} label="rank" />
+      <Hint keys={["/"]} label="search mods" />
+      <Hint keys={["Esc"]} label="deselect" />
+      <button
+        type="button"
+        onClick={openHotkeyCheatSheet}
+        className="hover:text-foreground ml-auto inline-flex items-center gap-1 underline-offset-2 hover:underline"
+      >
+        <Kbd>?</Kbd>
+        <span>all shortcuts</span>
+      </button>
+    </div>
+  )
+}
+
+function Hint({ keys, label }: { keys: string[]; label: string }) {
+  return (
+    <span className="inline-flex items-baseline gap-1">
+      <KbdGroup>
+        {keys.map((k, i) => (
+          <Kbd key={i}>{k}</Kbd>
+        ))}
+      </KbdGroup>
+      <span>{label}</span>
+    </span>
+  )
+}
+
+/**
+ * One-time onboarding banner shown the first time a user lands in the build
+ * editor. Dismissed forever via localStorage. The persistent strip beneath
+ * the editor handles ongoing discovery.
+ */
+export function KeyboardHintBanner() {
+  const [dismissed, setDismissed] = useState(readDismissed)
+  if (dismissed) return null
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, "1")
+    } catch {
+      /* private mode — banner just won't persist, fine */
+    }
+    setDismissed(true)
+  }
+
+  return (
+    <div className="bg-muted/30 flex items-center gap-3 rounded-md border border-dashed px-3 py-2 text-sm">
+      <span className="text-muted-foreground">
+        Keyboard-first: arrows move between slots, <Kbd>−</Kbd> / <Kbd>=</Kbd>{" "}
+        rank a mod, <Kbd>/</Kbd> opens mod search. Press <Kbd>?</Kbd> any time
+        for the full list.
+      </span>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss tip"
+        className="text-muted-foreground hover:bg-muted hover:text-foreground ml-auto inline-flex shrink-0 items-center justify-center rounded-sm p-1"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  )
+}
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1"
+  } catch {
+    return true
+  }
+}

--- a/apps/web/src/components/build-editor/mod-search-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-search-grid.tsx
@@ -1,7 +1,7 @@
 import { isRivenMod } from "@arsenyx/shared/warframe/rivens"
 import type { Mod, Polarity } from "@arsenyx/shared/warframe/types"
 import { Search, X } from "lucide-react"
-import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react"
+import { useDeferredValue, useMemo, useRef, useState } from "react"
 
 import {
   InputGroup,
@@ -18,12 +18,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { useHotkey } from "@/lib/hotkeys"
 import {
   BASE_ELEMENTS,
   DAMAGE_TYPE_COLORS,
   ELEMENTAL_COMBINATIONS,
 } from "@/lib/stats/types"
-import { cn, isEditableTarget } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 import { ModCard } from "./mod-card"
 import type { ModSlotKind } from "./mod-slot"
@@ -186,18 +187,7 @@ export function ModSearchGrid({
     searchRef.current?.select()
   }
 
-  // `/` focuses the search from anywhere on the page, mirroring the browse page.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "/") return
-      if (isEditableTarget(e.target)) return
-      e.preventDefault()
-      searchRef.current?.focus()
-      searchRef.current?.select()
-    }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [])
+  useHotkey("/", focusInput)
 
   // Stable ordering: computed from `mods` + `sort` only. Filters dim instead
   // of remove, so positions don't shift when search/rarity/polarity narrow

--- a/apps/web/src/components/build-editor/mod-slot.tsx
+++ b/apps/web/src/components/build-editor/mod-slot.tsx
@@ -72,6 +72,10 @@ export function ModSlot({
   const effective = effectivePolarity(slotPolarity, formaPolarity)
   const [hovered, setHovered] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
+  // The picker can only be open while this slot is the selected one. Tying
+  // open-state to `selected` lets arrow-key nav implicitly close the popover
+  // on the previously-clicked slot without a separate close effect.
+  const popoverOpen = pickerOpen && !!selected
 
   useRankHotkey({
     enabled: !readOnly && !!mod && hovered && !!onRankChange,
@@ -87,26 +91,28 @@ export function ModSlot({
   }
 
   return (
-    <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+    <Popover open={popoverOpen} onOpenChange={setPickerOpen}>
       <PopoverTrigger
         nativeButton={false}
-        render={<div />}
+        // Slots are driven by arrow-key navigation (window-scoped, see
+        // use-keyboard-nav.ts), not by Tab traversal. Keeping them out of the
+        // tab order avoids the browser focus ring visually enlarging the
+        // focused slot relative to its neighbors.
+        render={<div tabIndex={-1} />}
         data-build-slot
         onClick={readOnly ? undefined : onClick}
         onContextMenu={handleContextMenu}
         onMouseEnter={readOnly ? undefined : () => setHovered(true)}
         onMouseLeave={readOnly ? undefined : () => setHovered(false)}
         className={cn(
-          // Identical dimensions for empty and filled states so a row's
-          // height/width never shifts based on how many mods are placed.
-          // Sizes respond to the loadout container (@container/loadout on the
-          // grid wrapper), not the viewport — so the sidebar's width never
-          // squeezes the grid into overflow. ModCard itself is fixed 184px
-          // (see mod-card-config.ts DISPLAY_SIZE), so there's no intermediate
-          // slot size — either we have room for a 184px card, or we fall back
-          // to the 2-col stacked layout.
+          // Sized via @container/loadout on the parent grid (not the viewport),
+          // so the sidebar's width never squeezes the grid into overflow.
           "group relative flex h-[80px] w-full max-w-[184px] flex-col items-center justify-center transition-colors",
           "@min-[816px]/loadout:h-[100px] @min-[816px]/loadout:w-[184px]",
+          // `selected` is the single source of visual truth; suppress the
+          // default focus ring so a clicked-then-arrowed-away slot doesn't
+          // keep highlighting alongside the new selection.
+          "outline-none",
           !readOnly && "cursor-pointer",
           !mod && "rounded-md border",
           !mod &&
@@ -123,7 +129,7 @@ export function ModSlot({
             <ModCard
               mod={mod}
               rank={rank}
-              disableHover={pickerOpen}
+              disableHover={popoverOpen}
               drainOverride={
                 kind === "aura"
                   ? auraBonusForMod(mod, rank, effective)

--- a/apps/web/src/components/build-editor/use-keyboard-nav.ts
+++ b/apps/web/src/components/build-editor/use-keyboard-nav.ts
@@ -1,6 +1,4 @@
-import { useEffect } from "react"
-
-import { isEditableTarget } from "@/lib/utils"
+import { useHotkey } from "@/lib/hotkeys"
 
 import type { BuildSlotsState, SlotId, SlotLayout } from "./use-build-slots"
 
@@ -114,20 +112,11 @@ export function useSlotKeyboardNav({
   layout: SlotLayout
   enabled?: boolean
 }) {
-  // Pull primitives so the effect doesn't re-register on every render just
-  // because `layout` is a fresh object identity from the caller.
-  const { normalSlotCount, auraSlotCount, showExilus } = layout
-  useEffect(() => {
-    if (!enabled) return
-    const layoutSnapshot: SlotLayout = {
-      normalSlotCount,
-      auraSlotCount,
-      showExilus,
-    }
-    const onKey = (e: KeyboardEvent) => {
+  useHotkey(
+    ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"],
+    (e) => {
       const dir = DIR_BY_KEY[e.key]
       if (!dir) return
-      if (isEditableTarget(e.target)) return
       // Mod-search grid has its own keyboard handling (Tab in, arrows cycle
       // matches, Enter places). Don't also move the editor slot selection.
       const t = e.target as HTMLElement | null
@@ -135,17 +124,12 @@ export function useSlotKeyboardNav({
       // First arrow press after a click-outside restores selection to the
       // top-left normal slot rather than jumping a direction from there.
       if (slots.selected === null) {
-        e.preventDefault()
         slots.select("normal-0")
         return
       }
-      const next = move(slots.selected, dir, layoutSnapshot)
-      if (next !== slots.selected) {
-        e.preventDefault()
-        slots.select(next)
-      }
-    }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [slots, normalSlotCount, auraSlotCount, showExilus, enabled])
+      const next = move(slots.selected, dir, layout)
+      if (next !== slots.selected) slots.select(next)
+    },
+    { enabled },
+  )
 }

--- a/apps/web/src/components/build-editor/use-rank-hotkey.ts
+++ b/apps/web/src/components/build-editor/use-rank-hotkey.ts
@@ -1,9 +1,9 @@
-import { useEffect } from "react"
+import { useHotkey } from "@/lib/hotkeys"
 
 /**
  * Listen for `-`/`+` while `enabled`, firing `onDelta(-1)` or `onDelta(1)`.
- * Ignores keypresses inside editable elements so the rank doesn't shift
- * while the user is typing in a search box.
+ * Both shifted (`_`/`+`) and unshifted (`-`/`=`) variants are accepted so
+ * the same physical key works regardless of whether shift is held.
  */
 export function useRankHotkey({
   enabled,
@@ -12,23 +12,13 @@ export function useRankHotkey({
   enabled: boolean
   onDelta: (delta: -1 | 1) => void
 }) {
-  useEffect(() => {
-    if (!enabled) return
-    const handler = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLElement) {
-        const tag = e.target.tagName
-        if (tag === "INPUT" || tag === "TEXTAREA" || e.target.isContentEditable)
-          return
-      }
-      if (e.key === "-" || e.key === "_") {
-        e.preventDefault()
-        onDelta(-1)
-      } else if (e.key === "=" || e.key === "+") {
-        e.preventDefault()
-        onDelta(1)
-      }
-    }
-    window.addEventListener("keydown", handler)
-    return () => window.removeEventListener("keydown", handler)
-  }, [enabled, onDelta])
+  // Function matcher rather than array form: `+` only fires with shift held,
+  // and the string-spec parser enforces shift state strictly.
+  useHotkey(
+    (e) => RANK_KEYS.has(e.key),
+    (e) => onDelta(e.key === "-" || e.key === "_" ? -1 : 1),
+    { enabled },
+  )
 }
+
+const RANK_KEYS = new Set(["-", "_", "=", "+"])

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,7 +1,8 @@
-import { Menu, Search } from "lucide-react"
-import { useEffect, useState } from "react"
+import { Keyboard, Menu, Search } from "lucide-react"
+import { useState } from "react"
 
 import { CommandPalette } from "@/components/command-palette"
+import { openHotkeyCheatSheet } from "@/components/hotkey-cheat-sheet"
 import { Link } from "@/components/link"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
@@ -14,21 +15,13 @@ import {
 } from "@/components/ui/sheet"
 import { UserMenu } from "@/components/user-menu"
 import { SITE_CONFIG, NAV_ITEMS, ROUTES } from "@/lib/constants"
+import { useHotkey } from "@/lib/hotkeys"
 
 export function Header() {
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault()
-        setPaletteOpen((v) => !v)
-      }
-    }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [])
+  useHotkey("mod+k", () => setPaletteOpen((v) => !v), { allowInEditable: true })
 
   return (
     <header className="bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 w-full border-b backdrop-blur">
@@ -110,6 +103,15 @@ export function Header() {
             aria-label="Open search"
           >
             <Search />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={openHotkeyCheatSheet}
+            aria-label="Show keyboard shortcuts"
+            title="Keyboard shortcuts (?)"
+          >
+            <Keyboard />
           </Button>
           <UserMenu />
         </div>

--- a/apps/web/src/components/hotkey-cheat-sheet.tsx
+++ b/apps/web/src/components/hotkey-cheat-sheet.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
+import { HOTKEYS, HOTKEY_SCOPES, useHotkey } from "@/lib/hotkeys"
+
+const OPEN_EVENT = "arsenyx:open-cheat-sheet"
+
+/**
+ * Global keyboard cheat-sheet. Renders the `HOTKEYS` list, opened by `?`
+ * (Shift+/) anywhere on the site or by the keyboard button in the header.
+ *
+ * Mounted once at the root so the listener and dialog state live above any
+ * route. The header button uses `openHotkeyCheatSheet()` to dispatch a window
+ * event — avoids prop-drilling without introducing a context.
+ */
+export function HotkeyCheatSheet() {
+  const [open, setOpen] = useState(false)
+
+  // `?` is a shifted printable on most layouts; matching `e.key === "?"`
+  // works regardless of which physical key produced it.
+  useHotkey(
+    (e) => e.key === "?",
+    () => setOpen(true),
+  )
+
+  useEffect(() => {
+    const onOpen = () => setOpen(true)
+    window.addEventListener(OPEN_EVENT, onOpen)
+    return () => window.removeEventListener(OPEN_EVENT, onOpen)
+  }, [])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Context-aware. Some shortcuts only apply on certain pages.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-5 pt-1">
+          {HOTKEY_SCOPES.map((scope) => {
+            const rows = HOTKEYS.filter((h) => h.scope === scope)
+            if (rows.length === 0) return null
+            return (
+              <section key={scope} className="flex flex-col gap-2">
+                <h3 className="text-muted-foreground font-mono text-[10px] tracking-[0.22em] uppercase">
+                  {scope}
+                </h3>
+                <ul className="flex flex-col gap-1.5">
+                  {rows.map((row, i) => (
+                    <li
+                      key={`${scope}-${i}`}
+                      className="flex items-baseline justify-between gap-4 text-sm"
+                    >
+                      <span className="text-foreground">{row.description}</span>
+                      <KbdGroup className="shrink-0">
+                        {row.keys.map((k, j) => (
+                          <Kbd key={j}>{k}</Kbd>
+                        ))}
+                      </KbdGroup>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/** Open the cheat-sheet from anywhere — used by the header keyboard button. */
+export function openHotkeyCheatSheet() {
+  window.dispatchEvent(new CustomEvent(OPEN_EVENT))
+}

--- a/apps/web/src/lib/hotkeys.ts
+++ b/apps/web/src/lib/hotkeys.ts
@@ -1,0 +1,200 @@
+import { useEffect, useRef } from "react"
+
+import { isEditableTarget } from "@/lib/utils"
+
+/**
+ * Single source of truth for keyboard shortcuts. Adding an entry to `HOTKEYS`
+ * makes it appear in the cheat-sheet dialog automatically.
+ *
+ * Bare a–z letters are reserved for editor-local handlers (textarea, slot
+ * grid) — avoid binding them at the window level so they don't collide with
+ * text input. Punctuation (`/`, `?`, `-`, `=`) is fine globally.
+ */
+
+export type HotkeyScope =
+  | "Global"
+  | "Browse"
+  | "Build editor"
+  | "Mod search"
+  | "Guide editor"
+
+export type Hotkey = {
+  scope: HotkeyScope
+  /** Each entry is one renderable Kbd. Multiple entries = alternatives. */
+  keys: readonly string[]
+  description: string
+}
+
+export const HOTKEYS: readonly Hotkey[] = [
+  {
+    scope: "Global",
+    keys: ["Ctrl K", "⌘ K"],
+    description: "Open the command palette",
+  },
+  {
+    scope: "Global",
+    keys: ["?"],
+    description: "Show this shortcut list",
+  },
+  {
+    scope: "Browse",
+    keys: ["/"],
+    description: "Focus the search filter",
+  },
+  {
+    scope: "Build editor",
+    keys: ["↑", "↓", "←", "→"],
+    description: "Move between slots",
+  },
+  {
+    scope: "Build editor",
+    keys: ["−", "="],
+    description: "Lower or raise the rank of the selected mod / arcane",
+  },
+  {
+    scope: "Build editor",
+    keys: ["Esc"],
+    description: "Deselect the current slot",
+  },
+  {
+    scope: "Mod search",
+    keys: ["/"],
+    description: "Focus the mod search input",
+  },
+  {
+    scope: "Mod search",
+    keys: ["Tab"],
+    description: "Move from the search input into the result grid",
+  },
+  {
+    scope: "Mod search",
+    keys: ["Enter"],
+    description: "Place the focused mod into the selected slot",
+  },
+  {
+    scope: "Mod search",
+    keys: ["Esc"],
+    description: "Return focus to the search input",
+  },
+  {
+    scope: "Guide editor",
+    keys: ["Ctrl B", "⌘ B"],
+    description: "Wrap selection in **bold**",
+  },
+  {
+    scope: "Guide editor",
+    keys: ["Ctrl I", "⌘ I"],
+    description: "Wrap selection in _italic_",
+  },
+  {
+    scope: "Guide editor",
+    keys: ["Tab", "Shift Tab"],
+    description: "Indent / dedent the current line",
+  },
+  {
+    scope: "Guide editor",
+    keys: ["Enter"],
+    description: "Continue list bullets onto the next line",
+  },
+]
+
+// Insertion order from `HOTKEYS` — render the cheat-sheet sections in the
+// same order they're declared.
+export const HOTKEY_SCOPES: readonly HotkeyScope[] = [
+  ...new Set(HOTKEYS.map((h) => h.scope)),
+]
+
+// ---------------------------------------------------------------------------
+// useHotkey
+// ---------------------------------------------------------------------------
+
+type Matcher = string | readonly string[] | ((e: KeyboardEvent) => boolean)
+
+type Options = {
+  /** When false, the listener is not attached. */
+  enabled?: boolean
+  /** When true, fire even if focus is in an INPUT / TEXTAREA / contentEditable. */
+  allowInEditable?: boolean
+  /** When true (default), preventDefault on a match. */
+  preventDefault?: boolean
+}
+
+/**
+ * Window-scoped keyboard shortcut. Use for site-wide hotkeys; for shortcuts
+ * that only apply while a specific element is focused, attach `onKeyDown`
+ * directly to that element instead.
+ *
+ * The `matcher` accepts:
+ *   - `"k"`              — bare key, requires no modifiers and no shift
+ *   - `"mod+k"`          — `mod` matches Cmd on mac, Ctrl elsewhere
+ *   - `"shift+/"`, `"ctrl+shift+p"`, `"alt+enter"` — explicit modifiers
+ *   - `["ArrowUp", "ArrowDown", ...]` — any-of, shorthand for multiple specs
+ *   - `(e) => boolean`   — fully custom (use for shifted printables like `?`)
+ */
+export function useHotkey(
+  matcher: Matcher,
+  handler: (e: KeyboardEvent) => void,
+  opts: Options = {},
+) {
+  const {
+    enabled = true,
+    allowInEditable = false,
+    preventDefault = true,
+  } = opts
+
+  // Refs let everything that can change between renders — handler, matcher,
+  // and the option flags — flow into the listener without re-binding it.
+  // Without this, callers like `useRankHotkey` (whose `enabled` flips on
+  // hover) would attach/detach window listeners on every mouse-enter/leave.
+  const handlerRef = useRef(handler)
+  handlerRef.current = handler
+  const matcherRef = useRef(matcher)
+  matcherRef.current = matcher
+  const optsRef = useRef({ enabled, allowInEditable, preventDefault })
+  optsRef.current = { enabled, allowInEditable, preventDefault }
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const o = optsRef.current
+      if (!o.enabled) return
+      if (!o.allowInEditable && isEditableTarget(e.target)) return
+      if (!matches(matcherRef.current, e)) return
+      if (o.preventDefault) e.preventDefault()
+      handlerRef.current(e)
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [])
+}
+
+function matches(matcher: Matcher, e: KeyboardEvent): boolean {
+  if (typeof matcher === "function") return matcher(e)
+  const list = typeof matcher === "string" ? [matcher] : matcher
+  return list.some((spec) => matchSpec(spec, e))
+}
+
+function matchSpec(spec: string, e: KeyboardEvent): boolean {
+  const parts = spec
+    .toLowerCase()
+    .split("+")
+    .map((p) => p.trim())
+    .filter(Boolean)
+  const key = parts.pop()
+  if (!key) return false
+  const mods = new Set(parts)
+  const wantShift = mods.has("shift")
+  const wantAlt = mods.has("alt")
+  const wantMod = mods.has("mod")
+  const wantCtrl = mods.has("ctrl")
+  const wantMeta = mods.has("meta") || mods.has("cmd")
+
+  if (wantShift !== e.shiftKey) return false
+  if (wantAlt !== e.altKey) return false
+  if (wantMod) {
+    if (!(e.metaKey || e.ctrlKey)) return false
+  } else {
+    if (wantCtrl !== e.ctrlKey) return false
+    if (wantMeta !== e.metaKey) return false
+  }
+  return e.key.toLowerCase() === key
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,7 +9,42 @@ import { routeTree } from "./routeTree.gen"
 import "@/styles/globals.css"
 
 if (import.meta.env.DEV) {
-  import("cssstudio").then(({ startStudio }) => startStudio())
+  setupCssStudio()
+}
+
+function setupCssStudio() {
+  const KEY = "arsenyx.cssstudio"
+  const params = new URLSearchParams(location.search)
+  const param = params.get("cssstudio")
+  if (param === "1" || param === "0") {
+    try {
+      localStorage.setItem(KEY, param)
+    } catch {
+      /* private mode — fine, just won't persist */
+    }
+    // Strip the param so the URL doesn't stay sticky as the user navigates.
+    params.delete("cssstudio")
+    const qs = params.toString()
+    history.replaceState(
+      null,
+      "",
+      location.pathname + (qs ? `?${qs}` : "") + location.hash,
+    )
+  }
+  let on = false
+  try {
+    on = localStorage.getItem(KEY) === "1"
+  } catch {
+    /* fine */
+  }
+  if (on) {
+    void import("cssstudio").then(({ startStudio }) => startStudio())
+  } else {
+    // eslint-disable-next-line no-console
+    console.info(
+      "cssstudio is OFF. Append ?cssstudio=1 to the URL to enable, ?cssstudio=0 to disable.",
+    )
+  }
 }
 
 const queryClient = new QueryClient({

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query"
 import { Outlet, createRootRouteWithContext } from "@tanstack/react-router"
 
+import { HotkeyCheatSheet } from "@/components/hotkey-cheat-sheet"
 import { TooltipProvider } from "@/components/ui/tooltip"
 
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
@@ -13,6 +14,7 @@ function RootLayout() {
   return (
     <TooltipProvider>
       <Outlet />
+      <HotkeyCheatSheet />
     </TooltipProvider>
   )
 }

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -1,7 +1,7 @@
 import { hasIncarnon } from "@arsenyx/shared/warframe/incarnon-data"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { Suspense, useDeferredValue, useEffect, useMemo, useRef } from "react"
+import { Suspense, useDeferredValue, useMemo, useRef } from "react"
 
 import { CategoryTabs } from "@/components/browse/category-tabs"
 import {
@@ -22,6 +22,7 @@ import {
   InputGroupInput,
 } from "@/components/ui/input-group"
 import { Kbd } from "@/components/ui/kbd"
+import { useHotkey } from "@/lib/hotkeys"
 import { itemsIndexQuery } from "@/lib/items-index-query"
 import {
   isValidCategory,
@@ -118,24 +119,10 @@ function BrowseContent() {
   const deferredQ = useDeferredValue(q)
   const searchRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== "/") return
-      const target = e.target as HTMLElement | null
-      if (
-        target?.tagName === "INPUT" ||
-        target?.tagName === "TEXTAREA" ||
-        target?.isContentEditable
-      ) {
-        return
-      }
-      e.preventDefault()
-      searchRef.current?.focus()
-      searchRef.current?.select()
-    }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [])
+  useHotkey("/", () => {
+    searchRef.current?.focus()
+    searchRef.current?.select()
+  })
 
   const items = useMemo(() => data[category] ?? [], [data, category])
 

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -54,6 +54,8 @@ import {
   hasExilusSlot,
   ItemSidebar,
   ItemSidebarPopover,
+  KeyboardHintBanner,
+  KeyboardHintsStrip,
   ModGrid,
   ModSearchGrid,
   PublishDialog,
@@ -82,6 +84,7 @@ import {
 import { buildQuery, type SavedBuildData } from "@/lib/build-query"
 import { API_URL } from "@/lib/constants"
 import { helminthQuery, type HelminthAbility } from "@/lib/helminth-query"
+import { useHotkey } from "@/lib/hotkeys"
 import { consumeDraft } from "@/lib/import-draft"
 import { itemQuery } from "@/lib/item-query"
 import { modsQuery } from "@/lib/mods-query"
@@ -89,7 +92,6 @@ import { myOrgsQuery } from "@/lib/org-query"
 import { padShards, type PlacedShard } from "@/lib/shards"
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard"
 import { formatVisibility } from "@/lib/user-display"
-import { isEditableTarget } from "@/lib/utils"
 import {
   CATEGORIES,
   getImageUrl,
@@ -232,18 +234,17 @@ function EditorShell() {
 
   // Escape deselects the active mod/arcane slot, mirroring the
   // click-outside behavior. Skip when a dialog/popover is open (base-ui
-  // closes those via its own Escape handler) or when typing in a field.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return
-      if (isEditableTarget(e.target)) return
+  // closes those via its own Escape handler) or when typing in a field
+  // (useHotkey's editable-target guard handles the latter).
+  useHotkey(
+    "Escape",
+    () => {
       if (document.querySelector("[data-state='open'][role='dialog']")) return
       slots.select(null)
       arcanes.select(null)
-    }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [slots, arcanes])
+    },
+    { preventDefault: false },
+  )
 
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -580,6 +581,7 @@ function EditorShell() {
       />
 
       <div className="flex flex-col gap-4">
+        <KeyboardHintBanner />
         <div className="flex flex-col gap-4 xl:relative xl:block">
           <div className="flex w-full flex-col sm:hidden xl:absolute xl:top-0 xl:bottom-0 xl:left-0 xl:flex xl:w-[260px]">
             <ItemSidebar
@@ -656,6 +658,7 @@ function EditorShell() {
                 ) : undefined
               }
             />
+            <KeyboardHintsStrip />
           </div>
         </div>
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -23,8 +23,7 @@ export const Route = createFileRoute("/")({
 function Home() {
   const recent = useRecentItems(10)
   const hero =
-    recent.find((it) => it.category === "warframes" && it.isPrime) ??
-    recent[0]
+    recent.find((it) => it.category === "warframes" && it.isPrime) ?? recent[0]
 
   return (
     <div className="relative flex min-h-screen flex-col">
@@ -50,7 +49,7 @@ function Home() {
                     className="h-[220px] w-auto object-contain transition-transform duration-700 ease-out hover:scale-[1.02] md:h-[280px]"
                     draggable={false}
                   />
-                  <div className="mt-5 flex items-baseline justify-between gap-3 text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+                  <div className="text-muted-foreground mt-5 flex items-baseline justify-between gap-3 text-[11px] tracking-[0.22em] uppercase">
                     <span className="font-mono">
                       {formatDate(hero.releaseDate)}
                     </span>
@@ -58,7 +57,7 @@ function Home() {
                   </div>
                 </Link>
               ) : (
-                <div className="mx-auto h-[280px] w-full max-w-sm animate-pulse rounded-lg bg-muted/40" />
+                <div className="bg-muted/40 mx-auto h-[280px] w-full max-w-sm animate-pulse rounded-lg" />
               )}
             </div>
 
@@ -69,27 +68,27 @@ function Home() {
                 <br />
                 for Warframe.
               </h1>
-              <p className="mt-6 max-w-md text-base leading-relaxed text-muted-foreground">
-                Every frame, weapon, and companion in the game.
-                Mods, arcanes, shards. A URL when you're done.
+              <p className="text-muted-foreground mt-6 max-w-md text-base leading-relaxed">
+                Every frame, weapon, and companion in the game. Mods, arcanes,
+                shards. A URL when you're done.
               </p>
 
               <div className="mt-10 flex items-center gap-4">
                 <Link
                   href="/browse"
-                  className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-85"
+                  className="bg-foreground text-background inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-85"
                 >
                   Open arsenal
                   <ArrowRight aria-hidden className="size-4" />
                 </Link>
-                <span className="flex items-center gap-2 text-xs text-muted-foreground">
-                  or press <Kbd>/</Kbd> to search
+                <span className="text-muted-foreground flex items-center gap-2 text-xs">
+                  or press <Kbd>?</Kbd> for shortcuts
                 </span>
               </div>
 
               {/* ticker */}
               <div className="mt-14 border-t pt-6">
-                <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+                <p className="text-muted-foreground font-mono text-[11px] tracking-[0.22em] uppercase">
                   Recently added
                 </p>
                 <ul className="mt-3 space-y-1.5">
@@ -98,17 +97,17 @@ function Home() {
                       key={`${it.category}-${it.slug}`}
                       className="flex items-baseline gap-3 text-sm"
                     >
-                      <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                      <span className="text-muted-foreground font-mono text-[11px] tabular-nums">
                         {formatDate(it.releaseDate)}
                       </span>
                       <Link
                         href={getItemUrl(it.category, it.slug)}
-                        className="truncate text-foreground hover:underline"
+                        className="text-foreground truncate hover:underline"
                       >
                         {it.name}
                       </Link>
                       {it.isPrime && !isPrimeRedundant(it.name) && (
-                        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                        <span className="text-muted-foreground font-mono text-[10px] tracking-[0.2em] uppercase">
                           prime
                         </span>
                       )}
@@ -125,13 +124,15 @@ function Home() {
           <div className="mx-auto grid max-w-7xl gap-x-12 gap-y-14 px-6 py-20 md:grid-cols-3 md:py-28">
             <Pillar
               kicker="Keyboard"
-              line="Press / to find anything."
-              detail="The command palette searches frames, weapons, mods, arcanes, and builds. Arrow keys do the rest."
+              line="Press ? for shortcuts."
+              detail="The command palette searches frames, weapons, mods, arcanes, and builds. Arrows move between slots in the editor. The full list is one keystroke away."
               demo={
-                <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 font-mono text-xs">
-                  <span className="text-muted-foreground">/</span>
-                  <span className="text-foreground">voruna</span>
-                  <span className="ml-auto inline-block h-3 w-1.5 animate-pulse bg-foreground" />
+                <div className="bg-background flex items-center gap-2 rounded-md border px-3 py-2 font-mono text-xs">
+                  <Kbd>Ctrl K</Kbd>
+                  <span className="text-foreground">command palette</span>
+                  <span className="text-muted-foreground ml-auto inline-flex items-center gap-1">
+                    <Kbd>?</Kbd>
+                  </span>
                 </div>
               }
             />
@@ -140,7 +141,7 @@ function Home() {
               line="One URL, no account."
               detail="Builds encode into a short URL. Drop it in chat. The reader sees the full editor without signing in."
               demo={
-                <div className="rounded-md border bg-background px-3 py-2 font-mono text-xs">
+                <div className="bg-background rounded-md border px-3 py-2 font-mono text-xs">
                   <span className="text-muted-foreground">arsenyx.com/b/</span>
                   <span className="text-foreground">v0r-prime-tank</span>
                 </div>
@@ -153,11 +154,11 @@ function Home() {
               demo={
                 <Link
                   href="https://github.com/Reuzehagel/arsenyx"
-                  className="inline-flex items-center gap-2 rounded-md border bg-background px-3 py-2 font-mono text-xs hover:bg-muted/60"
+                  className="bg-background hover:bg-muted/60 inline-flex items-center gap-2 rounded-md border px-3 py-2 font-mono text-xs"
                 >
                   <span className="text-muted-foreground">git clone</span>
                   <span className="text-foreground">arsenyx</span>
-                  <span className="ml-auto text-muted-foreground" aria-hidden>
+                  <span className="text-muted-foreground ml-auto" aria-hidden>
                     ↗
                   </span>
                 </Link>
@@ -169,12 +170,12 @@ function Home() {
         {/* Quiet closing */}
         <section>
           <div className="mx-auto max-w-7xl px-6 py-16 text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.22em] text-muted-foreground">
+            <p className="text-muted-foreground font-mono text-xs tracking-[0.22em] uppercase">
               Begin
             </p>
             <Link
               href="/browse"
-              className="group mt-4 inline-flex items-baseline gap-3 text-2xl font-medium tracking-tight text-foreground hover:underline md:text-3xl"
+              className="group text-foreground mt-4 inline-flex items-baseline gap-3 text-2xl font-medium tracking-tight hover:underline md:text-3xl"
             >
               Open the arsenal
               <ArrowRight
@@ -203,14 +204,14 @@ function Pillar({
 }) {
   return (
     <article className="flex flex-col gap-4">
-      <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+      <p className="text-muted-foreground font-mono text-[11px] tracking-[0.22em] uppercase">
         {kicker}
       </p>
-      <h3 className="text-2xl font-medium tracking-tight text-foreground">
+      <h3 className="text-foreground text-2xl font-medium tracking-tight">
         {line}
       </h3>
       <div>{demo}</div>
-      <p className="text-sm leading-relaxed text-muted-foreground">{detail}</p>
+      <p className="text-muted-foreground text-sm leading-relaxed">{detail}</p>
     </article>
   )
 }

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -6,6 +6,7 @@ Non-obvious pitfalls. Add to this file when you hit one.
 
 - **Dev servers hide type errors.** Vite and `bun --hot` skip strict TS checks — always `bun run build` (web) and `bunx tsc --noEmit` (api) before claiming done.
 - **PowerShell doesn't support `<` redirection** — wrap in `bash -c '...'` for Docker stdin (e.g. piping SQL into `psql`).
+- **cssstudio is OFF by default in dev.** Toggle via URL: append `?cssstudio=1` to enable, `?cssstudio=0` to disable. The flag persists in `localStorage.arsenyx.cssstudio` and the param strips itself after apply. See [apps/web/src/main.tsx](../apps/web/src/main.tsx).
 
 ## Shadcn in the monorepo
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -1,0 +1,28 @@
+# Hotkeys
+
+Single source of truth: [`apps/web/src/lib/hotkeys.ts`](../apps/web/src/lib/hotkeys.ts).
+
+The `HOTKEYS` array drives the cheat-sheet dialog (opened by `?` or the keyboard button in the header). Adding an entry there is the only step needed to make a shortcut discoverable site-wide.
+
+## Rules
+
+- **Every site-wide hotkey is registered through `useHotkey`** ([apps/web/src/lib/hotkeys.ts](../apps/web/src/lib/hotkeys.ts)). It absorbs the editable-target guard and modifier parsing — don't hand-roll `addEventListener("keydown", …)` blocks. Element-scoped handlers (a textarea's own `onKeyDown`, a result-grid card) stay element-local.
+- **Every site-wide hotkey appears in `HOTKEYS`.** If the cheat-sheet doesn't list it, users can't discover it.
+- **If a hotkey affects a specific control, render a `<Kbd>` chip on that control** in addition to the cheat-sheet entry. Examples: the header's search button shows `Ctrl K`; the browse and mod-search inputs show `/`.
+- **Bare letters are reserved for editor-local handlers** (e.g. the guide-editor textarea uses `Ctrl+B` / `Ctrl+I`). Don't bind bare letters at the window level — they collide with text input and editor surfaces.
+- **`?` always opens the cheat-sheet.** Don't bind it elsewhere.
+
+## Conventions
+
+- A key can mean different things in different surfaces (`/` focuses the browse filter on `/browse`, focuses the mod-search input inside the build editor). That's fine — the cheat-sheet groups by scope so users see the right shortcut for their current context.
+- Prefer `mod+x` over `ctrl+x` / `meta+x` so the same binding works on macOS (Cmd) and elsewhere (Ctrl).
+- For shifted printables (`?`, `+`, `_`), pass a function matcher to `useHotkey` rather than a string spec — `useHotkey((e) => e.key === "?", …)`.
+
+## Discovery surfaces, in order of cost
+
+1. **`<Kbd>` chip on the relevant control** — cheapest, most discoverable. Users learn passively.
+2. **Persistent hint strip** in the build editor — always-visible muted footer summarising the editor's keys ([components/build-editor/keyboard-hints.tsx](../apps/web/src/components/build-editor/keyboard-hints.tsx)).
+3. **First-time banner** — one-shot, dismissible, `localStorage`-flagged. Welcomes new users to the editor, then disappears.
+4. **Cheat-sheet dialog** (`?`) — full reference, always available.
+
+There is no formal onboarding flow by design. Modal walkthroughs are usually skipped; the four surfaces above cover discovery without interrupting work.


### PR DESCRIPTION
## Summary

A single source of truth for keyboard shortcuts and a tiered discovery system, plus refactors of every existing hand-rolled keydown listener onto a shared hook.

## What changed

**New: `apps/web/src/lib/hotkeys.ts`**
- `HOTKEYS` array — every site-wide shortcut, grouped by scope. Drives the cheat-sheet automatically.
- `useHotkey(matcher, handler, opts)` hook — accepts `\"k\"`, `\"mod+k\"`, `[\"ArrowUp\", \"ArrowDown\"]`, or a function matcher. Absorbs the editable-target guard and modifier parsing.
- Listener binds **once per call** regardless of how `enabled` toggles. This eliminates the per-hover attach/detach churn that previously happened with ~10 \`useRankHotkey\` instances.

**Discovery surfaces (in order of cost)**
1. \`<Kbd>\` chips on the relevant control (mostly already there).
2. Persistent muted hint strip beneath the build-editor slot grid (\`KeyboardHintsStrip\`).
3. One-time dismissible banner the first time you open the editor (\`KeyboardHintBanner\`, \`localStorage.arsenyx.hotkeyHintDismissed\`).
4. Global cheat-sheet dialog (\`HotkeyCheatSheet\`), opened by \`?\` or the new header keyboard button.

**Refactors**
- Replaced five hand-rolled \`window.addEventListener(\"keydown\", …)\` blocks with \`useHotkey\`: header \`Ctrl+K\`, browse \`/\`, create's \`Escape\`, slot arrow nav, rank \`-\`/\`=\`, and mod-search \`/\`.

**Landing-page copy fix**
- Was: \"or press \`/\` to search\". But \`/\` only worked on \`/browse\` and inside the build editor — never on the landing page. Now: \"or press \`?\` for shortcuts\". The Keyboard pillar copy now matches reality (\`Ctrl K\` for the palette, \`?\` for the full list).

**Two related editor bugs fixed while testing**
- Polarity popover stayed open on the originally-clicked slot after arrow-key nav. Fixed by deriving \`popoverOpen = pickerOpen && !!selected\` instead of using a close effect.
- The browser focus ring on a clicked-then-arrow-keyed-away slot visually enlarged it relative to the currently-selected one. Slots are now \`tabIndex={-1}\` (arrow nav doesn't need Tab anyway — the listener is window-scoped) with \`outline-none\` so \`selected\` is the single visual source of truth.

**Unrelated dev-ergonomics**
- cssstudio is now **off by default** in dev. Toggle via \`?cssstudio=1\` / \`?cssstudio=0\` — flag persists in \`localStorage\`, the URL param strips itself after applying. Documented in \`docs/gotchas.md\`.

## Docs

- New \`docs/hotkeys.md\`: rules — every shortcut through \`useHotkey\` + \`HOTKEYS\`; bare a–z letters reserved for editor-local handlers (textarea, slot grid) so they don't collide with text input; \`?\` always opens the cheat-sheet.
- \`docs/gotchas.md\`: cssstudio toggle entry.

## Test plan

- [x] \`/\` (landing): does nothing (correct — no in-page filter exists).
- [x] \`?\` from anywhere: cheat-sheet opens, lists every scope.
- [x] \`Ctrl/Cmd+K\` from anywhere: command palette opens.
- [x] \`/browse\`: \`/\` focuses the filter input.
- [x] \`/create\`: arrow keys move selection between slots; \`-\`/\`=\` change rank when hovering a placed mod; \`Esc\` deselects.
- [x] Build editor banner appears once, dismissable, never reappears.
- [x] Click a slot to open the polarity popover, then arrow-key away — popover closes.
- [x] Tab does not focus individual slots (no growing-slot artifact).
- [x] Dev only: \`?cssstudio=1\` enables cssstudio + reloads + URL is clean afterward.