### PR TITLE
feat(security): allow profit-taker.com to embed the site

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -2,7 +2,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  X-Frame-Options: DENY
+  Content-Security-Policy: frame-ancestors 'self' https://profit-taker.com https://testing.profit-taker.com
   Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 /index.html


### PR DESCRIPTION
## Summary

- Replaces `X-Frame-Options: DENY` with `Content-Security-Policy: frame-ancestors` directive
- Allows embedding on `https://profit-taker.com` and `https://testing.profit-taker.com`
- All other origins remain blocked (`'self'` only)

## Test plan

- [ ] Verify the site loads correctly in an iframe on profit-taker.com
- [ ] Verify the site is still blocked in iframes on unrelated origins
- [ ] Confirm no CSP report errors after deploy