### PR TITLE
fix(zaw-selector): prevent right-edge paint flicker on hover

### DIFF
--- a/apps/web/src/components/build-editor/zaw-component-selector.tsx
+++ b/apps/web/src/components/build-editor/zaw-component-selector.tsx
@@ -79,7 +79,7 @@ function ZawPartCard({
         "bg-card/80 relative flex flex-col items-center overflow-hidden rounded-md select-none",
         "h-[90px] w-[100px]",
         !readOnly &&
-          "hover:ring-primary/50 cursor-pointer transition-shadow hover:ring-1",
+          "ring-1 ring-transparent cursor-pointer transition-[box-shadow,color] hover:ring-primary/50",
         open && "ring-primary ring-offset-background ring-2 ring-offset-1",
       )}
     >


### PR DESCRIPTION
## Summary

Fixes a visual flicker where the right edge of the hover ring on Zaw component cards (Grip / Link) briefly fails to paint when the cursor first enters the card.

## Cause

The card has `overflow-hidden rounded-md`, and the hover state transitioned from **no** box-shadow to a 1px Tailwind `ring` on `:hover`. When the shadow first appears, Chrome allocates a new paint layer for the rounded-clipped element — and the right edge drops one frame on that allocation.

## Fix

Pre-allocate the ring with `ring-1 ring-transparent` so the box-shadow always exists and the paint layer is sized correctly from the start. Only the ring color animates on hover (`transition-[box-shadow,color]`).

## Test plan
- [x] Open a build with a Zaw weapon, hover the Grip / Link cards from various directions, confirm the orange ring appears cleanly on all four edges with no right-edge flicker.
- [x] Click a card, confirm the open-state ring (`ring-2 ring-offset-1`) still renders correctly.
- [x] Read-only builds (shared links) still render the cards without any hover affordance.