### PR TITLE
Make author name clickable in build header

### DIFF
--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -553,6 +553,17 @@ function ViewerHeader({
                 >
                   {build.organization.name}
                 </RouterLink>
+              ) : build.user.username ? (
+                <>
+                  by{" "}
+                  <RouterLink
+                    to="/profile/$username"
+                    params={{ username: build.user.username }}
+                    className="text-[#a78bfa] hover:underline"
+                  >
+                    {author}
+                  </RouterLink>
+                </>
               ) : (
                 <>by {author}</>
               )}


### PR DESCRIPTION
Follow-up to #98. The 'by {author}' text in the viewer header now links to the user's profile page when a username is available, matching the org link styling.