### PR TITLE
Show + instead of = for rank hotkey hints

### DIFF
--- a/apps/web/src/components/build-editor/keyboard-hints.tsx
+++ b/apps/web/src/components/build-editor/keyboard-hints.tsx
@@ -22,7 +22,7 @@ export function KeyboardHintsStrip({ className }: { className?: string }) {
       )}
     >
       <Hint keys={["↑", "↓", "←", "→"]} label="navigate" />
-      <Hint keys={["−", "="]} label="rank" />
+      <Hint keys={["−", "+"]} label="rank" />
       <Hint keys={["/"]} label="search mods" />
       <Hint keys={["Esc"]} label="deselect" />
       <button
@@ -71,7 +71,7 @@ export function KeyboardHintBanner() {
   return (
     <div className="bg-muted/30 flex items-center gap-3 rounded-md border border-dashed px-3 py-2 text-sm">
       <span className="text-muted-foreground">
-        Keyboard-first: arrows move between slots, <Kbd>−</Kbd> / <Kbd>=</Kbd>{" "}
+        Keyboard-first: arrows move between slots, <Kbd>−</Kbd> / <Kbd>+</Kbd>{" "}
         rank a mod, <Kbd>/</Kbd> opens mod search. Press <Kbd>?</Kbd> any time
         for the full list.
       </span>

--- a/apps/web/src/lib/hotkeys.ts
+++ b/apps/web/src/lib/hotkeys.ts
@@ -48,7 +48,7 @@ export const HOTKEYS: readonly Hotkey[] = [
   },
   {
     scope: "Build editor",
-    keys: ["−", "="],
+    keys: ["−", "+"],
     description: "Lower or raise the rank of the selected mod / arcane",
   },
   {


### PR DESCRIPTION
## Summary
- The build-editor hotkey for ranking mods displayed `−` / `=`, which read like a typo. Swapped the displayed label to `−` / `+` since users mentally model it as "decrease / increase."
- Handler unchanged — `useRankHotkey` still accepts `-`, `=`, `_`, and `+`, so users don't have to hold Shift to type `+`.

## Why
Discord feedback: "why aren't they −/+?" The previous label was technically correct (`=` is the unshifted key) but visually mismatched user expectations.

## Changes
- `keyboard-hints.tsx` — hint strip + onboarding banner labels
- `hotkeys.ts` — cheat-sheet label

## Test plan
- [x] Verified in preview at `/create?item=ash&category=warframes`: footer strip and onboarding banner both show `− +` for rank
- [x] Confirm `-`, `=`, `_`, `+` all still rank mods up/down (no handler change, but worth a smoke test)