### PR TITLE
Ignore nested .claude/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ yarn-error.log*
 /apps/api/src/generated/
 
 # claude temp files
-/.claude/
+.claude/
 .agents/
 skills-lock.json
 .superpowers/


### PR DESCRIPTION
The root `.gitignore` had `/.claude/` (root-anchored), which left nested `.claude/` directories like `apps/web/.claude/launch.json` untracked-but-visible in `git status`. Drop the leading slash so the rule matches at any depth.