### PR TITLE
Fix exalted-weapon damage, mod pool, and arcane slot

### DIFF
--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -1,10 +1,23 @@
 import {
   getArcanesForCategory,
   getArcanesForSlot,
+  type ArcaneSlotType,
 } from "@arsenyx/shared/warframe/arcanes"
 import type { Arcane } from "@arsenyx/shared/warframe/types"
 
 import type { BrowseCategory, DetailItem } from "@/lib/warframe"
+
+/** Resolve which arcane pool an exalted weapon draws from. Mirrors the
+ * mod-pool logic in `getModsForItem`: bows take primary arcanes,
+ * trigger-bearing weapons (Balefire/Regulators) take secondary, everything
+ * else (Exalted Blade etc.) takes melee. */
+function getExaltedArcaneSlot(
+  item: Pick<DetailItem, "name" | "trigger">,
+): ArcaneSlotType {
+  if (item.name?.toLowerCase().includes("bow")) return "primary"
+  if (item.trigger) return "secondary"
+  return "melee"
+}
 
 /** Arcane slot count per category. Within `archwing`, only arch-guns
  * have arcane slots (slot 0 = Primary Arcane, slot 1 = Secondary Arcane —
@@ -20,6 +33,7 @@ export function getArcaneSlotCount(
     case "primary":
     case "secondary":
     case "melee":
+    case "exalted-weapons":
       return 1
     case "archwing":
       return itemType === "Arch-Gun" ? 2 : 0
@@ -40,6 +54,7 @@ export function getArcaneSlotConfig(
   allArcanes: Arcane[],
   category: BrowseCategory,
   count: number,
+  item?: Pick<DetailItem, "name" | "trigger">,
 ): ArcaneSlotConfig {
   if (count === 0) return { options: [] }
   if (category === "archwing") {
@@ -50,6 +65,10 @@ export function getArcaneSlotConfig(
       ],
       labels: ["Primary Arcane", "Secondary Arcane"],
     }
+  }
+  if (category === "exalted-weapons" && item) {
+    const slot = getExaltedArcaneSlot(item)
+    return { options: [getArcanesForSlot(allArcanes, slot)] }
   }
   const shared = getArcanesForCategory(allArcanes, category)
   return { options: Array.from({ length: count }, () => shared) }

--- a/apps/web/src/lib/stats/weapon.ts
+++ b/apps/web/src/lib/stats/weapon.ts
@@ -331,7 +331,18 @@ function calcDamageBreakdown(
   if (baseDamage.puncture) makePhysical("puncture", baseDamage.puncture)
   if (baseDamage.slash) makePhysical("slash", baseDamage.slash)
 
-  const totalModdedBase = physical.reduce((s, e) => s + e.value, 0)
+  // Innate base-element damage scales with base-damage mods (Serration etc.)
+  // and acts as the base for modded elementals on weapons with no physical
+  // damage (e.g. Balefire Charger's pure-electricity shots). Include it in
+  // totalModdedBase so elemental mod percentages have something to multiply.
+  let innateElementalBase = 0
+  for (const [type, value] of Object.entries(baseDamage)) {
+    if (BASE_ELEMENTS.includes(type as DamageType) && value && value > 0) {
+      innateElementalBase += value
+    }
+  }
+  const totalModdedBase =
+    physical.reduce((s, e) => s + e.value, 0) + innateElementalBase * baseMult
 
   // Collect elemental mods grouped by type, preserving source attribution.
   const elementalMods: {
@@ -358,10 +369,13 @@ function calcDamageBreakdown(
     elementalMods.push({ type, value: sum, sources })
   }
 
-  // Innate base elements come FIRST in the combination order.
+  // Innate base elements come FIRST in the combination order. Encode them
+  // as a percentage of totalModdedBase so combineElements' shared
+  // `totalModdedBase * pct / 100` formula recovers `value * baseMult`.
   for (const [type, value] of Object.entries(baseDamage)) {
     if (BASE_ELEMENTS.includes(type as DamageType) && value && value > 0) {
-      const pctEquivalent = (value / (totalModdedBase || 1)) * 100
+      const pctEquivalent =
+        totalModdedBase > 0 ? ((value * baseMult) / totalModdedBase) * 100 : 0
       elementalMods.unshift({
         type: type as DamageType,
         value: pctEquivalent,

--- a/apps/web/src/lib/warframe.ts
+++ b/apps/web/src/lib/warframe.ts
@@ -76,6 +76,7 @@ export interface DetailItem extends BrowseItem {
   abilities?: ItemAbility[]
   // weapon
   maxLevelCap?: number
+  trigger?: string
   totalDamage?: number
   criticalChance?: number
   criticalMultiplier?: number

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -346,8 +346,8 @@ function BuildViewerBodyInner({
   const arcaneCount = getArcaneSlotCount(category, item.type)
 
   const arcaneConfig = useMemo(
-    () => getArcaneSlotConfig(allArcanes, category, arcaneCount),
-    [allArcanes, category, arcaneCount],
+    () => getArcaneSlotConfig(allArcanes, category, arcaneCount, item),
+    [allArcanes, category, arcaneCount, item],
   )
 
   const auraSlotCount = getAuraSlotCount(category, item)

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -209,8 +209,8 @@ function EditorShell() {
   const arcaneCount = getArcaneSlotCount(category, item.type)
   const arcanes = useArcaneSlots(arcaneCount, savedData.arcanes)
   const arcaneConfig = useMemo(
-    () => getArcaneSlotConfig(allArcanes, category, arcaneCount),
-    [allArcanes, category, arcaneCount],
+    () => getArcaneSlotConfig(allArcanes, category, arcaneCount, item),
+    [allArcanes, category, arcaneCount, item],
   )
 
   // Escape deselects the active mod/arcane slot, mirroring the


### PR DESCRIPTION
## Summary

Three regressions surfaced on Balefire Charger Prime (and other exalted pistols/melee weapons): the stats panel showed `Total Damage: 0`, the mod search grid listed melee mods, and there was no arcane slot at all.

## What changed

- **Damage** — [apps/web/src/lib/stats/weapon.ts](apps/web/src/lib/stats/weapon.ts): `totalModdedBase` only summed *physical* damage, so for weapons whose innate damage is pure-elemental (Balefire's 500 electricity, 0 physical) every modded element multiplied by 0. Now includes `innateElementalBase * baseMult`. The `pctEquivalent` for innate base elements is recomputed against the new total so the shared `combineElements` formula still recovers `value * baseMult`.
- **Mod pool** — [apps/web/src/routes/create.tsx](apps/web/src/routes/create.tsx) + [apps/web/src/lib/warframe.ts](apps/web/src/lib/warframe.ts): `getModsForItem` needs `item.trigger` to pick the right pool for exalted weapons (bow → primary, has trigger → secondary, else → melee). Without it exalted pistols silently fell through to the melee branch in `packages/shared/src/warframe/mods.ts`. Pass `trigger` through and add the field to `DetailItem`.
- **Arcane slot** — [apps/web/src/components/build-editor/layout.ts](apps/web/src/components/build-editor/layout.ts) (+ the two callers): `exalted-weapons` returned 0 arcane slots. Give the category 1 slot and resolve the pool per item via a new `getExaltedArcaneSlot` helper that mirrors the mod-pool logic.

## Verification

Loaded the build in a local preview after each fix:

- **Damage** — fresh build with just Hornet Strike (220%) on Balefire Charger Prime shows Uncharged 1600, Charged 4800, Alt Fire 1600 (total 8000) — i.e. 500/1500/500 × 3.20. Previously all zero.
- **Mod pool** — Balefire's mod search now lists Hornet Strike, Primed Pistol Gambit, Galvanized Diffusion, etc.
- **Arcane pool** —
  - Balefire Charger Prime → Akimbo Slip Shot, Secondary Merciless, …
  - Exalted Umbra Blade → Melee Influence, Melee Crescendo, …
  - Artemis Bow Prime → Primary Deadhead, Primary Merciless, …

## Test plan

- [x] Open an existing exalted-weapon build and confirm the damage panel shows non-zero values for innate-electric/innate-radiation weapons.
- [x] Edit Balefire / Regulators and confirm pistol mods + Secondary arcanes appear.
- [x] Edit Exalted Umbra Blade and confirm melee mods + Melee arcanes appear.
- [x] Edit Artemis Bow and confirm primary/bow mods + Primary arcanes appear.