### PR TITLE
Show combined-element mods in weapon damage summary

### DIFF
--- a/apps/web/src/lib/stats/types.ts
+++ b/apps/web/src/lib/stats/types.ts
@@ -189,6 +189,15 @@ export const BASE_ELEMENTS: DamageType[] = [
   "toxin",
 ]
 
+export const COMBINED_ELEMENTS: DamageType[] = [
+  "blast",
+  "radiation",
+  "gas",
+  "magnetic",
+  "viral",
+  "corrosive",
+]
+
 export const DAMAGE_TYPE_LABELS: Record<DamageType, string> = {
   impact: "Impact",
   puncture: "Puncture",

--- a/apps/web/src/lib/stats/weapon.ts
+++ b/apps/web/src/lib/stats/weapon.ts
@@ -16,6 +16,7 @@ import {
 } from "./parser"
 import {
   BASE_ELEMENTS,
+  COMBINED_ELEMENTS,
   DAMAGE_TYPE_LABELS,
   ELEMENTAL_COMBINATIONS,
   type AttackModeStats,
@@ -376,16 +377,28 @@ function calcDamageBreakdown(
     baseDamageContribs,
   )
 
+  // Combined-element stats from mods/rivens/arcanes (e.g. a Riven rolling
+  // +Magnetic Damage). These don't combine further, so emit them directly.
+  const combinedByType = new Map<
+    DamageType,
+    { name: string; value: number }[]
+  >()
+  for (const s of stats) {
+    if (s.operation !== "percent_add") continue
+    if (!COMBINED_ELEMENTS.includes(s.type as DamageType)) continue
+    const t = s.type as DamageType
+    if (!combinedByType.has(t)) combinedByType.set(t, [])
+    combinedByType.get(t)!.push({ name: s.sourceName, value: s.value })
+  }
+  for (const [type, sources] of combinedByType) {
+    elemental.push(
+      makeUncombinedEntry(type, sources, totalModdedBase, baseDamageContribs),
+    )
+  }
+
   // Innate combined elementals (e.g. innate Blast on some weapons).
   for (const [type, value] of Object.entries(baseDamage)) {
-    if (
-      (type as DamageType) !== "impact" &&
-      (type as DamageType) !== "puncture" &&
-      (type as DamageType) !== "slash" &&
-      !BASE_ELEMENTS.includes(type as DamageType) &&
-      value &&
-      value > 0
-    ) {
+    if (COMBINED_ELEMENTS.includes(type as DamageType) && value && value > 0) {
       const contribs: StatContribution[] = [...baseDamageContribs]
       contribs.unshift({
         name: "Innate",
@@ -471,26 +484,38 @@ function combineElements(
       }
     }
     if (!combined) {
-      const value = (totalModdedBase * first.value) / 100
-      const contribs: StatContribution[] = [...baseDamageContribs]
-      for (const src of first.sources) {
-        contribs.push({
-          name: src.name,
-          amount: src.value,
-          operation: "percent_add",
-          group: DAMAGE_TYPE_LABELS[first.type],
-        })
-      }
-      result.push({
-        type: first.type,
-        value: round1(value),
-        base: 0,
-        contributions: contribs,
-      })
+      result.push(
+        makeUncombinedEntry(
+          first.type,
+          first.sources,
+          totalModdedBase,
+          baseDamageContribs,
+        ),
+      )
     }
   }
 
   return result
+}
+
+function makeUncombinedEntry(
+  type: DamageType,
+  sources: { name: string; value: number }[],
+  totalModdedBase: number,
+  baseDamageContribs: StatContribution[],
+): DamageEntry {
+  const sum = sources.reduce((t, s) => t + s.value, 0)
+  const value = (totalModdedBase * sum) / 100
+  const contribs: StatContribution[] = [...baseDamageContribs]
+  for (const src of sources) {
+    contribs.push({
+      name: src.name,
+      amount: src.value,
+      operation: "percent_add",
+      group: DAMAGE_TYPE_LABELS[type],
+    })
+  }
+  return { type, value: round1(value), base: 0, contributions: contribs }
 }
 
 export function sumDamage(d: DamageTypes): number {


### PR DESCRIPTION
Fixes #107.

## Problem

Mods that directly grant a combined element (e.g. **Accelerated Isotope** → +60% Radiation, **Magnetic Might** → +60% Magnetic) and Rivens rolling Magnetic / Radiation / Viral / Corrosive / Gas / Blast didn't appear in the weapon damage breakdown. The build referenced in the issue (https://arsenyx.com/builds/xUHWQdCqFf) has both of those mods, and neither Radiation nor Magnetic showed up.

## Cause

In `calcDamageBreakdown` ([apps/web/src/lib/stats/weapon.ts](apps/web/src/lib/stats/weapon.ts)), the elemental-stat collection loop filtered with `BASE_ELEMENTS.includes(s.type)`, so any stat already typed as a combined element was silently dropped before reaching `combineElements` or the renderer. The pre-existing innate-combined-element loop only handled values coming from `baseDamage` (innate weapon damage like Cyanex's Magnetic), not stats from mods/Rivens/arcanes.

## Fix

- Add a second pass that aggregates combined-element stats by type and emits them as `DamageEntry` items directly (combined elements don't combine further).
- Add `COMBINED_ELEMENTS` alongside `BASE_ELEMENTS` in [types.ts](apps/web/src/lib/stats/types.ts) so the surrounding filters collapse to one membership check (also simplifies the innate-combined loop).
- Factor the shared "sources → `DamageEntry`" build logic into `makeUncombinedEntry`, used by both the new pass and `combineElements`' existing uncombined branch.

No renderer or parser changes — the parser already emitted `{type: "magnetic"/"radiation"/...}` for these mods, and the renderer in `item-sidebar.tsx` already maps over the full `elemental` array.

## Verification

- `bun run build` in `apps/web/` passes.
- Confirmed the reported build's slots contain `+60% <DT_RADIATION_COLOR>Radiation` and `+60% <DT_MAGNETIC_COLOR>Magnetic` stat strings, which the parser maps to `type: "radiation"` / `"magnetic"` and the new pass now picks up.
- Behavior unchanged for builds with only base-element mods, and for weapons with innate combined damage (those paths weren't touched).

End-to-end browser verification against the production build URL was blocked by CORS (production API rejects `localhost:5173` origin), so visual confirmation should happen after deploy or via a local API + seeded build.