### PR TITLE
Clarify build timestamps with 'Updated' tooltip

### DIFF
--- a/apps/web/src/components/builds/build-card.tsx
+++ b/apps/web/src/components/builds/build-card.tsx
@@ -2,8 +2,13 @@ import { Link } from "@tanstack/react-router"
 import { Eye, Heart } from "lucide-react"
 
 import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { BuildListItem } from "@/lib/builds-list-query"
-import { relativeTime } from "@/lib/relative-time"
+import { formatAbsoluteTime, relativeTime } from "@/lib/relative-time"
 import { authorName } from "@/lib/user-display"
 import { getImageUrl } from "@/lib/warframe"
 
@@ -47,7 +52,12 @@ export function BuildCard({ build }: { build: BuildListItem }) {
               {build.viewCount}
             </span>
           </span>
-          <span>{timeAgo}</span>
+          <Tooltip>
+            <TooltipTrigger render={<span>{timeAgo}</span>} />
+            <TooltipContent>
+              Updated {formatAbsoluteTime(build.updatedAt)}
+            </TooltipContent>
+          </Tooltip>
         </div>
       </div>
     </Link>

--- a/apps/web/src/lib/relative-time.ts
+++ b/apps/web/src/lib/relative-time.ts
@@ -1,3 +1,24 @@
+const absoluteFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+})
+
+export function formatAbsoluteTime(iso: string): string {
+  const parts = absoluteFormatter.formatToParts(new Date(iso))
+  const date: string[] = []
+  const time: string[] = []
+  let inTime = false
+  for (const p of parts) {
+    if (p.type === "hour") inTime = true
+    ;(inTime ? time : date).push(p.value)
+  }
+  return `${date.join("").trim().replace(/,\s*$/, "")} · ${time.join("")}`
+}
+
 export function relativeTime(iso: string): string {
   const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60_000)
   if (mins < 1) return "just now"

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -65,6 +65,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { arcanesQuery } from "@/lib/arcanes-query"
 import { authClient } from "@/lib/auth-client"
 import { useDeleteBuild, useForkBuild } from "@/lib/build-actions"
@@ -77,6 +82,7 @@ import { useToggleBookmark, useToggleLike } from "@/lib/build-social"
 import { helminthQuery, type HelminthAbility } from "@/lib/helminth-query"
 import { itemQuery } from "@/lib/item-query"
 import { modsQuery } from "@/lib/mods-query"
+import { formatAbsoluteTime, relativeTime } from "@/lib/relative-time"
 import { padShards } from "@/lib/shards"
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard"
 import { authorName, formatVisibility } from "@/lib/user-display"
@@ -598,6 +604,18 @@ function ViewerHeader({
               <Badge variant="outline" className="text-xs">
                 {build.likeCount} likes · {build.viewCount} views
               </Badge>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Badge variant="outline" className="text-xs">
+                      Updated {relativeTime(build.updatedAt)}
+                    </Badge>
+                  }
+                />
+                <TooltipContent>
+                  Updated {formatAbsoluteTime(build.updatedAt)}
+                </TooltipContent>
+              </Tooltip>
               {build.visibility !== "PUBLIC" ? (
                 <Badge variant="secondary" className="text-xs">
                   {formatVisibility(build.visibility)}


### PR DESCRIPTION
## Summary

The `16h ago` label on build cards was ambiguous — readers couldn't tell whether it meant created or updated. It's `updatedAt`.

- **Build card**: wrap the timestamp in a tooltip showing `Updated May 8, 2026 · 14:23`. Keeps the card visually clean.
- **Build detail header**: add a visible `Updated 16h ago` badge next to likes/views, with the same absolute-time tooltip.
- New `formatAbsoluteTime` helper in `relative-time.ts` for the locale-aware date string.

## Test plan

- [x] Hover the timestamp on a build card — tooltip shows `Updated <date> · <time>`
- [x] Open a build detail page — `Updated x ago` badge sits next to likes/views, hovering it shows the absolute time
- [x] Both still render correctly inside the card's anchor (no invalid HTML — uses Base UI `render={<span/>}`)