### PR TITLE
Redesign item detail page and overhaul list/skeleton UX

### DIFF
--- a/apps/api/src/routes/_build-list.ts
+++ b/apps/api/src/routes/_build-list.ts
@@ -135,9 +135,11 @@ export function serializeListRow(b: ListRow) {
 
 export type ListFilters = {
   page: number
+  limit: number
   sort: ListSort | undefined
   q: string | undefined
   category: string | undefined
+  item: string | undefined
   hasGuide: boolean
   hasShards: boolean
 }
@@ -157,9 +159,16 @@ export function parseListQuery(c: {
   const q = qRaw && qRaw.length > 0 ? qRaw.slice(0, 200) : undefined
   const catRaw = c.req.query("category")
   const category = catRaw && isValidCategory(catRaw) ? catRaw : undefined
+  const itemRaw = c.req.query("item")?.trim()
+  const item = itemRaw && itemRaw.length > 0 ? itemRaw.slice(0, 200) : undefined
+  const limitRaw = parseInt(c.req.query("limit") ?? "", 10)
+  const limit =
+    Number.isFinite(limitRaw) && limitRaw > 0
+      ? Math.min(limitRaw, LIST_LIMIT)
+      : LIST_LIMIT
   const hasGuide = c.req.query("hasGuide") === "1"
   const hasShards = c.req.query("hasShards") === "1"
-  return { page, sort, q, category, hasGuide, hasShards }
+  return { page, limit, sort, q, category, item, hasGuide, hasShards }
 }
 
 function orderByForSort(sort: ListSort) {
@@ -204,6 +213,7 @@ function tiebreakerSql(sort: ListSort) {
 async function searchBuildIds(params: {
   q: string
   category: string | undefined
+  item: string | undefined
   hasGuide: boolean
   hasShards: boolean
   baseFilter: Prisma.Sql
@@ -211,11 +221,39 @@ async function searchBuildIds(params: {
   skip: number
   take: number
 }): Promise<{ ids: string[]; total: number }> {
-  const { q, category, hasGuide, hasShards, baseFilter, sort, skip, take } =
-    params
-  const query = Prisma.sql`websearch_to_tsquery('english', ${q})`
+  const {
+    q,
+    category,
+    item,
+    hasGuide,
+    hasShards,
+    baseFilter,
+    sort,
+    skip,
+    take,
+  } = params
+  const tokens = q.toLowerCase().match(/[a-z0-9]+/g) ?? []
+  if (tokens.length === 0) {
+    return { ids: [], total: 0 }
+  }
+  const tsqueryStr = tokens.map((t) => `${t}:*`).join(" & ")
+  const query = Prisma.sql`to_tsquery('english', ${tsqueryStr})`
+  // ILIKE fallback only fires when searchVector is NULL (fresh dev DBs whose
+  // trigger hasn't run). In production every row has a vector, so the planner
+  // can use the GIN index on `searchVector` without an unindexed OR branch.
+  const ilikeMatch = Prisma.sql`(${Prisma.join(
+    tokens.map(
+      (t) =>
+        Prisma.sql`("name" ILIKE ${`%${t}%`} OR "itemName" ILIKE ${`%${t}%`} OR "description" ILIKE ${`%${t}%`})`,
+    ),
+    " AND ",
+  )})`
+  const matchFilter = Prisma.sql`("searchVector" @@ ${query} OR ("searchVector" IS NULL AND ${ilikeMatch}))`
   const categoryFilter = category
     ? Prisma.sql`AND "itemCategory" = ${category}`
+    : Prisma.empty
+  const itemFilter = item
+    ? Prisma.sql`AND "itemUniqueName" = ${item}`
     : Prisma.empty
   const guideFilter = hasGuide
     ? Prisma.sql`AND "hasGuide" = true`
@@ -229,20 +267,22 @@ async function searchBuildIds(params: {
     prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
       SELECT id
       FROM builds
-      WHERE "searchVector" @@ ${query}
+      WHERE ${matchFilter}
         AND ${baseFilter}
         ${categoryFilter}
+        ${itemFilter}
         ${guideFilter}
         ${shardsFilter}
-      ORDER BY ts_rank("searchVector", ${query}) DESC, ${tiebreaker}
+      ORDER BY ts_rank(COALESCE("searchVector", ''::tsvector), ${query}) DESC, ${tiebreaker}
       LIMIT ${take} OFFSET ${skip}
     `),
     prisma.$queryRaw<{ n: number }[]>(Prisma.sql`
       SELECT COUNT(*)::int AS n
       FROM builds
-      WHERE "searchVector" @@ ${query}
+      WHERE ${matchFilter}
         AND ${baseFilter}
         ${categoryFilter}
+        ${itemFilter}
         ${guideFilter}
         ${shardsFilter}
     `),
@@ -261,12 +301,13 @@ export async function runList({
   baseFilter: Prisma.Sql
   defaultSort: ListSort
 }) {
-  const { page, q, category, hasGuide, hasShards } = filters
+  const { page, limit, q, category, item, hasGuide, hasShards } = filters
   const sort: ListSort = filters.sort ?? defaultSort
-  const skip = (page - 1) * LIST_LIMIT
+  const skip = (page - 1) * limit
 
   const where: Record<string, unknown> = { ...baseWhere }
   if (category) where.itemCategory = category
+  if (item) where.itemUniqueName = item
   if (hasGuide) where.hasGuide = true
   if (hasShards) where.hasShards = true
 
@@ -274,15 +315,16 @@ export async function runList({
     const { ids, total } = await searchBuildIds({
       q,
       category,
+      item,
       hasGuide,
       hasShards,
       baseFilter,
       sort,
       skip,
-      take: LIST_LIMIT,
+      take: limit,
     })
     if (ids.length === 0) {
-      return { builds: [], total, page, limit: LIST_LIMIT }
+      return { builds: [], total, page, limit }
     }
     const rows = await prisma.build.findMany({
       where: { id: { in: ids } },
@@ -296,7 +338,7 @@ export async function runList({
       builds: ordered.map(serializeListRow),
       total,
       page,
-      limit: LIST_LIMIT,
+      limit,
     }
   }
 
@@ -305,7 +347,7 @@ export async function runList({
       where,
       orderBy: orderByForSort(sort),
       skip,
-      take: LIST_LIMIT,
+      take: limit,
       select: LIST_SELECT,
     }),
     prisma.build.count({ where }),
@@ -315,6 +357,6 @@ export async function runList({
     builds: rows.map(serializeListRow),
     total,
     page,
-    limit: LIST_LIMIT,
+    limit,
   }
 }

--- a/apps/api/src/routes/_build-list.ts
+++ b/apps/api/src/routes/_build-list.ts
@@ -232,7 +232,11 @@ async function searchBuildIds(params: {
     skip,
     take,
   } = params
-  const tokens = q.toLowerCase().match(/[a-z0-9]+/g) ?? []
+  // Cap at 8 tokens × 64 chars to bound query work on pathological input.
+  // `[a-z0-9]+` already strips punctuation that would break to_tsquery syntax.
+  const tokens = (q.toLowerCase().match(/[a-z0-9]+/g) ?? [])
+    .slice(0, 8)
+    .map((t) => t.slice(0, 64))
   if (tokens.length === 0) {
     return { ids: [], total: 0 }
   }

--- a/apps/web/src/components/browse/category-tabs.tsx
+++ b/apps/web/src/components/browse/category-tabs.tsx
@@ -2,9 +2,11 @@ import { TabScroller } from "@/components/tab-scroller"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CATEGORIES, type BrowseCategory } from "@/lib/warframe"
 
+type BrowseFilter = BrowseCategory | "all"
+
 interface CategoryTabsProps {
-  activeCategory: BrowseCategory
-  onChange: (category: BrowseCategory) => void
+  activeCategory: BrowseFilter
+  onChange: (category: BrowseFilter) => void
 }
 
 export function CategoryTabs({ activeCategory, onChange }: CategoryTabsProps) {
@@ -12,9 +14,10 @@ export function CategoryTabs({ activeCategory, onChange }: CategoryTabsProps) {
     <TabScroller activeKey={activeCategory}>
       <Tabs
         value={activeCategory}
-        onValueChange={(v) => onChange(v as BrowseCategory)}
+        onValueChange={(v) => onChange(v as BrowseFilter)}
       >
         <TabsList>
+          <TabsTrigger value="all">All</TabsTrigger>
           {CATEGORIES.map((c) => (
             <TabsTrigger key={c.id} value={c.id}>
               {c.label}

--- a/apps/web/src/components/browse/item-card.tsx
+++ b/apps/web/src/components/browse/item-card.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@/components/link"
 import { Badge } from "@/components/ui/badge"
 import { Card } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 import { getImageUrl, getItemUrl, type BrowseItem } from "@/lib/warframe"
 
@@ -14,7 +15,7 @@ export function ItemCard({ item, index }: ItemCardProps) {
     <Link
       href={getItemUrl(item.category, item.slug)}
       data-index={index}
-      className="group focus-visible:ring-ring rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      className="group focus-visible:ring-ring rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-offset-2 [content-visibility:auto] [contain-intrinsic-size:auto_280px]"
     >
       <Card className="hover:border-primary/50 group-focus-visible:border-primary/50 relative h-full gap-0 overflow-hidden py-0 transition-[box-shadow,border-color] duration-200 hover:shadow-md">
         {item.vaulted && (
@@ -53,5 +54,20 @@ export function ItemCard({ item, index }: ItemCardProps) {
         </div>
       </Card>
     </Link>
+  )
+}
+
+export function ItemCardSkeleton() {
+  return (
+    <Card className="relative h-full gap-0 overflow-hidden py-0">
+      <Skeleton className="aspect-square w-full rounded-none" />
+      <div className="flex flex-col gap-1 p-3">
+        <Skeleton className="h-[1rem] w-3/4" />
+        <div className="flex items-center justify-between pt-0.5">
+          <Skeleton className="h-3 w-1/2" />
+          <Skeleton className="h-3 w-10" />
+        </div>
+      </div>
+    </Card>
   )
 }

--- a/apps/web/src/components/builds/build-card.tsx
+++ b/apps/web/src/components/builds/build-card.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { Eye, Heart } from "lucide-react"
 
+import { Skeleton } from "@/components/ui/skeleton"
 import type { BuildListItem } from "@/lib/builds-list-query"
 import { relativeTime } from "@/lib/relative-time"
 import { authorName } from "@/lib/user-display"
@@ -50,5 +51,22 @@ export function BuildCard({ build }: { build: BuildListItem }) {
         </div>
       </div>
     </Link>
+  )
+}
+
+export function BuildCardSkeleton() {
+  return (
+    <div className="bg-card block overflow-hidden rounded-lg border">
+      <Skeleton className="aspect-video w-full rounded-none" />
+      <div className="flex flex-col gap-1 p-3">
+        <Skeleton className="h-[1.125rem] w-3/4" />
+        <Skeleton className="h-[0.875rem] w-1/2" />
+        <Skeleton className="h-[0.875rem] w-2/5" />
+        <div className="flex items-center justify-between pt-0.5">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-10" />
+        </div>
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/components/builds/builds-list-view.tsx
+++ b/apps/web/src/components/builds/builds-list-view.tsx
@@ -1,8 +1,8 @@
-import { useSuspenseQuery } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { Filter } from "lucide-react"
-import { useEffect, useRef, useState, type ReactNode } from "react"
+import { useEffect, useState, type ReactNode } from "react"
 
-import { BuildCard } from "@/components/builds/build-card"
+import { BuildCard, BuildCardSkeleton } from "@/components/builds/build-card"
 import { BuildsCategoryTabs } from "@/components/builds/builds-category-tabs"
 import { BuildsSortDropdown } from "@/components/builds/builds-sort-dropdown"
 import { Badge } from "@/components/ui/badge"
@@ -18,8 +18,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
-import { publicBuildsQuery, type BuildListSort } from "@/lib/builds-list-query"
+import {
+  LIST_PAGE_SIZE,
+  publicBuildsQuery,
+  type BuildListSort,
+} from "@/lib/builds-list-query"
+import { cn } from "@/lib/utils"
 import { isValidCategory, type BrowseCategory } from "@/lib/warframe"
 
 import { SORT_VALUES } from "./builds-sort-dropdown"
@@ -103,6 +109,9 @@ export function nextBuildsListSearch(
 
 const SEARCH_DEBOUNCE_MS = 200
 
+export const BUILDS_GRID_CLASS =
+  "grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+
 export function BuildsListView({
   title,
   description,
@@ -130,21 +139,15 @@ export function BuildsListView({
   emptyState: ReactNode
   showFilters: boolean
 }) {
-  const { data } = useSuspenseQuery(query)
-  const totalPages = Math.max(1, Math.ceil(data.total / data.limit))
-
   const [qLocal, setQLocal] = useState(q)
   useEffect(() => setQLocal(q), [q])
-
-  const latest = useRef({ sort, category, onUpdateSearch })
-  latest.current = { sort, category, onUpdateSearch }
 
   useEffect(() => {
     if (qLocal === q) return
     const t = setTimeout(() => {
-      latest.current.onUpdateSearch({
-        sort: latest.current.sort,
-        category: latest.current.category,
+      onUpdateSearch({
+        sort,
+        category,
         q: qLocal || undefined,
         page: undefined,
         hasGuide: hasGuide || undefined,
@@ -152,7 +155,7 @@ export function BuildsListView({
       })
     }, SEARCH_DEBOUNCE_MS)
     return () => clearTimeout(t)
-  }, [qLocal, q, hasGuide, hasShards])
+  }, [qLocal, q, sort, category, hasGuide, hasShards, onUpdateSearch])
 
   const activeFilterCount = (hasGuide ? 1 : 0) + (hasShards ? 1 : 0)
 
@@ -264,6 +267,50 @@ export function BuildsListView({
         />
       ) : null}
 
+      <Results
+        query={query}
+        page={page}
+        q={q}
+        sort={sort}
+        category={category}
+        hasGuide={hasGuide}
+        hasShards={hasShards}
+        onUpdateSearch={onUpdateSearch}
+        emptyState={emptyState}
+      />
+    </div>
+  )
+}
+
+function Results({
+  query,
+  page,
+  q,
+  sort,
+  category,
+  hasGuide,
+  hasShards,
+  onUpdateSearch,
+  emptyState,
+}: {
+  query: BuildsQuery
+  page: number
+  q: string
+  sort: BuildListSort
+  category: BrowseCategory | undefined
+  hasGuide: boolean
+  hasShards: boolean
+  onUpdateSearch: (next: BuildsListSearch) => void
+  emptyState: ReactNode
+}) {
+  const { data, isPending, isFetching } = useQuery(query)
+
+  if (isPending || !data) return <ResultsSkeleton />
+
+  const totalPages = Math.max(1, Math.ceil(data.total / data.limit))
+
+  return (
+    <>
       <div className="text-muted-foreground text-sm">
         {data.total} {data.total === 1 ? "build" : "builds"}
         {q ? ` matching "${q}"` : ""}
@@ -272,7 +319,14 @@ export function BuildsListView({
       {data.builds.length === 0 ? (
         <div className="py-16 text-center">{emptyState}</div>
       ) : (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        <div
+          aria-busy={isFetching}
+          className={cn(
+            BUILDS_GRID_CLASS,
+            "transition-opacity",
+            isFetching && "opacity-60",
+          )}
+        >
           {data.builds.map((b) => (
             <BuildCard key={b.id} build={b} />
           ))}
@@ -322,6 +376,65 @@ export function BuildsListView({
           ) : null}
         </div>
       ) : null}
+    </>
+  )
+}
+
+function ResultsSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="flex flex-col gap-6"
+    >
+      <span className="sr-only">Loading builds…</span>
+      <Skeleton className="h-4 w-32" />
+      <div className={BUILDS_GRID_CLASS}>
+        {Array.from({ length: LIST_PAGE_SIZE }).map((_, i) => (
+          <BuildCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** Full-page builds list skeleton (chrome + results). */
+export function BuildsListSkeleton({
+  showFilters = true,
+  showHeader = true,
+}: {
+  showFilters?: boolean
+  showHeader?: boolean
+}) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="flex flex-col gap-6"
+    >
+      <span className="sr-only">Loading builds…</span>
+      {showHeader && (
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-9 w-64" />
+          <Skeleton className="h-5 w-80" />
+        </div>
+      )}
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <Skeleton className="h-9 flex-1" />
+        <div className="flex gap-3">
+          <Skeleton className="h-9 w-32" />
+          {showFilters && <Skeleton className="h-9 w-24" />}
+        </div>
+      </div>
+      {showFilters && <Skeleton className="h-8 w-full max-w-md" />}
+      <Skeleton className="h-4 w-32" />
+      <div className={BUILDS_GRID_CLASS}>
+        {Array.from({ length: LIST_PAGE_SIZE }).map((_, i) => (
+          <BuildCardSkeleton key={i} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import {
-  Book,
   Compass,
   Hammer,
   LayoutGrid,
@@ -27,9 +26,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { authClient } from "@/lib/auth-client"
-import { publicBuildsQuery, type BuildListItem } from "@/lib/builds-list-query"
 import { itemsIndexQuery } from "@/lib/items-index-query"
-import { authorName } from "@/lib/user-display"
 import { CATEGORIES, getImageUrl, type BrowseItem } from "@/lib/warframe"
 
 const SEARCH_DEBOUNCE_MS = 200
@@ -64,14 +61,6 @@ export function CommandPalette({
   }, [query, open])
 
   const { data: items } = useQuery({ ...itemsIndexQuery, enabled: open })
-  const builds = useQuery({
-    ...publicBuildsQuery({
-      page: 1,
-      sort: "newest",
-      q: debouncedQuery,
-    }),
-    enabled: open && debouncedQuery.length > 0,
-  })
 
   const allItems = useMemo<ItemEntry[]>(() => {
     if (!items) return []
@@ -97,8 +86,6 @@ export function CommandPalette({
     fn()
   }
 
-  const hasBuildResults = (builds.data?.builds.length ?? 0) > 0
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -107,20 +94,16 @@ export function CommandPalette({
       >
         <DialogTitle className="sr-only">Search</DialogTitle>
         <DialogDescription className="sr-only">
-          Jump to items, builds, or pages.
+          Jump to items or pages.
         </DialogDescription>
         <Command shouldFilter={false}>
           <CommandInput
-            placeholder="Search items, builds, or pages…"
+            placeholder="Search items or pages…"
             value={query}
             onValueChange={setQuery}
           />
           <CommandList>
-            <CommandEmpty>
-              {builds.isFetching && debouncedQuery.length > 0
-                ? "Searching…"
-                : "No results."}
-            </CommandEmpty>
+            <CommandEmpty>No results.</CommandEmpty>
 
             {!debouncedQuery && (
               <>
@@ -208,28 +191,6 @@ export function CommandPalette({
               </CommandGroup>
             ) : null}
 
-            {debouncedQuery && hasBuildResults ? (
-              <>
-                {filteredItems.length > 0 ? <CommandSeparator /> : null}
-                <CommandGroup heading="Builds">
-                  {builds.data!.builds.slice(0, 8).map((b) => (
-                    <BuildRow
-                      key={b.id}
-                      build={b}
-                      onSelect={() =>
-                        go(() =>
-                          navigate({
-                            to: "/builds/$slug",
-                            params: { slug: b.slug },
-                          }),
-                        )
-                      }
-                    />
-                  ))}
-                </CommandGroup>
-              </>
-            ) : null}
-
             {debouncedQuery ? (
               <>
                 <CommandSeparator />
@@ -278,28 +239,6 @@ function ItemRow({
       />
       <span>{item.name}</span>
       <CommandShortcut>{item.categoryLabel}</CommandShortcut>
-    </CommandItem>
-  )
-}
-
-function BuildRow({
-  build,
-  onSelect,
-}: {
-  build: BuildListItem
-  onSelect: () => void
-}) {
-  return (
-    <CommandItem
-      value={`build:${build.slug}`}
-      keywords={[build.name, build.item.name, authorName(build.user, "")]}
-      onSelect={onSelect}
-    >
-      <Book />
-      <span className="truncate">{build.name}</span>
-      <CommandShortcut>
-        {build.item.name} · {authorName(build.user, "—")}
-      </CommandShortcut>
     </CommandItem>
   )
 }

--- a/apps/web/src/components/delayed-fallback.tsx
+++ b/apps/web/src/components/delayed-fallback.tsx
@@ -1,0 +1,40 @@
+import { Suspense, useEffect, useState, type ReactNode } from "react"
+
+/**
+ * Hold rendering for `delayMs` before showing children. Prevents skeleton
+ * flash when a Suspense boundary resolves from cache in <200ms — the user
+ * sees nothing instead of a loading state that immediately disappears.
+ */
+export function DelayedFallback({
+  delayMs = 200,
+  children,
+}: {
+  delayMs?: number
+  children: ReactNode
+}) {
+  const [show, setShow] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setShow(true), delayMs)
+    return () => clearTimeout(t)
+  }, [delayMs])
+  return show ? <>{children}</> : null
+}
+
+/** `<Suspense>` whose fallback is gated by `<DelayedFallback>`. */
+export function DelayedSuspense({
+  fallback,
+  delayMs,
+  children,
+}: {
+  fallback: ReactNode
+  delayMs?: number
+  children: ReactNode
+}) {
+  return (
+    <Suspense
+      fallback={<DelayedFallback delayMs={delayMs}>{fallback}</DelayedFallback>}
+    >
+      {children}
+    </Suspense>
+  )
+}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,5 +1,6 @@
 import { Icons } from "@/components/icons"
 import { Link } from "@/components/link"
+import { ThemeToggle } from "@/components/theme-toggle"
 import { Separator } from "@/components/ui/separator"
 import { SITE_CONFIG, FOOTER_LINKS } from "@/lib/constants"
 import type { NavLink } from "@/lib/types"
@@ -48,11 +49,13 @@ export function Footer() {
     <footer className="bg-background border-t">
       <div className="wrap py-10">
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
-          {/* Brand */}
           <div className="flex flex-col gap-4">
-            <h3 className="text-lg font-semibold tracking-tight">
-              {SITE_CONFIG.name}
-            </h3>
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-lg font-semibold tracking-tight">
+                {SITE_CONFIG.name}
+              </h3>
+              <ThemeToggle />
+            </div>
             <p className="text-muted-foreground text-sm leading-relaxed">
               {SITE_CONFIG.description}
             </p>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,7 +1,6 @@
 import { Keyboard, Menu, Search } from "lucide-react"
-import { useState } from "react"
+import { lazy, Suspense, useState } from "react"
 
-import { CommandPalette } from "@/components/command-palette"
 import { openHotkeyCheatSheet } from "@/components/hotkey-cheat-sheet"
 import { Link } from "@/components/link"
 import { Button } from "@/components/ui/button"
@@ -16,6 +15,12 @@ import {
 import { UserMenu } from "@/components/user-menu"
 import { SITE_CONFIG, NAV_ITEMS, ROUTES } from "@/lib/constants"
 import { useHotkey } from "@/lib/hotkeys"
+
+const CommandPalette = lazy(() =>
+  import("@/components/command-palette").then((m) => ({
+    default: m.CommandPalette,
+  })),
+)
 
 export function Header() {
   const [paletteOpen, setPaletteOpen] = useState(false)
@@ -116,7 +121,11 @@ export function Header() {
           <UserMenu />
         </div>
       </div>
-      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+      {paletteOpen ? (
+        <Suspense fallback={null}>
+          <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+        </Suspense>
+      ) : null}
     </header>
   )
 }

--- a/apps/web/src/components/item-detail/content.tsx
+++ b/apps/web/src/components/item-detail/content.tsx
@@ -1,0 +1,244 @@
+import { Link as RouterLink } from "@tanstack/react-router"
+import { ArrowRight } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
+  formatPct,
+  formatStat,
+  getCategoryLabel,
+  getImageUrl,
+  type BrowseCategory,
+  type DetailItem,
+} from "@/lib/warframe"
+
+import { TopBuildsSection } from "./top-builds-section"
+
+export function ItemDetailContent({
+  item,
+  category,
+  slug,
+}: {
+  item: DetailItem
+  category: BrowseCategory
+  slug: string
+}) {
+  const stats = statsFor(item, category)
+  const abilities = abilitiesFor(item, category)
+  const bg = getImageUrl(item.imageName)
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-col gap-8">
+        <div className="border-border/50 relative isolate overflow-hidden rounded-2xl border">
+          <div
+            className="absolute inset-0 -z-10 bg-cover bg-center bg-no-repeat opacity-30 blur-md"
+            style={{ backgroundImage: `url(${bg})` }}
+            aria-hidden
+          />
+          <div
+            className="from-background/90 via-background/60 to-background/30 absolute inset-0 -z-10 bg-gradient-to-r"
+            aria-hidden
+          />
+          <div className="relative flex flex-col gap-6 p-8 md:flex-row md:items-center md:gap-8 md:p-12">
+            <div className="bg-muted/40 ring-border/60 flex size-40 shrink-0 items-center justify-center self-center rounded-xl ring-1 backdrop-blur md:size-56 md:self-auto">
+              <img
+                src={bg}
+                alt={item.name}
+                fetchPriority="high"
+                decoding="async"
+                className="size-full object-contain p-3"
+              />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-3">
+              <div className="text-muted-foreground text-xs uppercase tracking-[0.2em]">
+                {getCategoryLabel(category)}
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <h1 className="text-4xl font-bold tracking-tight md:text-6xl">
+                  {item.name}
+                </h1>
+                {item.vaulted && <Badge variant="outline">Vaulted</Badge>}
+              </div>
+              {item.description && (
+                <p className="text-muted-foreground max-w-2xl text-base md:text-lg">
+                  {item.description}
+                </p>
+              )}
+              {stats.length > 0 && (
+                <div className="flex flex-wrap gap-2 pt-1">
+                  {stats.map((s) => (
+                    <StatPill key={s.label} label={s.label} value={s.value} />
+                  ))}
+                </div>
+              )}
+              {abilities.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {abilities.map((a, i) => (
+                    <Tooltip key={a.uniqueName}>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            className="bg-muted/40 border-border/40 hover:bg-muted/70 hover:border-border inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors"
+                          />
+                        }
+                      >
+                        <span className="bg-background/60 text-muted-foreground flex size-5 items-center justify-center rounded-full text-[10px] font-semibold tabular-nums">
+                          {i + 1}
+                        </span>
+                        <span className="font-medium">{a.name}</span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        <div className="font-semibold">{a.name}</div>
+                        <div className="text-muted-foreground mt-1">
+                          {a.description}
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </div>
+              )}
+              <div className="flex flex-wrap items-center gap-4 pt-2">
+                <Button
+                  size="lg"
+                  render={
+                    <RouterLink
+                      to="/create"
+                      search={{ item: slug, category }}
+                    />
+                  }
+                >
+                  Create Build
+                </Button>
+                <ItemMeta item={item} />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-baseline justify-between">
+            <h2 className="text-xl font-semibold">Top community builds</h2>
+            <RouterLink
+              to="/builds"
+              search={{ q: item.name, sort: "top" }}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm transition-colors"
+            >
+              View all
+              <ArrowRight className="size-3.5" />
+            </RouterLink>
+          </div>
+          <TopBuildsSection item={item} />
+        </section>
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function StatPill({
+  label,
+  value,
+}: {
+  label: string
+  value: string | number | undefined
+}) {
+  if (value === undefined || value === null || value === "") return null
+  const display = typeof value === "number" ? formatStat(value) : value
+  return (
+    <div className="bg-muted/40 border-border/40 inline-flex items-baseline gap-1.5 rounded-full border px-3 py-1 text-sm">
+      <span className="text-muted-foreground text-xs">{label}</span>
+      <span className="font-semibold tabular-nums">{display}</span>
+    </div>
+  )
+}
+
+function ItemMeta({ item }: { item: DetailItem }) {
+  return (
+    <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+      {item.masteryReq !== undefined && item.masteryReq > 0 && (
+        <span>
+          Mastery{" "}
+          <span className="text-foreground font-medium">
+            MR {item.masteryReq}
+          </span>
+        </span>
+      )}
+      {item.type && (
+        <span>
+          Type <span className="text-foreground font-medium">{item.type}</span>
+        </span>
+      )}
+    </div>
+  )
+}
+
+const WARFRAME_CATEGORIES = new Set<BrowseCategory>([
+  "warframes",
+  "necramechs",
+])
+const WEAPON_CATEGORIES = new Set<BrowseCategory>([
+  "primary",
+  "secondary",
+  "melee",
+  "companion-weapons",
+  "archwing",
+  "exalted-weapons",
+])
+
+type Stat = { label: string; value: string | number | undefined }
+
+function statsFor(item: DetailItem, category: BrowseCategory): Stat[] {
+  if (WARFRAME_CATEGORIES.has(category)) {
+    return [
+      { label: "Health", value: item.health },
+      { label: "Shield", value: item.shield },
+      { label: "Armor", value: item.armor },
+      { label: "Energy", value: item.power },
+      { label: "Sprint", value: item.sprintSpeed },
+    ]
+  }
+  if (WEAPON_CATEGORIES.has(category)) {
+    const rows: Stat[] = [
+      { label: "Damage", value: item.totalDamage },
+      { label: "Crit %", value: formatPct(item.criticalChance) },
+      {
+        label: "Crit x",
+        value:
+          item.criticalMultiplier !== undefined
+            ? `${item.criticalMultiplier}x`
+            : undefined,
+      },
+      { label: "Status", value: formatPct(item.procChance) },
+      {
+        label: "Fire Rate",
+        value:
+          item.fireRate !== undefined
+            ? formatStat(item.fireRate, 3)
+            : undefined,
+      },
+      { label: "Magazine", value: item.magazineSize },
+      {
+        label: "Reload",
+        value:
+          item.reloadTime !== undefined
+            ? `${formatStat(item.reloadTime)}s`
+            : undefined,
+      },
+    ]
+    if (category === "melee") rows.push({ label: "Range", value: item.range })
+    return rows
+  }
+  return []
+}
+
+function abilitiesFor(item: DetailItem, category: BrowseCategory) {
+  if (!WARFRAME_CATEGORIES.has(category)) return []
+  return item.abilities ?? []
+}

--- a/apps/web/src/components/item-detail/frame.tsx
+++ b/apps/web/src/components/item-detail/frame.tsx
@@ -1,0 +1,67 @@
+import { Link as RouterLink } from "@tanstack/react-router"
+
+import { Footer } from "@/components/footer"
+import { Header } from "@/components/header"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { Skeleton } from "@/components/ui/skeleton"
+import { getCategoryLabel, type BrowseCategory } from "@/lib/warframe"
+
+export function ItemDetailFrame({
+  category,
+  itemName,
+  children,
+}: {
+  category: BrowseCategory
+  /** Absent while the item-detail data is still loading; renders a small
+   *  skeleton in the breadcrumb's name slot. */
+  itemName?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
+        <div className="wrap flex flex-col gap-6 py-6">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  render={
+                    <RouterLink to="/browse" search={{ category: "warframes" }} />
+                  }
+                >
+                  Browse
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  render={<RouterLink to="/browse" search={{ category }} />}
+                >
+                  {getCategoryLabel(category)}
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {itemName ? (
+                  <BreadcrumbPage>{itemName}</BreadcrumbPage>
+                ) : (
+                  <Skeleton className="h-4 w-24" />
+                )}
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          {children}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/src/components/item-detail/frame.tsx
+++ b/apps/web/src/components/item-detail/frame.tsx
@@ -13,55 +13,59 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { getCategoryLabel, type BrowseCategory } from "@/lib/warframe"
 
-export function ItemDetailFrame({
+/** Page chrome (Header + main wrap + Footer). Stays mounted across the
+ *  Suspense boundary so the header doesn't unmount/remount when item data
+ *  resolves. */
+export function ItemDetailFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
+        <div className="wrap flex flex-col gap-6 py-6">{children}</div>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export function ItemDetailBreadcrumb({
   category,
   itemName,
-  children,
 }: {
   category: BrowseCategory
   /** Absent while the item-detail data is still loading; renders a small
    *  skeleton in the breadcrumb's name slot. */
   itemName?: string
-  children: React.ReactNode
 }) {
   return (
-    <div className="relative flex min-h-screen flex-col">
-      <Header />
-      <main className="flex-1">
-        <div className="wrap flex flex-col gap-6 py-6">
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbLink
-                  render={
-                    <RouterLink to="/browse" search={{ category: "warframes" }} />
-                  }
-                >
-                  Browse
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbLink
-                  render={<RouterLink to="/browse" search={{ category }} />}
-                >
-                  {getCategoryLabel(category)}
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                {itemName ? (
-                  <BreadcrumbPage>{itemName}</BreadcrumbPage>
-                ) : (
-                  <Skeleton className="h-4 w-24" />
-                )}
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
-          {children}
-        </div>
-      </main>
-      <Footer />
-    </div>
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink
+            render={
+              <RouterLink to="/browse" search={{ category: "warframes" }} />
+            }
+          >
+            Browse
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink
+            render={<RouterLink to="/browse" search={{ category }} />}
+          >
+            {getCategoryLabel(category)}
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          {itemName ? (
+            <BreadcrumbPage>{itemName}</BreadcrumbPage>
+          ) : (
+            <Skeleton className="h-4 w-24" />
+          )}
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
   )
 }

--- a/apps/web/src/components/item-detail/top-builds-section.tsx
+++ b/apps/web/src/components/item-detail/top-builds-section.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { BuildCard, BuildCardSkeleton } from "@/components/builds/build-card"
+import { publicBuildsQuery } from "@/lib/builds-list-query"
+import type { DetailItem } from "@/lib/warframe"
+
+const GRID_CLASS =
+  "grid gap-3 grid-cols-[repeat(auto-fit,minmax(190px,1fr))] [&>*]:max-w-[240px]"
+
+const TOP_BUILDS_LIMIT = 6
+
+export function TopBuildsSection({ item }: { item: DetailItem }) {
+  const { data, isLoading } = useQuery(
+    publicBuildsQuery({
+      page: 1,
+      sort: "top",
+      item: item.uniqueName,
+      limit: TOP_BUILDS_LIMIT,
+    }),
+  )
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        className={GRID_CLASS}
+      >
+        <span className="sr-only">Loading top builds…</span>
+        {Array.from({ length: TOP_BUILDS_LIMIT }).map((_, i) => (
+          <BuildCardSkeleton key={i} />
+        ))}
+      </div>
+    )
+  }
+
+  const builds = data?.builds ?? []
+
+  if (builds.length === 0) {
+    return (
+      <div className="border-border/50 bg-muted/20 flex flex-col items-center gap-2 rounded-lg border border-dashed py-12 text-center">
+        <p className="text-muted-foreground text-sm">
+          No community builds yet for {item.name}.
+        </p>
+        <p className="text-muted-foreground/70 text-xs">
+          Be the first to share one.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={GRID_CLASS}>
+      {builds.map((b) => (
+        <BuildCard key={b.id} build={b} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/lib/builds-list-query.ts
+++ b/apps/web/src/lib/builds-list-query.ts
@@ -1,6 +1,10 @@
-import { queryOptions } from "@tanstack/react-query"
+import { keepPreviousData, queryOptions } from "@tanstack/react-query"
 
 import { API_URL } from "@/lib/constants"
+
+/** Mirrors LIST_LIMIT in apps/api/src/routes/_build-list.ts. Skeleton bone
+ *  counts use this so the placeholder grid matches the loaded grid. */
+export const LIST_PAGE_SIZE = 24
 
 export type BuildListSort =
   | "newest"
@@ -14,6 +18,8 @@ export type BuildListParams = {
   sort: BuildListSort
   q?: string
   category?: string
+  item?: string
+  limit?: number
   hasGuide?: boolean
   hasShards?: boolean
 }
@@ -63,6 +69,8 @@ function buildQueryString(params: BuildListParams, defaultSort: BuildListSort) {
   if (params.sort !== defaultSort) q.set("sort", params.sort)
   if (params.q) q.set("q", params.q)
   if (params.category) q.set("category", params.category)
+  if (params.item) q.set("item", params.item)
+  if (params.limit) q.set("limit", String(params.limit))
   if (params.hasGuide) q.set("hasGuide", "1")
   if (params.hasShards) q.set("hasShards", "1")
   const str = q.toString()
@@ -80,6 +88,7 @@ export const publicBuildsQuery = (params: BuildListParams) =>
       if (!r.ok) throw new Error("failed to load builds")
       return r.json()
     },
+    placeholderData: keepPreviousData,
   })
 
 export const myBuildsQuery = (params: BuildListParams) =>
@@ -94,6 +103,7 @@ export const myBuildsQuery = (params: BuildListParams) =>
       if (!r.ok) throw new Error("failed to load builds")
       return r.json()
     },
+    placeholderData: keepPreviousData,
     retry: false,
   })
 
@@ -109,5 +119,6 @@ export const bookmarkedBuildsQuery = (params: BuildListParams) =>
       if (!r.ok) throw new Error("failed to load builds")
       return r.json()
     },
+    placeholderData: keepPreviousData,
     retry: false,
   })

--- a/apps/web/src/lib/warframe.ts
+++ b/apps/web/src/lib/warframe.ts
@@ -121,3 +121,7 @@ export const CATEGORIES: { id: BrowseCategory; label: string }[] = [
 export function isValidCategory(value: string): value is BrowseCategory {
   return CATEGORIES.some((c) => c.id === value)
 }
+
+export function getCategoryLabel(category: string): string {
+  return CATEGORIES.find((c) => c.id === category)?.label ?? category
+}

--- a/apps/web/src/routes/bookmarks.tsx
+++ b/apps/web/src/routes/bookmarks.tsx
@@ -4,7 +4,6 @@ import {
   redirect,
   useNavigate,
 } from "@tanstack/react-router"
-import { Suspense } from "react"
 
 import {
   BuildsListView,
@@ -46,24 +45,6 @@ export const Route = createFileRoute("/bookmarks")({
 })
 
 function BookmarksPage() {
-  return (
-    <div className="relative flex min-h-screen flex-col">
-      <Header />
-      <main className="flex-1">
-        <div className="wrap flex flex-col gap-6 py-6">
-          <Suspense
-            fallback={<p className="text-muted-foreground">Loading builds…</p>}
-          >
-            <BookmarksContent />
-          </Suspense>
-        </div>
-      </main>
-      <Footer />
-    </div>
-  )
-}
-
-function BookmarksContent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const page = search.page ?? 1
@@ -77,39 +58,47 @@ function BookmarksContent() {
     navigate({ search: nextBuildsListSearch(next, "newest"), replace: true })
 
   return (
-    <BuildsListView
-      title="My Bookmarks"
-      description="Builds you've bookmarked."
-      query={bookmarkedBuildsQuery({
-        page,
-        sort,
-        q,
-        category,
-        hasGuide: hasGuide || undefined,
-        hasShards: hasShards || undefined,
-      })}
-      page={page}
-      sort={sort}
-      q={q}
-      category={category}
-      hasGuide={hasGuide}
-      hasShards={hasShards}
-      onUpdateSearch={onUpdateSearch}
-      showFilters
-      emptyState={
-        <>
-          <p className="text-muted-foreground">
-            You haven't bookmarked any builds yet.
-          </p>
-          <p className="text-muted-foreground mt-2 text-sm">
-            Browse{" "}
-            <Link to="/builds" className="text-primary underline">
-              public builds
-            </Link>{" "}
-            and tap the bookmark icon to save them here.
-          </p>
-        </>
-      }
-    />
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
+        <div className="wrap flex flex-col gap-6 py-6">
+          <BuildsListView
+            title="My Bookmarks"
+            description="Builds you've bookmarked."
+            query={bookmarkedBuildsQuery({
+              page,
+              sort,
+              q,
+              category,
+              hasGuide: hasGuide || undefined,
+              hasShards: hasShards || undefined,
+            })}
+            page={page}
+            sort={sort}
+            q={q}
+            category={category}
+            hasGuide={hasGuide}
+            hasShards={hasShards}
+            onUpdateSearch={onUpdateSearch}
+            showFilters
+            emptyState={
+              <>
+                <p className="text-muted-foreground">
+                  You haven't bookmarked any builds yet.
+                </p>
+                <p className="text-muted-foreground mt-2 text-sm">
+                  Browse{" "}
+                  <Link to="/builds" className="text-primary underline">
+                    public builds
+                  </Link>{" "}
+                  and tap the bookmark icon to save them here.
+                </p>
+              </>
+            }
+          />
+        </div>
+      </main>
+      <Footer />
+    </div>
   )
 }

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -1,19 +1,20 @@
 import { hasIncarnon } from "@arsenyx/shared/warframe/incarnon-data"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { Suspense, useDeferredValue, useMemo, useRef } from "react"
+import { useDeferredValue, useMemo, useRef } from "react"
 
 import { CategoryTabs } from "@/components/browse/category-tabs"
 import {
   FilterDropdown,
   MASTERY_MAX,
 } from "@/components/browse/filter-dropdown"
-import { ItemCard } from "@/components/browse/item-card"
+import { ItemCard, ItemCardSkeleton } from "@/components/browse/item-card"
 import {
   SortDropdown,
   SORT_VALUES,
   type SortOption,
 } from "@/components/browse/sort-dropdown"
+import { DelayedSuspense } from "@/components/delayed-fallback"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import {
@@ -25,13 +26,16 @@ import { Kbd } from "@/components/ui/kbd"
 import { useHotkey } from "@/lib/hotkeys"
 import { itemsIndexQuery } from "@/lib/items-index-query"
 import {
+  CATEGORIES,
   isValidCategory,
   type BrowseCategory,
   type BrowseItem,
 } from "@/lib/warframe"
 
+type BrowseFilter = BrowseCategory | "all"
+
 type BrowseSearch = {
-  category: BrowseCategory
+  category: BrowseFilter
   q?: string
   sort?: SortOption
   mastery?: number
@@ -42,10 +46,12 @@ type BrowseSearch = {
 
 export const Route = createFileRoute("/browse")({
   validateSearch: (search: Record<string, unknown>): BrowseSearch => {
-    const category =
-      typeof search.category === "string" && isValidCategory(search.category)
-        ? search.category
-        : "warframes"
+    const category: BrowseFilter =
+      search.category === "all"
+        ? "all"
+        : typeof search.category === "string" && isValidCategory(search.category)
+          ? search.category
+          : "warframes"
     const q =
       typeof search.q === "string" && search.q.length > 0 ? search.q : undefined
     const sort =
@@ -92,14 +98,28 @@ function BrowsePage() {
               builds.
             </p>
           </div>
-          <Suspense
-            fallback={<p className="text-muted-foreground">Loading items…</p>}
-          >
+          <DelayedSuspense fallback={<BrowseSkeleton />}>
             <BrowseContent />
-          </Suspense>
+          </DelayedSuspense>
         </div>
       </main>
       <Footer />
+    </div>
+  )
+}
+
+function BrowseSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+    >
+      <span className="sr-only">Loading items…</span>
+      {Array.from({ length: 18 }).map((_, i) => (
+        <ItemCardSkeleton key={i} />
+      ))}
     </div>
   )
 }
@@ -124,7 +144,13 @@ function BrowseContent() {
     searchRef.current?.select()
   })
 
-  const items = useMemo(() => data[category] ?? [], [data, category])
+  const items = useMemo(
+    () =>
+      category === "all"
+        ? CATEGORIES.flatMap((c) => data[c.id] ?? [])
+        : (data[category] ?? []),
+    [data, category],
+  )
 
   const visible = useMemo(
     () =>
@@ -197,7 +223,7 @@ function BrowseContent() {
         activeCategory={category}
         onChange={(next) =>
           navigate({
-            search: (s) => ({ ...s, category: next, q: undefined }),
+            search: (s) => ({ ...s, category: next }),
           })
         }
       />

--- a/apps/web/src/routes/browse_.$category.$slug.tsx
+++ b/apps/web/src/routes/browse_.$category.$slug.tsx
@@ -9,7 +9,10 @@ import { DelayedSuspense } from "@/components/delayed-fallback"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { ItemDetailContent } from "@/components/item-detail/content"
-import { ItemDetailFrame } from "@/components/item-detail/frame"
+import {
+  ItemDetailBreadcrumb,
+  ItemDetailFrame,
+} from "@/components/item-detail/frame"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { itemQuery } from "@/lib/item-query"
@@ -31,15 +34,18 @@ function ItemDetailPage() {
   const { category, slug } = Route.useParams()
   const cat = category as BrowseCategory
   return (
-    <DelayedSuspense
-      fallback={
-        <ItemDetailFrame category={cat}>
-          <ItemDetailSkeleton />
-        </ItemDetailFrame>
-      }
-    >
-      <ItemDetailView category={cat} slug={slug} />
-    </DelayedSuspense>
+    <ItemDetailFrame>
+      <DelayedSuspense
+        fallback={
+          <>
+            <ItemDetailBreadcrumb category={cat} />
+            <ItemDetailSkeleton />
+          </>
+        }
+      >
+        <ItemDetailView category={cat} slug={slug} />
+      </DelayedSuspense>
+    </ItemDetailFrame>
   )
 }
 
@@ -52,9 +58,10 @@ function ItemDetailView({
 }) {
   const { data: item } = useSuspenseQuery(itemQuery(category, slug))
   return (
-    <ItemDetailFrame category={category} itemName={item.name}>
+    <>
+      <ItemDetailBreadcrumb category={category} itemName={item.name} />
       <ItemDetailContent item={item} category={category} slug={slug} />
-    </ItemDetailFrame>
+    </>
   )
 }
 

--- a/apps/web/src/routes/browse_.$category.$slug.tsx
+++ b/apps/web/src/routes/browse_.$category.$slug.tsx
@@ -4,23 +4,16 @@ import {
   notFound,
   Link as RouterLink,
 } from "@tanstack/react-router"
-import { Suspense } from "react"
 
+import { DelayedSuspense } from "@/components/delayed-fallback"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
-import { Badge } from "@/components/ui/badge"
+import { ItemDetailContent } from "@/components/item-detail/content"
+import { ItemDetailFrame } from "@/components/item-detail/frame"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
 import { itemQuery } from "@/lib/item-query"
-import {
-  CATEGORIES,
-  formatPct,
-  formatStat,
-  getImageUrl,
-  isValidCategory,
-  type BrowseCategory,
-} from "@/lib/warframe"
+import { isValidCategory, type BrowseCategory } from "@/lib/warframe"
 
 export const Route = createFileRoute("/browse_/$category/$slug")({
   beforeLoad: ({ params }) => {
@@ -35,208 +28,78 @@ export const Route = createFileRoute("/browse_/$category/$slug")({
 })
 
 function ItemDetailPage() {
+  const { category, slug } = Route.useParams()
+  const cat = category as BrowseCategory
   return (
-    <div className="relative flex min-h-screen flex-col">
-      <Header />
-      <main className="flex-1">
-        <div className="wrap flex flex-col gap-8 py-6">
-          <Suspense
-            fallback={<p className="text-muted-foreground">Loading item…</p>}
-          >
-            <ItemDetailContent />
-          </Suspense>
-        </div>
-      </main>
-      <Footer />
-    </div>
+    <DelayedSuspense
+      fallback={
+        <ItemDetailFrame category={cat}>
+          <ItemDetailSkeleton />
+        </ItemDetailFrame>
+      }
+    >
+      <ItemDetailView category={cat} slug={slug} />
+    </DelayedSuspense>
   )
 }
 
-function ItemDetailContent() {
-  const { category, slug } = Route.useParams()
-  const cat = category as BrowseCategory
-  const { data: item } = useSuspenseQuery(itemQuery(cat, slug))
-  const categoryLabel = CATEGORIES.find((c) => c.id === cat)?.label ?? cat
-
-  const isWarframe = cat === "warframes" || cat === "necramechs"
-  const isWeapon =
-    cat === "primary" ||
-    cat === "secondary" ||
-    cat === "melee" ||
-    cat === "companion-weapons" ||
-    cat === "archwing" ||
-    cat === "exalted-weapons"
-  const isMelee = cat === "melee"
-
+function ItemDetailView({
+  category,
+  slug,
+}: {
+  category: BrowseCategory
+  slug: string
+}) {
+  const { data: item } = useSuspenseQuery(itemQuery(category, slug))
   return (
-    <>
-      <nav className="text-muted-foreground flex items-center gap-2 text-sm">
-        <RouterLink
-          to="/browse"
-          search={{ category: "warframes" }}
-          className="hover:text-foreground transition-colors"
-        >
-          Browse
-        </RouterLink>
-        <span>/</span>
-        <RouterLink
-          to="/browse"
-          search={{ category: cat }}
-          className="hover:text-foreground transition-colors"
-        >
-          {categoryLabel}
-        </RouterLink>
-        <span>/</span>
-        <span className="text-foreground">{item.name}</span>
-      </nav>
+    <ItemDetailFrame category={category} itemName={item.name}>
+      <ItemDetailContent item={item} category={category} slug={slug} />
+    </ItemDetailFrame>
+  )
+}
 
-      <div className="flex flex-col gap-8 md:flex-row">
-        <div className="shrink-0">
-          <div className="bg-muted/30 relative flex size-48 items-center justify-center rounded-xl border md:h-64 md:w-64">
-            <img
-              src={getImageUrl(item.imageName)}
-              alt={item.name}
-              width={256}
-              height={256}
-              className="object-contain"
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-1 flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="text-3xl font-bold tracking-tight">{item.name}</h1>
-              {item.vaulted && <Badge variant="outline">Vaulted</Badge>}
+function ItemDetailSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="flex flex-col gap-8"
+    >
+      <span className="sr-only">Loading item…</span>
+      <div className="border-border/50 relative isolate overflow-hidden rounded-2xl border">
+        <div className="relative flex flex-col gap-6 p-8 md:flex-row md:items-center md:gap-8 md:p-12">
+          <Skeleton className="size-40 shrink-0 self-center rounded-xl md:size-56 md:self-auto" />
+          <div className="flex min-w-0 flex-1 flex-col gap-3">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-12 w-2/3 md:h-16" />
+            <Skeleton className="h-4 w-full max-w-2xl" />
+            <Skeleton className="h-4 w-4/5 max-w-2xl" />
+            <div className="flex flex-wrap gap-2 pt-1">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-7 w-20 rounded-full" />
+              ))}
             </div>
-            {item.description && (
-              <p className="text-muted-foreground max-w-2xl">
-                {item.description}
-              </p>
-            )}
-          </div>
-
-          <div className="flex flex-wrap gap-4 text-sm">
-            {item.masteryReq !== undefined && item.masteryReq > 0 && (
-              <div className="flex items-center gap-1">
-                <span className="text-muted-foreground">Mastery:</span>
-                <span className="font-medium">MR {item.masteryReq}</span>
-              </div>
-            )}
-            {item.type && (
-              <div className="flex items-center gap-1">
-                <span className="text-muted-foreground">Type:</span>
-                <span className="font-medium">{item.type}</span>
-              </div>
-            )}
-          </div>
-
-          <div className="flex flex-wrap gap-3 pt-4">
-            <Button
-              size="lg"
-              render={
-                <RouterLink
-                  to="/create"
-                  search={{ item: slug, category: cat }}
-                />
-              }
-            >
-              Create Build
-            </Button>
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-32 rounded-full" />
+              ))}
+            </div>
+            <div className="flex items-center gap-4 pt-2">
+              <Skeleton className="h-10 w-32" />
+            </div>
           </div>
         </div>
       </div>
-
-      <Separator />
-
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {isWarframe && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Base Stats</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <dl className="grid grid-cols-2 gap-3 text-sm">
-                <StatItem label="Health" value={item.health} />
-                <StatItem label="Shield" value={item.shield} />
-                <StatItem label="Armor" value={item.armor} />
-                <StatItem label="Energy" value={item.power} />
-                <StatItem label="Sprint" value={item.sprintSpeed} />
-              </dl>
-            </CardContent>
-          </Card>
-        )}
-
-        {isWeapon && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Weapon Stats</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <dl className="grid grid-cols-2 gap-3 text-sm">
-                <StatItem label="Damage" value={item.totalDamage} />
-                <StatItem
-                  label="Crit Chance"
-                  value={formatPct(item.criticalChance)}
-                />
-                <StatItem
-                  label="Crit Multi"
-                  value={
-                    item.criticalMultiplier !== undefined
-                      ? `${item.criticalMultiplier}x`
-                      : undefined
-                  }
-                />
-                <StatItem label="Status" value={formatPct(item.procChance)} />
-                <StatItem
-                  label="Fire Rate"
-                  value={
-                    item.fireRate !== undefined
-                      ? formatStat(item.fireRate, 3)
-                      : undefined
-                  }
-                />
-                <StatItem label="Magazine" value={item.magazineSize} />
-                <StatItem
-                  label="Reload"
-                  value={
-                    item.reloadTime !== undefined
-                      ? `${formatStat(item.reloadTime)}s`
-                      : undefined
-                  }
-                />
-                {isMelee && <StatItem label="Range" value={item.range} />}
-              </dl>
-            </CardContent>
-          </Card>
-        )}
-
-        {isWarframe && item.abilities && item.abilities.length > 0 && (
-          <Card className="md:col-span-2 lg:col-span-2">
-            <CardHeader>
-              <CardTitle className="text-lg">Abilities</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {item.abilities.map((ability, index) => (
-                  <div key={ability.uniqueName} className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-muted-foreground text-xs">
-                        {index + 1}
-                      </span>
-                      <span className="font-medium">{ability.name}</span>
-                    </div>
-                    <p className="text-muted-foreground line-clamp-2 text-sm">
-                      {ability.description}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        )}
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-6 w-56" />
+        <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(190px,1fr))] [&>*]:max-w-[240px]">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="aspect-[3/4] w-full" />
+          ))}
+        </div>
       </div>
-    </>
+    </div>
   )
 }
 
@@ -260,23 +123,6 @@ function ItemNotFound() {
         </div>
       </main>
       <Footer />
-    </div>
-  )
-}
-
-function StatItem({
-  label,
-  value,
-}: {
-  label: string
-  value: string | number | undefined
-}) {
-  if (value === undefined || value === null || value === "") return null
-  const display = typeof value === "number" ? formatStat(value) : value
-  return (
-    <div className="flex flex-col">
-      <dt className="text-muted-foreground">{label}</dt>
-      <dd className="font-medium tabular-nums">{display}</dd>
     </div>
   )
 }

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -82,7 +82,7 @@ import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard"
 import { authorName, formatVisibility } from "@/lib/user-display"
 import { cn } from "@/lib/utils"
 import {
-  CATEGORIES,
+  getCategoryLabel,
   getImageUrl,
   isValidCategory,
   type BrowseCategory,
@@ -308,8 +308,7 @@ function BuildViewerBodyInner({
     [build.buildData, allMods, allArcanes, helminthAbilities],
   )
 
-  const categoryLabel =
-    CATEGORIES.find((c) => c.id === category)?.label ?? category
+  const categoryLabel = getCategoryLabel(category)
   const isCompanion = category === "companions"
   const normalSlotCount = getNormalSlotCount(category)
   const arcaneCount = getArcaneSlotCount(category, item.type)
@@ -723,9 +722,7 @@ function ShareMenu({ slug }: { slug: string }) {
         ) : (
           <Share2 data-icon="inline-start" />
         )}
-        <span className="inline-block w-[3.25rem] text-center">
-          {copied ? "Copied!" : "Share"}
-        </span>
+        {copied ? "Copied!" : "Share"}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-44">
         <DropdownMenuItem onClick={onCopyLink}>

--- a/apps/web/src/routes/builds.index.tsx
+++ b/apps/web/src/routes/builds.index.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
-import { Suspense } from "react"
 
 import {
   BuildsListView,
@@ -31,24 +30,6 @@ export const Route = createFileRoute("/builds/")({
 })
 
 function BuildsIndexPage() {
-  return (
-    <div className="relative flex min-h-screen flex-col">
-      <Header />
-      <main className="flex-1">
-        <div className="wrap flex flex-col gap-6 py-6">
-          <Suspense
-            fallback={<p className="text-muted-foreground">Loading builds…</p>}
-          >
-            <BuildsIndexContent />
-          </Suspense>
-        </div>
-      </main>
-      <Footer />
-    </div>
-  )
-}
-
-function BuildsIndexContent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const page = search.page ?? 1
@@ -62,41 +43,49 @@ function BuildsIndexContent() {
     navigate({ search: nextBuildsListSearch(next, "newest"), replace: true })
 
   return (
-    <BuildsListView
-      title="Community Builds"
-      description="Discover builds created by the community."
-      query={publicBuildsQuery({
-        page,
-        sort,
-        q: q || undefined,
-        category,
-        hasGuide: hasGuide || undefined,
-        hasShards: hasShards || undefined,
-      })}
-      page={page}
-      sort={sort}
-      q={q}
-      category={category}
-      hasGuide={hasGuide}
-      hasShards={hasShards}
-      onUpdateSearch={onUpdateSearch}
-      showFilters
-      emptyState={
-        <>
-          <p className="text-muted-foreground">No builds match.</p>
-          <p className="text-muted-foreground mt-2 text-sm">
-            Try a different search, or head to{" "}
-            <Link
-              to="/browse"
-              search={{ category: "warframes" }}
-              className="text-primary underline"
-            >
-              Browse
-            </Link>{" "}
-            to publish one.
-          </p>
-        </>
-      }
-    />
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
+        <div className="wrap flex flex-col gap-6 py-6">
+          <BuildsListView
+            title="Community Builds"
+            description="Discover builds created by the community."
+            query={publicBuildsQuery({
+              page,
+              sort,
+              q: q || undefined,
+              category,
+              hasGuide: hasGuide || undefined,
+              hasShards: hasShards || undefined,
+            })}
+            page={page}
+            sort={sort}
+            q={q}
+            category={category}
+            hasGuide={hasGuide}
+            hasShards={hasShards}
+            onUpdateSearch={onUpdateSearch}
+            showFilters
+            emptyState={
+              <>
+                <p className="text-muted-foreground">No builds match.</p>
+                <p className="text-muted-foreground mt-2 text-sm">
+                  Try a different search, or head to{" "}
+                  <Link
+                    to="/browse"
+                    search={{ category: "warframes" }}
+                    className="text-primary underline"
+                  >
+                    Browse
+                  </Link>{" "}
+                  to publish one.
+                </p>
+              </>
+            }
+          />
+        </div>
+      </main>
+      <Footer />
+    </div>
   )
 }

--- a/apps/web/src/routes/builds.mine.tsx
+++ b/apps/web/src/routes/builds.mine.tsx
@@ -4,7 +4,6 @@ import {
   redirect,
   useNavigate,
 } from "@tanstack/react-router"
-import { Suspense } from "react"
 
 import {
   BuildsListView,
@@ -43,24 +42,6 @@ export const Route = createFileRoute("/builds/mine")({
 })
 
 function MineBuildsPage() {
-  return (
-    <div className="relative flex min-h-screen flex-col">
-      <Header />
-      <main className="flex-1">
-        <div className="wrap flex flex-col gap-6 py-6">
-          <Suspense
-            fallback={<p className="text-muted-foreground">Loading builds…</p>}
-          >
-            <MineBuildsContent />
-          </Suspense>
-        </div>
-      </main>
-      <Footer />
-    </div>
-  )
-}
-
-function MineBuildsContent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const page = search.page ?? 1
@@ -74,43 +55,51 @@ function MineBuildsContent() {
     navigate({ search: nextBuildsListSearch(next, "updated"), replace: true })
 
   return (
-    <BuildsListView
-      title="My Builds"
-      description="Builds you've authored."
-      query={myBuildsQuery({
-        page,
-        sort,
-        q,
-        category,
-        hasGuide: hasGuide || undefined,
-        hasShards: hasShards || undefined,
-      })}
-      page={page}
-      sort={sort}
-      q={q}
-      category={category}
-      hasGuide={hasGuide}
-      hasShards={hasShards}
-      onUpdateSearch={onUpdateSearch}
-      showFilters
-      emptyState={
-        <>
-          <p className="text-muted-foreground">
-            You haven't saved any builds yet.
-          </p>
-          <p className="text-muted-foreground mt-2 text-sm">
-            Start one from{" "}
-            <Link
-              to="/browse"
-              search={{ category: "warframes" }}
-              className="text-primary underline"
-            >
-              Browse
-            </Link>
-            .
-          </p>
-        </>
-      }
-    />
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
+        <div className="wrap flex flex-col gap-6 py-6">
+          <BuildsListView
+            title="My Builds"
+            description="Builds you've authored."
+            query={myBuildsQuery({
+              page,
+              sort,
+              q,
+              category,
+              hasGuide: hasGuide || undefined,
+              hasShards: hasShards || undefined,
+            })}
+            page={page}
+            sort={sort}
+            q={q}
+            category={category}
+            hasGuide={hasGuide}
+            hasShards={hasShards}
+            onUpdateSearch={onUpdateSearch}
+            showFilters
+            emptyState={
+              <>
+                <p className="text-muted-foreground">
+                  You haven't saved any builds yet.
+                </p>
+                <p className="text-muted-foreground mt-2 text-sm">
+                  Start one from{" "}
+                  <Link
+                    to="/browse"
+                    search={{ category: "warframes" }}
+                    className="text-primary underline"
+                  >
+                    Browse
+                  </Link>
+                  .
+                </p>
+              </>
+            }
+          />
+        </div>
+      </main>
+      <Footer />
+    </div>
   )
 }

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -96,7 +96,7 @@ import { padShards, type PlacedShard } from "@/lib/shards"
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard"
 import { formatVisibility } from "@/lib/user-display"
 import {
-  CATEGORIES,
+  getCategoryLabel,
   getImageUrl,
   isValidCategory,
   type BrowseCategory,
@@ -211,8 +211,7 @@ function EditorShell() {
     helminthAbilities,
   ])
 
-  const categoryLabel =
-    CATEGORIES.find((c) => c.id === category)?.label ?? category
+  const categoryLabel = getCategoryLabel(category)
 
   const isCompanion = category === "companions"
   const normalSlotCount = getNormalSlotCount(category)

--- a/apps/web/src/routes/org.$slug.tsx
+++ b/apps/web/src/routes/org.$slug.tsx
@@ -1,7 +1,6 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Settings } from "lucide-react"
-import { Suspense } from "react"
 
 import {
   BuildsListView,
@@ -10,6 +9,7 @@ import {
   parseBuildsListSearch,
   type BuildsListSearch,
 } from "@/components/builds/builds-list-view"
+import { DelayedSuspense } from "@/components/delayed-fallback"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Link } from "@/components/link"
@@ -48,13 +48,13 @@ function OrgPage() {
       <Header />
       <main className="flex-1">
         <div className="wrap flex flex-col gap-6 py-6">
-          <Suspense
+          <DelayedSuspense
             fallback={
               <p className="text-muted-foreground">Loading organization…</p>
             }
           >
             <OrgContent />
-          </Suspense>
+          </DelayedSuspense>
         </div>
       </main>
       <Footer />
@@ -84,33 +84,29 @@ function OrgContent() {
       <OrgMembers org={org} />
       <section className="flex flex-col gap-3">
         <h2 className="text-lg font-semibold">Builds</h2>
-        <Suspense
-          fallback={<p className="text-muted-foreground">Loading builds…</p>}
-        >
-          <BuildsListView
-            query={orgBuildsQuery(slug, {
-              page,
-              sort,
-              q,
-              category,
-              hasGuide: hasGuide || undefined,
-              hasShards: hasShards || undefined,
-            })}
-            page={page}
-            sort={sort}
-            q={q}
-            category={category}
-            hasGuide={hasGuide}
-            hasShards={hasShards}
-            onUpdateSearch={onUpdateSearch}
-            showFilters
-            emptyState={
-              <p className="text-muted-foreground">
-                No public builds yet under this organization.
-              </p>
-            }
-          />
-        </Suspense>
+        <BuildsListView
+          query={orgBuildsQuery(slug, {
+            page,
+            sort,
+            q,
+            category,
+            hasGuide: hasGuide || undefined,
+            hasShards: hasShards || undefined,
+          })}
+          page={page}
+          sort={sort}
+          q={q}
+          category={category}
+          hasGuide={hasGuide}
+          hasShards={hasShards}
+          onUpdateSearch={onUpdateSearch}
+          showFilters
+          emptyState={
+            <p className="text-muted-foreground">
+              No public builds yet under this organization.
+            </p>
+          }
+        />
       </section>
     </>
   )

--- a/apps/web/src/routes/profile.$username.tsx
+++ b/apps/web/src/routes/profile.$username.tsx
@@ -1,6 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { Suspense } from "react"
 
 import {
   BuildsListView,
@@ -9,6 +8,7 @@ import {
   parseBuildsListSearch,
   type BuildsListSearch,
 } from "@/components/builds/builds-list-view"
+import { DelayedSuspense } from "@/components/delayed-fallback"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Badge } from "@/components/ui/badge"
@@ -51,11 +51,13 @@ function ProfilePage() {
       <Header />
       <main className="flex-1">
         <div className="wrap flex flex-col gap-6 py-6">
-          <Suspense
-            fallback={<p className="text-muted-foreground">Loading profile…</p>}
+          <DelayedSuspense
+            fallback={
+              <p className="text-muted-foreground">Loading profile…</p>
+            }
           >
             <ProfileContent />
-          </Suspense>
+          </DelayedSuspense>
         </div>
       </main>
       <Footer />
@@ -82,33 +84,29 @@ function ProfileContent() {
   return (
     <>
       <ProfileHeader profile={profile} />
-      <Suspense
-        fallback={<p className="text-muted-foreground">Loading builds…</p>}
-      >
-        <BuildsListView
-          title="Public builds"
-          description={`Builds shared by ${profile.displayUsername ?? profile.username ?? "this user"}.`}
-          query={profileBuildsQuery(username, {
-            page,
-            sort,
-            q,
-            category,
-            hasGuide: hasGuide || undefined,
-            hasShards: hasShards || undefined,
-          })}
-          page={page}
-          sort={sort}
-          q={q}
-          category={category}
-          hasGuide={hasGuide}
-          hasShards={hasShards}
-          onUpdateSearch={onUpdateSearch}
-          showFilters
-          emptyState={
-            <p className="text-muted-foreground">No public builds yet.</p>
-          }
-        />
-      </Suspense>
+      <BuildsListView
+        title="Public builds"
+        description={`Builds shared by ${profile.displayUsername ?? profile.username ?? "this user"}.`}
+        query={profileBuildsQuery(username, {
+          page,
+          sort,
+          q,
+          category,
+          hasGuide: hasGuide || undefined,
+          hasShards: hasShards || undefined,
+        })}
+        page={page}
+        sort={sort}
+        q={q}
+        category={category}
+        hasGuide={hasGuide}
+        hasShards={hasShards}
+        onUpdateSearch={onUpdateSearch}
+        showFilters
+        emptyState={
+          <p className="text-muted-foreground">No public builds yet.</p>
+        }
+      />
     </>
   )
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -225,3 +225,9 @@ body {
     -webkit-mask-size: 200% 100%;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

- **Item detail page**: new magazine-style hero with background image, stat pills, ability tooltip pills, and a "Top community builds" section. Persistent Header/Footer/breadcrumb via `ItemDetailFrame`.
- **Builds list UX**: switched from `useSuspenseQuery` to `useQuery` with `keepPreviousData` so search-as-you-type keeps prior results visible (with a subtle dim) instead of flashing skeletons. Chrome stays mounted — the search input never loses focus mid-keystroke.
- **Backend search**: added `item` and `limit` filters on `/builds`; full-text search has an ILIKE fallback gated on `searchVector IS NULL` so fresh dev DBs work without forcing a seq scan in prod.
- **Skeleton overhaul**: co-located `BuildCardSkeleton`/`ItemCardSkeleton` with their real cards (zero CLS), `prefers-reduced-motion` rule, shared `BUILDS_GRID_CLASS`, new `<DelayedSuspense>` wrapper that gates fallbacks behind a 200 ms timer to prevent flash on warm-cache loads.
- **Browse**: added "All" tab; `content-visibility: auto` on offscreen cards so 800+ items render without virtualization.
- **Header**: lazy-load `CommandPalette` (saves ~52 KB on first paint). Removed builds from the palette to keep it focused on item lookup.
- **Footer**: inline theme toggle.
- **Helpers**: `getCategoryLabel()` + `LIST_PAGE_SIZE` extracted to dedupe call sites across routes.

## Test plan

- [ ] /browse — All tab shows items from every category, item-card hover/focus still work
- [ ] /browse/warframes/excalibur — magazine layout renders, abilities show tooltips on hover, "Top community builds" loads
- [ ] /builds — search-as-you-type updates results without losing focus, no skeleton flash, dim transition while fetching
- [ ] /builds with q=ash — ILIKE fallback works locally (searchVector NULL), tsvector path works in prod
- [ ] /profile/<user>, /org/<slug>, /bookmarks, /builds/mine — all still load builds correctly
- [ ] Header → ⌘K opens command palette (lazy-loaded), navigates to items
- [ ] prefers-reduced-motion disables skeleton pulse