### PR TITLE
fix: align builds-list query key with loader prefetch shape

### DIFF
--- a/apps/web/src/components/item-detail/top-builds-section.tsx
+++ b/apps/web/src/components/item-detail/top-builds-section.tsx
@@ -4,8 +4,11 @@ import { BuildCard, BuildCardSkeleton } from "@/components/builds/build-card"
 import { publicBuildsQuery } from "@/lib/builds-list-query"
 import type { DetailItem } from "@/lib/warframe"
 
-const GRID_CLASS =
-  "grid gap-3 grid-cols-[repeat(auto-fit,minmax(190px,1fr))] [&>*]:max-w-[240px]"
+// Flex-wrap with fixed-width cards so a small number of builds (e.g. 2)
+// don't get stretched across the full row by `1fr` grid tracks. Cards
+// align left, wrap to fill rows, and leave natural unused space on the
+// right rather than ballooning each card.
+const GRID_CLASS = "flex flex-wrap gap-3 [&>*]:w-[240px] [&>*]:max-w-full"
 
 const TOP_BUILDS_LIMIT = 6
 

--- a/apps/web/src/routes/bookmarks.tsx
+++ b/apps/web/src/routes/bookmarks.tsx
@@ -47,12 +47,7 @@ export const Route = createFileRoute("/bookmarks")({
 function BookmarksPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const page = search.page ?? 1
-  const sort = search.sort ?? "newest"
-  const q = search.q ?? ""
-  const category = search.category
-  const hasGuide = search.hasGuide === true
-  const hasShards = search.hasShards === true
+  const params = buildsListLoaderDeps(search, "newest")
 
   const onUpdateSearch = (next: BuildsListSearch) =>
     navigate({ search: nextBuildsListSearch(next, "newest"), replace: true })
@@ -65,20 +60,13 @@ function BookmarksPage() {
           <BuildsListView
             title="My Bookmarks"
             description="Builds you've bookmarked."
-            query={bookmarkedBuildsQuery({
-              page,
-              sort,
-              q,
-              category,
-              hasGuide: hasGuide || undefined,
-              hasShards: hasShards || undefined,
-            })}
-            page={page}
-            sort={sort}
-            q={q}
-            category={category}
-            hasGuide={hasGuide}
-            hasShards={hasShards}
+            query={bookmarkedBuildsQuery(params)}
+            page={params.page}
+            sort={params.sort}
+            q={params.q}
+            category={params.category}
+            hasGuide={params.hasGuide}
+            hasShards={params.hasShards}
             onUpdateSearch={onUpdateSearch}
             showFilters
             emptyState={

--- a/apps/web/src/routes/builds.index.tsx
+++ b/apps/web/src/routes/builds.index.tsx
@@ -32,12 +32,7 @@ export const Route = createFileRoute("/builds/")({
 function BuildsIndexPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const page = search.page ?? 1
-  const sort = search.sort ?? "newest"
-  const q = search.q ?? ""
-  const category = search.category
-  const hasGuide = search.hasGuide === true
-  const hasShards = search.hasShards === true
+  const params = buildsListLoaderDeps(search, "newest")
 
   const onUpdateSearch = (next: BuildsListSearch) =>
     navigate({ search: nextBuildsListSearch(next, "newest"), replace: true })
@@ -50,20 +45,13 @@ function BuildsIndexPage() {
           <BuildsListView
             title="Community Builds"
             description="Discover builds created by the community."
-            query={publicBuildsQuery({
-              page,
-              sort,
-              q: q || undefined,
-              category,
-              hasGuide: hasGuide || undefined,
-              hasShards: hasShards || undefined,
-            })}
-            page={page}
-            sort={sort}
-            q={q}
-            category={category}
-            hasGuide={hasGuide}
-            hasShards={hasShards}
+            query={publicBuildsQuery(params)}
+            page={params.page}
+            sort={params.sort}
+            q={params.q}
+            category={params.category}
+            hasGuide={params.hasGuide}
+            hasShards={params.hasShards}
             onUpdateSearch={onUpdateSearch}
             showFilters
             emptyState={

--- a/apps/web/src/routes/builds.mine.tsx
+++ b/apps/web/src/routes/builds.mine.tsx
@@ -44,12 +44,7 @@ export const Route = createFileRoute("/builds/mine")({
 function MineBuildsPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const page = search.page ?? 1
-  const sort = search.sort ?? "updated"
-  const q = search.q ?? ""
-  const category = search.category
-  const hasGuide = search.hasGuide === true
-  const hasShards = search.hasShards === true
+  const params = buildsListLoaderDeps(search, "updated")
 
   const onUpdateSearch = (next: BuildsListSearch) =>
     navigate({ search: nextBuildsListSearch(next, "updated"), replace: true })
@@ -62,20 +57,13 @@ function MineBuildsPage() {
           <BuildsListView
             title="My Builds"
             description="Builds you've authored."
-            query={myBuildsQuery({
-              page,
-              sort,
-              q,
-              category,
-              hasGuide: hasGuide || undefined,
-              hasShards: hasShards || undefined,
-            })}
-            page={page}
-            sort={sort}
-            q={q}
-            category={category}
-            hasGuide={hasGuide}
-            hasShards={hasShards}
+            query={myBuildsQuery(params)}
+            page={params.page}
+            sort={params.sort}
+            q={params.q}
+            category={params.category}
+            hasGuide={params.hasGuide}
+            hasShards={params.hasShards}
             onUpdateSearch={onUpdateSearch}
             showFilters
             emptyState={

--- a/apps/web/src/routes/org.$slug.tsx
+++ b/apps/web/src/routes/org.$slug.tsx
@@ -66,12 +66,7 @@ function OrgContent() {
   const { slug } = Route.useParams()
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const page = search.page ?? 1
-  const sort = search.sort ?? "newest"
-  const q = search.q ?? ""
-  const category = search.category
-  const hasGuide = search.hasGuide === true
-  const hasShards = search.hasShards === true
+  const params = buildsListLoaderDeps(search, "newest")
 
   const { data: org } = useSuspenseQuery(orgQuery(slug))
 
@@ -85,20 +80,13 @@ function OrgContent() {
       <section className="flex flex-col gap-3">
         <h2 className="text-lg font-semibold">Builds</h2>
         <BuildsListView
-          query={orgBuildsQuery(slug, {
-            page,
-            sort,
-            q,
-            category,
-            hasGuide: hasGuide || undefined,
-            hasShards: hasShards || undefined,
-          })}
-          page={page}
-          sort={sort}
-          q={q}
-          category={category}
-          hasGuide={hasGuide}
-          hasShards={hasShards}
+          query={orgBuildsQuery(slug, params)}
+          page={params.page}
+          sort={params.sort}
+          q={params.q}
+          category={params.category}
+          hasGuide={params.hasGuide}
+          hasShards={params.hasShards}
           onUpdateSearch={onUpdateSearch}
           showFilters
           emptyState={

--- a/apps/web/src/routes/profile.$username.tsx
+++ b/apps/web/src/routes/profile.$username.tsx
@@ -69,12 +69,7 @@ function ProfileContent() {
   const { username } = Route.useParams()
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const page = search.page ?? 1
-  const sort = search.sort ?? "newest"
-  const q = search.q ?? ""
-  const category = search.category
-  const hasGuide = search.hasGuide === true
-  const hasShards = search.hasShards === true
+  const params = buildsListLoaderDeps(search, "newest")
 
   const { data: profile } = useSuspenseQuery(profileQuery(username))
 
@@ -87,20 +82,13 @@ function ProfileContent() {
       <BuildsListView
         title="Public builds"
         description={`Builds shared by ${profile.displayUsername ?? profile.username ?? "this user"}.`}
-        query={profileBuildsQuery(username, {
-          page,
-          sort,
-          q,
-          category,
-          hasGuide: hasGuide || undefined,
-          hasShards: hasShards || undefined,
-        })}
-        page={page}
-        sort={sort}
-        q={q}
-        category={category}
-        hasGuide={hasGuide}
-        hasShards={hasShards}
+        query={profileBuildsQuery(username, params)}
+        page={params.page}
+        sort={params.sort}
+        q={params.q}
+        category={params.category}
+        hasGuide={params.hasGuide}
+        hasShards={params.hasShards}
         onUpdateSearch={onUpdateSearch}
         showFilters
         emptyState={


### PR DESCRIPTION
## Summary

First-paint skeleton flash on /profile/<user>, /org/<slug>, /builds, /builds/mine, /bookmarks was caused by a cache-key mismatch between the route's loader and the component:

- Loader called \`publicBuildsQuery(buildsListLoaderDeps(search, ...))\` → params shape \`{ q: \"\", hasGuide: false, hasShards: false, ... }\`
- Component called \`publicBuildsQuery({ q: q || undefined, hasGuide: hasGuide || undefined, ... })\` → params shape \`{ q: undefined, hasGuide: undefined, ... }\`

React Query hashes the params object to derive the queryKey. The two shapes hash differently, so the prefetched cache entry was effectively orphaned — useQuery saw no cache hit, kicked off a fresh fetch, and rendered \`<ResultsSkeleton />\` for the duration of that fetch (≈70–110 ms locally, longer in prod).

Fix: route every component through the same \`buildsListLoaderDeps()\` helper the loader uses. Loader and component now share one canonical shape; the prefetched data lands in the cache under the exact key useQuery looks up.

\`buildQueryString\` already skips falsy values (\`if (params.q)\`, \`if (params.hasGuide)\`), so the wire request is byte-identical.

## Test plan

- [ ] /profile/<any-user> — no skeleton flash on first paint
- [ ] /org/<any-slug> — no skeleton flash
- [ ] /builds, /builds/mine, /bookmarks — no flash
- [ ] Search-as-you-type still works (results dim, no skeleton)
- [ ] Sort/filter changes still update the URL correctly