### PR TITLE
fix(deployment-toggle): pass items prop so SelectValue renders the label

### DIFF
--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -91,6 +91,11 @@ import { ZawComponentSelector } from "./zaw-component-selector"
 
 const SHARD_SLOTS = 5
 
+const DEPLOYMENT_ITEMS: { value: DeploymentContext; label: string }[] = [
+  { value: "atmospheric", label: "Atmospheric" },
+  { value: "archwing", label: "Archwing" },
+]
+
 function itemHasWeaponData(item: DetailItem): boolean {
   if (item.totalDamage !== undefined) return true
   const attacks = (item as { attacks?: unknown[] }).attacks
@@ -430,6 +435,7 @@ export function ItemSidebar({
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">Deployment</span>
                 <Select
+                  items={DEPLOYMENT_ITEMS}
                   value={effectiveDeploymentContext}
                   onValueChange={(v) =>
                     onSetDeploymentContext?.(v as DeploymentContext)
@@ -441,8 +447,11 @@ export function ItemSidebar({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectGroup>
-                      <SelectItem value="atmospheric">Atmospheric</SelectItem>
-                      <SelectItem value="archwing">Archwing</SelectItem>
+                      {DEPLOYMENT_ITEMS.map((it) => (
+                        <SelectItem key={it.value} value={it.value}>
+                          {it.label}
+                        </SelectItem>
+                      ))}
                     </SelectGroup>
                   </SelectContent>
                 </Select>


### PR DESCRIPTION
## Summary

Follow-up to #88. The deployment toggle was rendering the raw value (`atmospheric`) in the trigger instead of the label (`Atmospheric`).

## Cause

Base UI `<Select>` needs `items={[{ value, label }]}` on the root for `<SelectValue />` to render the label for the current value. Without it, `SelectValue` falls back to showing the raw value string. This is documented in [docs/gotchas.md](https://github.com/reuzehagel/arsenyx/blob/main/docs/gotchas.md#base-ui-shadcn-underneath) and matches the wiring of every other `<Select>` in the app (`LichBonusElementPicker`, `BuildsSortDropdown`, `FilterSelect`).

## Change

- Added module-level `DEPLOYMENT_ITEMS` array in `item-sidebar.tsx`
- Passed `items={DEPLOYMENT_ITEMS}` to `<Select>` and used `.map()` for the `<SelectItem>` children, mirroring the existing `LichBonusElementPicker` pattern in the same file

## Test plan

- [ ] Open `/create/archwing/corvas` (or `/create/archwing/corvas-prime`)
- [ ] Verify the Deployment dropdown trigger shows **Atmospheric** (capitalized label), not `atmospheric`
- [ ] Switch to Archwing, verify the trigger updates to **Archwing**
- [ ] Verify weapon damage updates accordingly when the toggle changes (Corvas should regain Heat in Archwing mode)

https://claude.ai/code/session_01RKtxTP42WSwirf16MeAkYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKtxTP42WSwirf16MeAkYe)_