### PR TITLE
Keep author link gray, reserve purple for orgs

### DIFF
--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -559,7 +559,7 @@ function ViewerHeader({
                   <RouterLink
                     to="/profile/$username"
                     params={{ username: build.user.username }}
-                    className="text-[#a78bfa] hover:underline"
+                    className="hover:text-foreground hover:underline"
                   >
                     {author}
                   </RouterLink>


### PR DESCRIPTION
Follow-up to #99. Author link in the build header now uses the same gray hover-underline style as the item/category links — purple stays exclusive to orgs.