### PR TITLE
Surface stance slot on Zaw strikes

### DIFF
--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -90,12 +90,17 @@ export function hasExilusSlot(category: BrowseCategory): boolean {
  * Arch-melee weapons do not carry stancePolarity and so get no slot.
  * Exalted melees have a stance pre-applied in-game and the player cannot
  * swap it, so we skip the slot entirely for the `exalted-weapons` category.
+ *
+ * Zaw strike components are user-built melees that carry no stancePolarity
+ * on the strike entry but absolutely do equip a stance in-game — always
+ * surface the slot (innate polarity unknown; user can forma).
  */
 export function hasStanceSlot(
-  item: Pick<DetailItem, "stancePolarity">,
+  item: Pick<DetailItem, "stancePolarity" | "type">,
   category: BrowseCategory,
 ): boolean {
   if (category === "exalted-weapons") return false
+  if (item.type === "Zaw Component") return true
   return Boolean(item.stancePolarity)
 }
 


### PR DESCRIPTION
## Summary

Zaws build their own melee weapon from Strike + Grip + Link components. WFCD's data carries `stancePolarity` only on complete melee entries, never on the Strike component itself, so `hasStanceSlot` returned `false` for every zaw — meaning users couldn't equip a stance on a build that absolutely has one in-game.

Add a one-line `type === "Zaw Component"` carve-out to render the slot with no innate polarity. User can forma it.

Stance class filtering (Polearm vs. Staff vs. Heavy Blade etc.) stays fail-open until upstream `@wfcd/items` populates `meleeClass` — same behavior as regular melees, so this PR doesn't regress class-specific stance picking.

## Test plan

- [ ] Open `/create?item=balla&category=melee` → stance slot renders (no innate polarity)
- [ ] Place a stance mod from the picker → fills the stance slot
- [ ] Right-click the stance slot → polarity picker opens
- [ ] Forma the slot to e.g. naramon, place Bleeding Willow (naramon) → +10 capacity bonus
- [ ] Verify other zaw strikes (Cyath, Dehtat, Plague Kripath, etc.) also show a stance slot
- [ ] Verify regular melees (Skana) and exalted melees still behave the same as before