### PR TITLE
Make item and category clickable in build header

### DIFF
--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -529,7 +529,22 @@ function ViewerHeader({
               {build.name}
             </h1>
             <span className="text-muted-foreground text-sm">
-              {build.item.name} · {categoryLabel} ·{" "}
+              <RouterLink
+                to="/browse/$category/$slug"
+                params={{ category, slug: itemSlug }}
+                className="hover:text-foreground hover:underline"
+              >
+                {build.item.name}
+              </RouterLink>
+              {" · "}
+              <RouterLink
+                to="/browse"
+                search={{ category }}
+                className="hover:text-foreground hover:underline"
+              >
+                {categoryLabel}
+              </RouterLink>
+              {" · "}
               {build.organization ? (
                 <RouterLink
                   to="/org/$slug"


### PR DESCRIPTION
## Summary
- The viewer header on a build page (`{itemName} · {categoryLabel} · {org}`) had only the org as a link. Item name and category were plain text.
- Now both link out: item name -> `/browse/$category/$slug`, category label -> `/browse?category=...`.

## Notes
- Uses existing routing patterns already in use elsewhere in the app.
- Hover-only underline so the new links don't visually compete with the org link.