### PR TITLE
Type arch-gun arcane slots as Primary + Secondary

### DIFF
--- a/apps/web/src/components/build-editor/arcane-slot.tsx
+++ b/apps/web/src/components/build-editor/arcane-slot.tsx
@@ -22,6 +22,8 @@ import type { PlacedArcane } from "./use-arcane-slots"
 interface ArcaneSlotProps {
   options: Arcane[]
   placed?: PlacedArcane | null
+  /** Placeholder text shown when the slot is empty. Defaults to "Arcane". */
+  label?: string
   /** Names of arcanes already placed in sibling slots — dimmed in the picker. */
   usedNames?: Set<string>
   selected?: boolean
@@ -35,6 +37,7 @@ interface ArcaneSlotProps {
 export function ArcaneSlot({
   options,
   placed,
+  label = "Arcane",
   usedNames,
   selected,
   onSelect,
@@ -97,7 +100,7 @@ export function ArcaneSlot({
           <>
             <Plus className="text-muted-foreground/15 group-hover:text-muted-foreground/30 size-6 transition-colors" />
             <span className="text-muted-foreground/30 mt-1 font-mono text-[10px] tracking-wide uppercase">
-              Arcane
+              {label}
             </span>
           </>
         )}

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -15,6 +15,7 @@ export {
   calculateTotalEndoCost,
 } from "./calculations"
 export {
+  getArcaneSlotConfig,
   getArcaneSlotCount,
   getAuraSlotCount,
   getMaxLevelCap,

--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -1,8 +1,15 @@
+import {
+  getArcanesForCategory,
+  getArcanesForSlot,
+} from "@arsenyx/shared/warframe/arcanes"
+import type { Arcane } from "@arsenyx/shared/warframe/types"
+
 import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 
 /** Arcane slot count per category. Within `archwing`, only arch-guns
- * have arcane slots (top = Primary Arcane, bottom = Secondary Arcane);
- * archwing suits and arch-melee weapons have none. */
+ * have arcane slots (slot 0 = Primary Arcane, slot 1 = Secondary Arcane —
+ * matches the in-game arsenal); archwing suits and arch-melee weapons
+ * have none. */
 export function getArcaneSlotCount(
   category: BrowseCategory,
   itemType: DetailItem["type"],
@@ -19,6 +26,33 @@ export function getArcaneSlotCount(
     default:
       return 0
   }
+}
+
+/** Per-slot arcane picker config. Arch-guns get typed slots (one primary,
+ * one secondary, with matching labels); every other category gets the
+ * same shared option list across all slots and no custom labels. */
+export interface ArcaneSlotConfig {
+  options: Arcane[][]
+  labels?: string[]
+}
+
+export function getArcaneSlotConfig(
+  allArcanes: Arcane[],
+  category: BrowseCategory,
+  count: number,
+): ArcaneSlotConfig {
+  if (count === 0) return { options: [] }
+  if (category === "archwing") {
+    return {
+      options: [
+        getArcanesForSlot(allArcanes, "primary"),
+        getArcanesForSlot(allArcanes, "secondary"),
+      ],
+      labels: ["Primary Arcane", "Secondary Arcane"],
+    }
+  }
+  const shared = getArcanesForCategory(allArcanes, category)
+  return { options: Array.from({ length: count }, () => shared) }
 }
 
 /** Categories that have an Exilus slot. Necramechs, companions, and every

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -47,22 +47,25 @@ export function getExilusInnatePolarity(
 }
 
 export function ArcaneRow({
-  count,
   arcanes,
   options,
+  labels,
   readOnly = false,
 }: {
-  count: number
   arcanes: ArcaneSlotsState
-  options: Arcane[]
+  /** Per-slot picker options. Slot count = `options.length`. */
+  options: Arcane[][]
+  /** Optional per-slot placeholder labels. */
+  labels?: string[]
   readOnly?: boolean
 }) {
   return (
     <div className="flex w-full items-start justify-center gap-3 sm:gap-6">
-      {Array.from({ length: count }).map((_, i) => (
+      {options.map((slotOptions, i) => (
         <ArcaneSlot
           key={i}
-          options={options}
+          options={slotOptions}
+          label={labels?.[i]}
           placed={arcanes.placed[i]}
           usedNames={arcanes.usedNames}
           selected={arcanes.selected === i}

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -1,8 +1,6 @@
-import { getArcanesForCategory } from "@arsenyx/shared/warframe/arcanes"
 import { slugify } from "@arsenyx/shared/warframe/slugs"
 import {
   DEFAULT_DEPLOYMENT_CONTEXT,
-  type Arcane,
   type Mod,
 } from "@arsenyx/shared/warframe/types"
 import { useSuspenseQuery } from "@tanstack/react-query"
@@ -32,6 +30,7 @@ import {
   calculateCapacity,
   calculateFormaCount,
   calculateTotalEndoCost,
+  getArcaneSlotConfig,
   getArcaneSlotCount,
   getAuraPolarities,
   getAuraSlotCount,
@@ -319,9 +318,9 @@ function BuildViewerBodyInner({
   const normalSlotCount = getNormalSlotCount(category)
   const arcaneCount = getArcaneSlotCount(category, item.type)
 
-  const arcaneOptions = useMemo(
-    () => getArcanesForCategory(allArcanes, category),
-    [allArcanes, category],
+  const arcaneConfig = useMemo(
+    () => getArcaneSlotConfig(allArcanes, category, arcaneCount),
+    [allArcanes, category, arcaneCount],
   )
 
   const auraSlotCount = getAuraSlotCount(category, item)
@@ -470,9 +469,9 @@ function BuildViewerBodyInner({
               arcaneRow={
                 arcaneCount > 0 ? (
                   <ArcaneRow
-                    count={arcaneCount}
                     arcanes={arcanes}
-                    options={arcaneOptions}
+                    options={arcaneConfig.options}
+                    labels={arcaneConfig.labels}
                     readOnly
                   />
                 ) : undefined

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,4 +1,3 @@
-import { getArcanesForCategory } from "@arsenyx/shared/warframe/arcanes"
 import { decodeBuild, encodeBuild } from "@arsenyx/shared/warframe/build-codec"
 import {
   getIncarnonGenesisImage,
@@ -47,6 +46,7 @@ import {
   calculateCapacity,
   calculateFormaCount,
   calculateTotalEndoCost,
+  getArcaneSlotConfig,
   getArcaneSlotCount,
   getAuraPolarities,
   getAuraSlotCount,
@@ -229,9 +229,9 @@ function EditorShell() {
   })
   const arcaneCount = getArcaneSlotCount(category, item.type)
   const arcanes = useArcaneSlots(arcaneCount, savedData.arcanes)
-  const arcaneOptions = useMemo(
-    () => getArcanesForCategory(allArcanes, category),
-    [allArcanes, category],
+  const arcaneConfig = useMemo(
+    () => getArcaneSlotConfig(allArcanes, category, arcaneCount),
+    [allArcanes, category, arcaneCount],
   )
 
   // Escape deselects the active mod/arcane slot, mirroring the
@@ -663,9 +663,9 @@ function EditorShell() {
               arcaneRow={
                 arcaneCount > 0 ? (
                   <ArcaneRow
-                    count={arcaneCount}
                     arcanes={arcanes}
-                    options={arcaneOptions}
+                    options={arcaneConfig.options}
+                    labels={arcaneConfig.labels}
                   />
                 ) : undefined
               }


### PR DESCRIPTION
## Summary

Arch-guns now have one **Primary Arcane** slot and one **Secondary Arcane** slot, matching the in-game arsenal. Previously both slots offered the combined primary + secondary list, which let users save illegal configurations like two primary arcanes (reported on Discord by hampter, confirmed by Kalaay).

## What changed

- New `getArcaneSlotConfig(allArcanes, category, count)` in `apps/web/src/components/build-editor/layout.ts` — returns per-slot options + optional labels. Arch-gun gets typed slots; everything else gets one shared list.
- `ArcaneRow` simplified to take `options: Arcane[][]` directly (was a `Arcane[] | Arcane[][]` union with a runtime branch). Slot count is derived from `options.length`.
- New `label` prop on `ArcaneSlot` (default "Arcane"), so arch-gun's two slots render "PRIMARY ARCANE" and "SECONDARY ARCANE" placeholders.
- Both routes (`create.tsx`, `builds.\$slug.tsx`) collapse to a single `useMemo` returning `{ options, labels }` — kills the previous copy-paste.

## Test plan

Verified in the browser preview:

- [x] Arch-gun (Corvas): slot 0 picker shows 13 primary arcanes only, slot 1 shows 17 secondary arcanes only.
- [x] Warframe (Mag): both slots share the full 70-arcane list, generic "ARCANE" label preserved.
- [x] Primary weapon (Braton): 1 slot, 13 primary arcanes only.
- [x] Secondary weapon (Lex): 1 slot, 17 secondary arcanes only.
- [x] Melee (Skana): 1 slot, 11 melee arcanes only.
- [x] \`bun run build\` clean.