### PR TITLE
Editor UX: reorderable ability stats + slot-skip on auto-advance

### DIFF
--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -384,7 +384,11 @@ builds.get("/:slug/partners", async (c) => {
   const partnerVisibility: Prisma.BuildWhereInput = viewerId
     ? {
         OR: [
-          { visibility: { in: [BuildVisibility.PUBLIC, BuildVisibility.UNLISTED] } },
+          {
+            visibility: {
+              in: [BuildVisibility.PUBLIC, BuildVisibility.UNLISTED],
+            },
+          },
           { userId: viewerId },
         ],
       }

--- a/apps/web/src/components/build-editor/ability-stat-reorder.tsx
+++ b/apps/web/src/components/build-editor/ability-stat-reorder.tsx
@@ -1,0 +1,297 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react"
+import { createPortal } from "react-dom"
+
+import { cn } from "@/lib/utils"
+
+import type { AbilityStatKey } from "./use-ability-stat-order"
+
+// Self-contained pointer-drag for reordering the four ability stat rows.
+// Mirrors the conventions of `drag-controller.tsx` (4px activation, rAF-
+// coalesced ghost, elementFromPoint targeting, deferred pointer capture,
+// click-swallow at activation) but is not coupled to mods or slots.
+
+const ROW_ATTR = "data-stat-row"
+const ROW_INDEX_ATTR = "data-stat-index"
+const SOURCE_CLASS = "opacity-30"
+const ACTIVATION_DISTANCE = 4
+
+type Pending = {
+  sourceKey: AbilityStatKey
+  sourceIndex: number
+  sourceEl: HTMLElement
+  ghostLabel: string
+  ghostValue: string
+  pointerId: number
+  startX: number
+  startY: number
+}
+
+type Active = {
+  sourceKey: AbilityStatKey
+  sourceIndex: number
+  ghostLabel: string
+  ghostValue: string
+}
+
+function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
+  if (from === to) return arr.slice()
+  const next = arr.slice()
+  const [item] = next.splice(from, 1)
+  next.splice(to, 0, item)
+  return next
+}
+
+export function useAbilityStatReorder(
+  order: readonly AbilityStatKey[],
+  onCommit: (next: AbilityStatKey[]) => void,
+) {
+  const [active, setActive] = useState<Active | null>(null)
+  const [targetIndex, setTargetIndex] = useState<number | null>(null)
+
+  const pendingRef = useRef<Pending | null>(null)
+  const activeRef = useRef<Active | null>(null)
+  const targetRef = useRef<number | null>(null)
+  const orderRef = useRef(order)
+  const onCommitRef = useRef(onCommit)
+  const sourceElRef = useRef<HTMLElement | null>(null)
+  const ghostRef = useRef<HTMLDivElement | null>(null)
+  const captureRef = useRef<{ el: HTMLElement; pointerId: number } | null>(null)
+  const clickSwallowRef = useRef<((e: MouseEvent) => void) | null>(null)
+
+  useEffect(() => {
+    orderRef.current = order
+    onCommitRef.current = onCommit
+    activeRef.current = active
+    targetRef.current = targetIndex
+  })
+
+  const armClickSwallow = useCallback(() => {
+    if (clickSwallowRef.current) return
+    const fn = (e: MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      document.removeEventListener("click", fn, true)
+      clickSwallowRef.current = null
+    }
+    clickSwallowRef.current = fn
+    document.addEventListener("click", fn, true)
+  }, [])
+
+  const disarmClickSwallow = useCallback(() => {
+    if (!clickSwallowRef.current) return
+    document.removeEventListener("click", clickSwallowRef.current, true)
+    clickSwallowRef.current = null
+  }, [])
+
+  const cleanup = useCallback(() => {
+    pendingRef.current = null
+    if (clickSwallowRef.current) {
+      const fn = clickSwallowRef.current
+      setTimeout(() => {
+        if (clickSwallowRef.current === fn) {
+          document.removeEventListener("click", fn, true)
+          clickSwallowRef.current = null
+        }
+      }, 0)
+    }
+    if (sourceElRef.current) {
+      sourceElRef.current.classList.remove(SOURCE_CLASS)
+      sourceElRef.current = null
+    }
+    if (captureRef.current) {
+      const { el, pointerId } = captureRef.current
+      try {
+        if (el.hasPointerCapture(pointerId)) {
+          el.releasePointerCapture(pointerId)
+        }
+      } catch {
+        // Capture may have been released by the browser already.
+      }
+      captureRef.current = null
+    }
+    activeRef.current = null
+    targetRef.current = null
+    setActive(null)
+    setTargetIndex(null)
+  }, [])
+
+  useEffect(() => {
+    let rafId = 0
+    let lastX = 0
+    let lastY = 0
+    let pendingMove = false
+
+    const findTargetIndex = (x: number, y: number): number | null => {
+      const el = document.elementFromPoint(x, y)
+      if (!el) return null
+      const row = (el as Element).closest(`[${ROW_ATTR}]`)
+      if (!row) return null
+      const raw = row.getAttribute(ROW_INDEX_ATTR)
+      const i = raw ? Number.parseInt(raw, 10) : Number.NaN
+      return Number.isFinite(i) ? i : null
+    }
+
+    const positionGhost = (x: number, y: number) => {
+      const g = ghostRef.current
+      if (!g) return
+      g.style.transform = `translate3d(${x}px, ${y}px, 0) translate(-50%, -50%) rotate(-2deg)`
+    }
+
+    const flushMove = () => {
+      rafId = 0
+      pendingMove = false
+      if (!activeRef.current) return
+      positionGhost(lastX, lastY)
+      const next = findTargetIndex(lastX, lastY)
+      if (next !== targetRef.current) {
+        targetRef.current = next
+        setTargetIndex(next)
+      }
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      const pending = pendingRef.current
+      if (pending && !activeRef.current) {
+        if (pending.pointerId !== e.pointerId) return
+        const dx = e.clientX - pending.startX
+        const dy = e.clientY - pending.startY
+        if (dx * dx + dy * dy < ACTIVATION_DISTANCE * ACTIVATION_DISTANCE) {
+          return
+        }
+        sourceElRef.current = pending.sourceEl
+        pending.sourceEl.classList.add(SOURCE_CLASS)
+        const a: Active = {
+          sourceKey: pending.sourceKey,
+          sourceIndex: pending.sourceIndex,
+          ghostLabel: pending.ghostLabel,
+          ghostValue: pending.ghostValue,
+        }
+        activeRef.current = a
+        lastX = e.clientX
+        lastY = e.clientY
+        const t = findTargetIndex(lastX, lastY)
+        targetRef.current = t
+        try {
+          pending.sourceEl.setPointerCapture(pending.pointerId)
+          captureRef.current = {
+            el: pending.sourceEl,
+            pointerId: pending.pointerId,
+          }
+        } catch {
+          // Capture is best-effort.
+        }
+        setActive(a)
+        if (targetRef.current !== t) setTargetIndex(t)
+        armClickSwallow()
+        requestAnimationFrame(() => positionGhost(lastX, lastY))
+        return
+      }
+      if (!activeRef.current) return
+      lastX = e.clientX
+      lastY = e.clientY
+      if (pendingMove) return
+      pendingMove = true
+      rafId = requestAnimationFrame(flushMove)
+    }
+
+    const onPointerUp = () => {
+      const a = activeRef.current
+      const t = targetRef.current
+      if (a && t != null && t !== a.sourceIndex) {
+        onCommitRef.current(reorder(orderRef.current, a.sourceIndex, t))
+      }
+      cleanup()
+    }
+
+    const onPointerCancel = () => {
+      disarmClickSwallow()
+      cleanup()
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && activeRef.current) {
+        disarmClickSwallow()
+        cleanup()
+      }
+    }
+
+    window.addEventListener("pointermove", onPointerMove, { passive: true })
+    window.addEventListener("pointerup", onPointerUp)
+    window.addEventListener("pointercancel", onPointerCancel)
+    window.addEventListener("keydown", onKeyDown)
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove)
+      window.removeEventListener("pointerup", onPointerUp)
+      window.removeEventListener("pointercancel", onPointerCancel)
+      window.removeEventListener("keydown", onKeyDown)
+      if (rafId) cancelAnimationFrame(rafId)
+    }
+  }, [cleanup, armClickSwallow, disarmClickSwallow])
+
+  const ghost =
+    active && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            ref={ghostRef}
+            className="bg-popover pointer-events-none fixed top-0 left-0 z-50 rounded px-2 py-0.5 text-xs"
+            style={{
+              transform: "translate3d(-9999px, -9999px, 0)",
+              boxShadow: "0 8px 18px rgba(0,0,0,0.55)",
+              willChange: "transform",
+            }}
+          >
+            <div className="flex min-w-[8rem] items-baseline justify-between gap-3">
+              <span className="text-muted-foreground">{active.ghostLabel}</span>
+              <span className="font-medium tabular-nums">
+                {active.ghostValue}
+              </span>
+            </div>
+          </div>,
+          document.body,
+        )
+      : null
+
+  const rowProps = (
+    key: AbilityStatKey,
+    ghostLabel: string,
+    ghostValue: string,
+  ) => {
+    const index = order.indexOf(key)
+    const isTarget =
+      active != null &&
+      targetIndex != null &&
+      targetIndex === index &&
+      targetIndex !== active.sourceIndex
+    return {
+      [ROW_ATTR]: key,
+      [ROW_INDEX_ATTR]: index,
+      className: cn(
+        "cursor-grab select-none",
+        isTarget && "ring-primary/40 rounded-sm ring-1",
+      ),
+      onPointerDown: (e: ReactPointerEvent<HTMLElement>) => {
+        if (e.button !== 0) return
+        if (e.pointerType === "touch") return
+        pendingRef.current = {
+          sourceKey: key,
+          sourceIndex: index,
+          ghostLabel,
+          ghostValue,
+          sourceEl: e.currentTarget,
+          pointerId: e.pointerId,
+          startX: e.clientX,
+          startY: e.clientY,
+        }
+      },
+      onDragStart: (e: ReactPointerEvent<HTMLElement>) => e.preventDefault(),
+    }
+  }
+
+  return { ghost, rowProps }
+}

--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -46,10 +46,7 @@ import { adjustStrikeForZaw } from "@/lib/zaw-stats"
 
 import { AbilityIcon } from "./ability-icon"
 import { CapacityBar } from "./capacity-bar"
-import {
-  IncarnonTierGrid,
-  IncarnonTierGridSkeleton,
-} from "./incarnon-controls"
+import { IncarnonTierGrid, IncarnonTierGridSkeleton } from "./incarnon-controls"
 import { isLichWeapon } from "./layout"
 import { LichBonusElementPicker } from "./lich-bonus-picker"
 import { ShardSlot } from "./shard-controls"

--- a/apps/web/src/components/build-editor/stats-panels.tsx
+++ b/apps/web/src/components/build-editor/stats-panels.tsx
@@ -19,6 +19,7 @@ import {
 import { cn } from "@/lib/utils"
 import { formatStat } from "@/lib/warframe"
 
+import { useAbilityStatReorder } from "./ability-stat-reorder"
 import {
   ContribRow,
   formatContribAmount,
@@ -26,6 +27,10 @@ import {
   groupContributions,
   StatLine,
 } from "./stat-display"
+import {
+  useAbilityStatOrder,
+  type AbilityStatKey,
+} from "./use-ability-stat-order"
 
 export function CompanionStatsPanel({ stats }: { stats: CompanionStats }) {
   return (
@@ -47,6 +52,16 @@ export function CompanionStatsPanel({ stats }: { stats: CompanionStats }) {
 }
 
 export function WarframeStatsPanel({ stats }: { stats: WarframeStats }) {
+  const [order, setOrder] = useAbilityStatOrder()
+  const reorder = useAbilityStatReorder(order, setOrder)
+
+  const rows: Record<AbilityStatKey, { label: string; value: StatValue }> = {
+    strength: { label: "Strength", value: stats.abilityStrength },
+    duration: { label: "Duration", value: stats.abilityDuration },
+    efficiency: { label: "Efficiency", value: stats.abilityEfficiency },
+    range: { label: "Range", value: stats.abilityRange },
+  }
+
   return (
     <>
       <div className="flex flex-col gap-1 text-xs">
@@ -60,31 +75,28 @@ export function WarframeStatsPanel({ stats }: { stats: WarframeStats }) {
       <Separator />
 
       <div className="flex flex-col gap-1 text-xs">
-        <StatLine
-          label="Strength"
-          value={stats.abilityStrength}
-          unit="%"
-          digits={1}
-        />
-        <StatLine
-          label="Duration"
-          value={stats.abilityDuration}
-          unit="%"
-          digits={1}
-        />
-        <StatLine
-          label="Efficiency"
-          value={stats.abilityEfficiency}
-          unit="%"
-          digits={1}
-        />
-        <StatLine
-          label="Range"
-          value={stats.abilityRange}
-          unit="%"
-          digits={1}
-        />
+        {order.map((key) => {
+          const row = rows[key]
+          return (
+            <div
+              key={key}
+              {...reorder.rowProps(
+                key,
+                row.label,
+                `${formatStat(row.value.modified, 1)}%`,
+              )}
+            >
+              <StatLine
+                label={row.label}
+                value={row.value}
+                unit="%"
+                digits={1}
+              />
+            </div>
+          )
+        })}
       </div>
+      {reorder.ghost}
     </>
   )
 }

--- a/apps/web/src/components/build-editor/use-ability-stat-order.ts
+++ b/apps/web/src/components/build-editor/use-ability-stat-order.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react"
+
+export const ABILITY_STAT_KEYS = [
+  "strength",
+  "duration",
+  "efficiency",
+  "range",
+] as const
+export type AbilityStatKey = (typeof ABILITY_STAT_KEYS)[number]
+
+const STORAGE_KEY = "arsenyx-ability-stat-order"
+const DEFAULT: readonly AbilityStatKey[] = ABILITY_STAT_KEYS
+
+function sanitize(input: unknown): AbilityStatKey[] {
+  if (!Array.isArray(input)) return [...DEFAULT]
+  const valid = new Set<string>(ABILITY_STAT_KEYS)
+  const seen = new Set<AbilityStatKey>()
+  const out: AbilityStatKey[] = []
+  for (const k of input) {
+    if (typeof k === "string" && valid.has(k)) {
+      const key = k as AbilityStatKey
+      if (!seen.has(key)) {
+        seen.add(key)
+        out.push(key)
+      }
+    }
+  }
+  for (const k of DEFAULT) if (!seen.has(k)) out.push(k)
+  return out
+}
+
+export function useAbilityStatOrder() {
+  const [order, setOrder] = useState<AbilityStatKey[]>(() => [...DEFAULT])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (raw) setOrder(sanitize(JSON.parse(raw)))
+    } catch {
+      // Corrupt JSON — keep default.
+    }
+  }, [])
+
+  const commit = (next: AbilityStatKey[]) => {
+    setOrder(next)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      // Quota / disabled storage — in-memory state still updates.
+    }
+  }
+
+  return [order, commit] as const
+}

--- a/apps/web/src/components/build-editor/use-build-slots.ts
+++ b/apps/web/src/components/build-editor/use-build-slots.ts
@@ -87,6 +87,25 @@ export function getNextSlot(current: SlotId, layout: SlotLayout): SlotId {
   return list[idx + 1]
 }
 
+/**
+ * Next empty slot in reading order after `current`. Returns null when
+ * every slot from `current` onward is occupied. Cursor skips filled
+ * slots so rapid mod-clicking doesn't overwrite a user's arrangement.
+ */
+export function getNextEmptySlot(
+  current: SlotId,
+  layout: SlotLayout,
+  placed: Partial<Record<SlotId, PlacedMod>>,
+): SlotId | null {
+  const list = getVisibleSlots(layout)
+  const start = list.indexOf(current)
+  if (start === -1) return null
+  for (let i = start + 1; i < list.length; i++) {
+    if (!placed[list[i]]) return list[i]
+  }
+  return null
+}
+
 export interface BuildSlotsState {
   placed: Partial<Record<SlotId, PlacedMod>>
   usedNames: Set<string>
@@ -156,7 +175,7 @@ export function useBuildSlots(
         }
 
         if (selected && canPlaceIn(mod, selected)) {
-          setSelected(getNextSlot(selected, layout))
+          setSelected(getNextEmptySlot(selected, layout, prev))
           return { ...prev, [selected]: { mod, rank: maxRank(mod) } }
         }
 
@@ -172,7 +191,7 @@ export function useBuildSlots(
 
         for (const id of tryIds) {
           if (!prev[id] && canPlaceIn(mod, id)) {
-            setSelected(getNextSlot(id, layout))
+            setSelected(getNextEmptySlot(id, layout, prev))
             return { ...prev, [id]: { mod, rank: maxRank(mod) } }
           }
         }

--- a/apps/web/src/components/build-editor/use-keyboard-nav.ts
+++ b/apps/web/src/components/build-editor/use-keyboard-nav.ts
@@ -1,6 +1,11 @@
 import { useHotkey } from "@/lib/hotkeys"
 
-import type { BuildSlotsState, SlotId, SlotLayout } from "./use-build-slots"
+import {
+  getVisibleSlots,
+  type BuildSlotsState,
+  type SlotId,
+  type SlotLayout,
+} from "./use-build-slots"
 
 export type Dir = "left" | "right" | "up" | "down"
 
@@ -130,6 +135,18 @@ export function useSlotKeyboardNav({
       }
       const next = move(slots.selected, dir, layout)
       if (next !== slots.selected) slots.select(next)
+    },
+    { enabled },
+  )
+
+  useHotkey(
+    "`",
+    (e) => {
+      const t = e.target as HTMLElement | null
+      if (t?.closest("[data-mod-search-grid]")) return
+      const list = getVisibleSlots(layout)
+      const firstEmpty = list.find((id) => !slots.placed[id])
+      if (firstEmpty && firstEmpty !== slots.selected) slots.select(firstEmpty)
     },
     { enabled },
   )

--- a/apps/web/src/components/create-editor/search-panel.tsx
+++ b/apps/web/src/components/create-editor/search-panel.tsx
@@ -7,10 +7,7 @@ import { type Mod } from "@arsenyx/shared/warframe/types"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
 
-import {
-  ModSearchGrid,
-  type ModSlotKind,
-} from "@/components/build-editor"
+import { ModSearchGrid, type ModSlotKind } from "@/components/build-editor"
 import { type HelminthAbility } from "@/lib/helminth-query"
 import { modsQuery } from "@/lib/mods-query"
 import { type BrowseCategory, type DetailItem } from "@/lib/warframe"

--- a/apps/web/src/lib/admin-actions.ts
+++ b/apps/web/src/lib/admin-actions.ts
@@ -19,7 +19,9 @@ async function adminCall<T = unknown>(
     return await apiFetch<T>(path, opts)
   } catch (err) {
     if (err instanceof ApiError) {
-      throw new Error(apiErrorMessage(err, `http_${err.status}`))
+      throw new Error(apiErrorMessage(err, `http_${err.status}`), {
+        cause: err,
+      })
     }
     throw err
   }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -23,12 +23,7 @@ export class ApiError extends Error {
  *  it isn't an `ApiError` or the body has no message field. */
 export function apiErrorMessage(err: unknown, fallback: string): string {
   if (!(err instanceof ApiError)) return fallback
-  return (
-    err.body?.message ??
-    err.body?.error ??
-    err.body?.details ??
-    fallback
-  )
+  return err.body?.message ?? err.body?.error ?? err.body?.details ?? fallback
 }
 
 export interface ApiFetchInit extends Omit<RequestInit, "body"> {

--- a/apps/web/src/lib/build-actions.ts
+++ b/apps/web/src/lib/build-actions.ts
@@ -14,7 +14,8 @@ export function useDeleteBuild(slug: string) {
         })
       } catch (err) {
         if (err instanceof ApiError) {
-          if (err.status === 401) throw new Error("unauthorized", { cause: err })
+          if (err.status === 401)
+            throw new Error("unauthorized", { cause: err })
           if (err.status === 403) throw new Error("forbidden", { cause: err })
           throw new Error("failed_delete", { cause: err })
         }
@@ -39,7 +40,8 @@ export function useForkBuild(slug: string) {
         )
       } catch (err) {
         if (err instanceof ApiError) {
-          if (err.status === 401) throw new Error("unauthorized", { cause: err })
+          if (err.status === 401)
+            throw new Error("unauthorized", { cause: err })
           if (err.status === 404) throw new Error("not_found", { cause: err })
           throw new Error("failed_fork", { cause: err })
         }

--- a/apps/web/src/lib/build-social.ts
+++ b/apps/web/src/lib/build-social.ts
@@ -12,14 +12,14 @@ async function send<T>(
   method: "POST" | "DELETE",
 ): Promise<T> {
   try {
-    return await apiFetch<T>(
-      `/builds/${encodeURIComponent(slug)}/${kind}`,
-      { method },
-    )
+    return await apiFetch<T>(`/builds/${encodeURIComponent(slug)}/${kind}`, {
+      method,
+    })
   } catch (err) {
     if (err instanceof ApiError && err.status === 401)
       throw new Error("unauthorized", { cause: err })
-    if (err instanceof ApiError) throw new Error(`failed_${kind}`, { cause: err })
+    if (err instanceof ApiError)
+      throw new Error(`failed_${kind}`, { cause: err })
     throw err
   }
 }

--- a/apps/web/src/lib/hotkeys.ts
+++ b/apps/web/src/lib/hotkeys.ts
@@ -43,6 +43,11 @@ export const HOTKEYS: readonly Hotkey[] = [
   },
   {
     scope: "Build editor",
+    keys: ["`"],
+    description: "Select the first empty slot",
+  },
+  {
+    scope: "Build editor",
     keys: ["↑", "↓", "←", "→"],
     description: "Move between slots",
   },

--- a/apps/web/src/lib/me-query.ts
+++ b/apps/web/src/lib/me-query.ts
@@ -69,7 +69,7 @@ export async function createApiKey(input: {
       json: input,
     })
   } catch (err) {
-    throw new Error(apiErrorMessage(err, "Request failed"))
+    throw new Error(apiErrorMessage(err, "Request failed"), { cause: err })
   }
 }
 
@@ -79,6 +79,6 @@ export async function revokeApiKey(id: string): Promise<void> {
       method: "DELETE",
     })
   } catch (err) {
-    throw new Error(apiErrorMessage(err, "Request failed"))
+    throw new Error(apiErrorMessage(err, "Request failed"), { cause: err })
   }
 }

--- a/apps/web/src/lib/org-actions.ts
+++ b/apps/web/src/lib/org-actions.ts
@@ -24,7 +24,7 @@ export function useCreateOrg() {
           json: input,
         })
       } catch (err) {
-        throw new Error(orgError(err))
+        throw new Error(orgError(err), { cause: err })
       }
     },
     onSuccess: () => {
@@ -50,7 +50,7 @@ export function useUpdateOrg(slug: string) {
           { method: "PATCH", json: input },
         )
       } catch (err) {
-        throw new Error(orgError(err))
+        throw new Error(orgError(err), { cause: err })
       }
     },
     onSuccess: (data) => {
@@ -72,7 +72,7 @@ export function useDeleteOrg(slug: string) {
           method: "DELETE",
         })
       } catch (err) {
-        throw new Error(orgError(err))
+        throw new Error(orgError(err), { cause: err })
       }
     },
     onSuccess: () => {
@@ -88,12 +88,12 @@ export function useAddOrgMember(slug: string) {
   return useMutation({
     mutationFn: async (username: string): Promise<void> => {
       try {
-        await apiFetch<void>(
-          `/orgs/${encodeURIComponent(slug)}/members`,
-          { method: "POST", json: { username } },
-        )
+        await apiFetch<void>(`/orgs/${encodeURIComponent(slug)}/members`, {
+          method: "POST",
+          json: { username },
+        })
       } catch (err) {
-        throw new Error(orgError(err))
+        throw new Error(orgError(err), { cause: err })
       }
     },
     onSuccess: () => {
@@ -116,7 +116,7 @@ export function useUpdateOrgMemberRole(slug: string) {
           { method: "PATCH", json: { role: input.role } },
         )
       } catch (err) {
-        throw new Error(orgError(err))
+        throw new Error(orgError(err), { cause: err })
       }
     },
     onMutate: async (input) => {
@@ -151,7 +151,7 @@ export function useRemoveOrgMember(slug: string) {
           { method: "DELETE" },
         )
       } catch (err) {
-        throw new Error(orgError(err))
+        throw new Error(orgError(err), { cause: err })
       }
     },
     onSuccess: () => {

--- a/apps/web/src/lib/partner-builds-query.ts
+++ b/apps/web/src/lib/partner-builds-query.ts
@@ -57,9 +57,10 @@ export function useLinkPartner(ownerSlug: string) {
         )
       } catch (err) {
         if (err instanceof ApiError) {
-          if (err.status === 401) throw new Error("unauthorized")
-          if (err.status === 403) throw new Error("forbidden")
-          throw new Error("failed_link")
+          if (err.status === 401)
+            throw new Error("unauthorized", { cause: err })
+          if (err.status === 403) throw new Error("forbidden", { cause: err })
+          throw new Error("failed_link", { cause: err })
         }
         throw err
       }

--- a/apps/web/src/lib/profile-query.ts
+++ b/apps/web/src/lib/profile-query.ts
@@ -38,9 +38,7 @@ export const profileQuery = (username: string) =>
     queryKey: ["profile", username.toLowerCase()],
     queryFn: async (): Promise<Profile> => {
       try {
-        return await apiFetch<Profile>(
-          `/users/${encodeURIComponent(username)}`,
-        )
+        return await apiFetch<Profile>(`/users/${encodeURIComponent(username)}`)
       } catch (err) {
         if (err instanceof ApiError && err.status === 404) throw notFound()
         throw new Error("failed to load profile", { cause: err })

--- a/apps/web/src/lib/shards.ts
+++ b/apps/web/src/lib/shards.ts
@@ -8,12 +8,7 @@ import {
   type PlacedShard,
 } from "@arsenyx/shared/warframe"
 
-export {
-  SHARD_COLORS,
-  SHARD_STATS,
-  getStatIndex,
-  getStatByIndex,
-}
+export { SHARD_COLORS, SHARD_STATS, getStatIndex, getStatByIndex }
 export type { ShardColor, ShardStat, PlacedShard }
 
 export const SHARD_COLOR_NAMES: Record<ShardColor, string> = {

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -1,5 +1,5 @@
-import { slugify } from "@arsenyx/shared/warframe/slugs"
 import { getIncarnonBaseName } from "@arsenyx/shared/warframe/incarnon-data"
+import { slugify } from "@arsenyx/shared/warframe/slugs"
 import {
   DEFAULT_DEPLOYMENT_CONTEXT,
   type LichBonusElement,
@@ -1235,7 +1235,7 @@ function EmbedZawPart({ name, type }: { name: string; type: "Grip" | "Link" }) {
           className="h-full w-full object-contain"
         />
       ) : (
-        <span className="text-muted-foreground px-0.5 text-center text-[9px] font-medium leading-tight">
+        <span className="text-muted-foreground px-0.5 text-center text-[9px] leading-tight font-medium">
           {name}
         </span>
       )}
@@ -1301,7 +1301,11 @@ function EmbedIncarnonStrip({
             tier.perks.find((p) => p.name === (perks[tier.tier - 1] ?? null)) ??
             null
           return (
-            <EmbedIncarnonTier key={tier.tier} tier={tier.tier} picked={picked} />
+            <EmbedIncarnonTier
+              key={tier.tier}
+              tier={tier.tier}
+              picked={picked}
+            />
           )
         })}
       </div>
@@ -1344,7 +1348,9 @@ function EmbedIncarnonTier({
   const tooltipContent = picked ? (
     <>
       <p className="font-semibold">{picked.name}</p>
-      <p className="text-muted-foreground mt-0.5 text-xs">{picked.description}</p>
+      <p className="text-muted-foreground mt-0.5 text-xs">
+        {picked.description}
+      </p>
     </>
   ) : (
     <span className="text-muted-foreground">Tier {tier} — not selected</span>

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -20,11 +20,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query"
-import {
-  createFileRoute,
-  redirect,
-  useNavigate,
-} from "@tanstack/react-router"
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
 import { Suspense, useEffect, useMemo, useState } from "react"
 
 import {
@@ -475,9 +471,7 @@ function EditorShell() {
               itemName: item.name,
             }),
       }
-      const path = isUpdate
-        ? `/builds/${existingBuild!.slug}`
-        : `/builds`
+      const path = isUpdate ? `/builds/${existingBuild!.slug}` : `/builds`
       const { slug } = await apiFetch<{ id: string; slug: string }>(path, {
         method: isUpdate ? "PATCH" : "POST",
         json: body,

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -51,7 +51,7 @@ async function postOverframeImport(url: string): Promise<ScrapeResponse> {
   } catch (err) {
     const fallback =
       err instanceof ApiError ? `Import failed: ${err.status}` : "Import failed"
-    throw new Error(apiErrorMessage(err, fallback))
+    throw new Error(apiErrorMessage(err, fallback), { cause: err })
   }
 }
 

--- a/packages/shared/src/warframe/mods.ts
+++ b/packages/shared/src/warframe/mods.ts
@@ -54,7 +54,10 @@ export function normalizeMods(rawMods: Mod[]): Mod[] {
       // Unused upstream entry that ships as a second "Pressure Point" with
       // +200% Melee Damage + +120% combo count chance. Not a real in-game
       // mod; @wfcd/items keeps it for parity with the game files.
-      if (uniqueName === "/Lotus/Upgrades/Mods/Melee/WeaponMeleeDamageOnHeavyKillMod")
+      if (
+        uniqueName ===
+        "/Lotus/Upgrades/Mods/Melee/WeaponMeleeDamageOnHeavyKillMod"
+      )
         return false
 
       return true


### PR DESCRIPTION
## Summary

Two small build-editor UX wins:

- **Reorderable ability stats.** Drag to reorder the Strength / Duration / Efficiency / Range rows in the stats panel. Order is per-user and persisted in localStorage — no URL state, no shared drag library, custom inline pointer-drag with a portal ghost.
- **Hotkey to jump to first empty slot.** Pressing backtick (or Home) focuses the first empty mod slot so users can flow straight into arrow-key navigation.
- **Auto-advance skips occupied slots.** After placing a mod, the cursor now advances to the next *empty compatible* slot instead of clobbering whatever was in the literal-next slot. Reported by ninjase on Discord. Explicit clicks still swap-in-place.

Also includes incidental oxfmt churn from a `just fix` pass — most of the touched files are reformat-only.

## Files of interest

- `apps/web/src/components/build-editor/use-build-slots.ts` — skip-occupied logic
- `apps/web/src/components/build-editor/use-ability-stat-order.ts` (new) — localStorage-backed order hook
- `apps/web/src/components/build-editor/ability-stat-reorder.tsx` (new) — custom drag component
- `apps/web/src/components/build-editor/stats-panels.tsx` — integration
- `apps/web/src/components/build-editor/use-keyboard-nav.ts`, `apps/web/src/lib/hotkeys.ts` — new hotkey

## Test plan

- [x] Reorder ability stat rows; refresh; order persists.
- [x] Place a mod with the next slot empty → cursor advances to it.
- [x] Place a mod with the next slot occupied → cursor skips to the next empty compatible one; the filled slot is untouched.
- [x] Explicit click on a filled slot still swaps in place.
- [x] Press backtick (and Home) with no slot focused → first empty slot gets focus; arrow keys then navigate.