### PR TITLE
Preload expanded mod card assets on compact mount

### DIFF
--- a/apps/web/src/components/build-editor/mod-card.tsx
+++ b/apps/web/src/components/build-editor/mod-card.tsx
@@ -23,6 +23,22 @@ import {
 
 const NUMBER_PATTERN = /(\d+(\.\d+)?)/g
 
+// `Background` and `LowerTab` PNGs are only referenced by the expanded card,
+// so on first hover the browser fetches them cold — visible as a delay before
+// the lower stat panel paints. Warm them up as soon as a compact card of a
+// given rarity mounts, so they're in the HTTP cache by the time the user
+// hovers. Module-level set dedupes across all card instances.
+const preloadedRarities = new Set<ModRarity>()
+
+function preloadExpandedAssets(rarity: ModRarity) {
+  if (preloadedRarities.has(rarity)) return
+  preloadedRarities.add(rarity)
+  for (const asset of ["Background", "LowerTab"] as const) {
+    const img = new Image()
+    img.src = getModAssetUrl(rarity, asset)
+  }
+}
+
 // Stats where a "positive" riven roll is semantically a debuff — we invert the
 // displayed sign so the number reads the way the in-game arsenal shows it.
 const INVERTED_RIVEN_STATS = new Set(["Zoom"])
@@ -150,6 +166,10 @@ function CompactModCard({
   const drain =
     drainOverride ??
     (mod.rivenStats ? (mod.baseDrain ?? 0) : (mod.baseDrain ?? 0) + rank)
+
+  useEffect(() => {
+    preloadExpandedAssets(rarity)
+  }, [rarity])
 
   return (
     <ModCardFrame rarity={rarity} variant="compact" vtPrefix={vtPrefix}>


### PR DESCRIPTION
## Summary

The `Background` and `LowerTab` PNGs are only referenced by the expanded mod card, so on first hover the browser fetched them cold — visible as a delay before the lower stat panel painted (the symptom: hovering a mod and watching the dark textured panel pop in late).

Fix: warm them up via `new Image()` as soon as a compact card of that rarity mounts, so they're in the HTTP cache by hover time. Module-level `Set` dedupes so each rarity preloads once per session (max 8 rarities × 2 assets).

## Why this location

`CompactModCard` is mounted for every card in the search grid and slot grid, so by the time the user reaches for a hover, the relevant rarity assets have already been preloaded. The other frame chrome (`FrameTop`, `FrameBottom`, `TopRightBacker`) is already loaded by the compact card itself, so only `Background` and `LowerTab` need warmup.

## Test plan

- [x] On a cold cache, hover a mod in the search grid and confirm the expanded card's stat panel paints without a visible flash of empty background
- [x] DevTools network: confirm `*Background.png` / `*LowerTab.png` for visible rarities are fetched shortly after the grid mounts (not on hover)