### PR TITLE
Embed videos in build guides; fix Exodia arcanes on Zaws

### DIFF
--- a/apps/web/src/components/build-editor/guide-editor.tsx
+++ b/apps/web/src/components/build-editor/guide-editor.tsx
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query"
 import { ChevronDown, Link2, X } from "lucide-react"
 import { useRef, useState } from "react"
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
 
+import { MarkdownBody } from "@/components/markdown-body"
 import { Button } from "@/components/ui/button"
 import {
   Command,
@@ -92,7 +91,7 @@ export function GuideEditor({
             <MarkdownTextarea
               value={description}
               onChange={onDescriptionChange}
-              placeholder="Write your build guide in markdown — headings, lists, links, code blocks all work."
+              placeholder="Write your build guide in markdown — headings, lists, links, code blocks all work. Paste a YouTube or Vimeo link on its own line to embed the video."
             />
           </TabsContent>
           <TabsContent value="preview">
@@ -393,10 +392,9 @@ function MarkdownTextarea({
 
 function MarkdownPreview({ source }: { source: string }) {
   return (
-    <div className="prose prose-sm dark:prose-invert [&_a]:text-primary [&_code]:bg-muted [&_pre]:bg-muted [&_blockquote]:border-border [&_blockquote]:text-muted-foreground [&_th]:border-border [&_td]:border-border max-w-none [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-xs [&_h1]:mt-0 [&_h1]:mb-2 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h3]:font-semibold [&_li]:ml-4 [&_li]:list-disc [&_ol]:mb-2 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol_li]:list-decimal [&_p]:mb-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:p-2 [&_pre]:text-xs [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_table]:w-full [&_td]:border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:px-2 [&_th]:py-1 [&_ul]:mb-2 [&_ul]:list-disc [&_ul]:pl-4">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[]}>
-        {source}
-      </ReactMarkdown>
-    </div>
+    <MarkdownBody
+      source={source}
+      className="prose prose-sm dark:prose-invert [&_a]:text-primary [&_code]:bg-muted [&_pre]:bg-muted [&_blockquote]:border-border [&_blockquote]:text-muted-foreground [&_th]:border-border [&_td]:border-border max-w-none [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-xs [&_h1]:mt-0 [&_h1]:mb-2 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h3]:font-semibold [&_li]:ml-4 [&_li]:list-disc [&_ol]:mb-2 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol_li]:list-decimal [&_p]:mb-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:p-2 [&_pre]:text-xs [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_table]:w-full [&_td]:border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:px-2 [&_th]:py-1 [&_ul]:mb-2 [&_ul]:list-disc [&_ul]:pl-4"
+    />
   )
 }

--- a/apps/web/src/components/markdown-body.tsx
+++ b/apps/web/src/components/markdown-body.tsx
@@ -1,0 +1,101 @@
+import type { ElementContent } from "hast"
+import { useMemo } from "react"
+import ReactMarkdown, { type Components } from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+import { getVideoEmbed } from "@/lib/video-embed"
+
+/**
+ * Renders user-authored markdown for build guides. Bare YouTube/Vimeo URLs
+ * on their own line are upgraded to embedded iframes; inline links stay
+ * regular anchors. Raw HTML in the source is escaped — no rehype-raw.
+ */
+export function MarkdownBody({
+  source,
+  className,
+}: {
+  source: string
+  className?: string
+}) {
+  const prepared = useMemo(() => isolateVideoLines(source), [source])
+  return (
+    <div className={className}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {prepared}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+/**
+ * Wraps lines that consist solely of a recognized video URL with blank
+ * lines so markdown treats them as their own paragraph. Without this,
+ * `Hi\nhttps://youtu.be/...\nTesting` would be one paragraph and the
+ * embed check would miss it.
+ */
+function isolateVideoLines(source: string): string {
+  const lines = source.split(/\r?\n/)
+  const out: string[] = []
+  for (const line of lines) {
+    const trimmed = line.trim()
+    const isVideo =
+      /^https?:\/\/\S+$/.test(trimmed) && getVideoEmbed(trimmed) !== null
+    if (isVideo) {
+      if (out.length > 0 && out[out.length - 1].trim() !== "") out.push("")
+      out.push(trimmed)
+      out.push("")
+    } else {
+      out.push(line)
+    }
+  }
+  return out.join("\n")
+}
+
+function soloVideoHref(kids: ElementContent[]): string | null {
+  if (kids.length !== 1) return null
+  const only = kids[0]
+  if (only.type !== "element" || only.tagName !== "a") return null
+  const href = only.properties?.href
+  return typeof href === "string" ? href : null
+}
+
+const components: Components = {
+  p({ node, children, ...rest }) {
+    const href = soloVideoHref(node?.children ?? [])
+    const embed = href ? getVideoEmbed(href) : null
+    if (embed) return <VideoEmbed {...embed} />
+    return <p {...rest}>{children}</p>
+  },
+}
+
+function VideoEmbed({
+  src,
+  title,
+  aspect,
+}: {
+  src: string
+  title: string
+  aspect: "16/9" | "9/16"
+}) {
+  const portrait = aspect === "9/16"
+  return (
+    <div
+      className="bg-muted relative my-3 w-full overflow-hidden rounded-lg border"
+      style={{
+        aspectRatio: portrait ? "9 / 16" : "16 / 9",
+        maxWidth: portrait ? "min(100%, 320px)" : "min(100%, 560px)",
+      }}
+    >
+      {/* oxlint-disable-next-line react/iframe-missing-sandbox -- trusted video provider; sandbox would break the player */}
+      <iframe
+        src={src}
+        title={title}
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+        className="absolute inset-0 size-full"
+      />
+    </div>
+  )
+}

--- a/apps/web/src/lib/video-embed.ts
+++ b/apps/web/src/lib/video-embed.ts
@@ -1,0 +1,82 @@
+/**
+ * Maps a URL to a safe video embed. Strict allowlist — only well-known
+ * video hosts whose embed iframes are sandboxed by the provider.
+ *
+ * Used by markdown rendering to auto-embed bare YouTube/Vimeo links that
+ * appear on their own line. Inline links inside prose are left alone.
+ */
+export type VideoEmbed = {
+  src: string
+  title: string
+  aspect: "16/9" | "9/16"
+}
+
+export function getVideoEmbed(rawUrl: string): VideoEmbed | null {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return null
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null
+
+  const host = url.hostname.replace(/^www\./, "")
+
+  // YouTube — youtu.be/ID, youtube.com/watch?v=ID, youtube.com/shorts/ID,
+  // youtube.com/embed/ID, m.youtube.com/watch?v=ID
+  const start = parseTimecode(
+    url.searchParams.get("t") ?? url.searchParams.get("start") ?? "",
+  )
+  if (host === "youtu.be") {
+    return ytEmbed(url.pathname.slice(1).split("/")[0], start)
+  }
+  if (
+    host === "youtube.com" ||
+    host === "m.youtube.com" ||
+    host === "youtube-nocookie.com"
+  ) {
+    if (url.pathname === "/watch") return ytEmbed(url.searchParams.get("v"), start)
+    const shorts = url.pathname.match(/^\/shorts\/([^/]+)/)
+    if (shorts) return ytEmbed(shorts[1], start, "9/16")
+    const embed = url.pathname.match(/^\/embed\/([^/]+)/)
+    if (embed) return ytEmbed(embed[1], start)
+  }
+
+  // Vimeo — vimeo.com/ID or vimeo.com/ID/HASH (unlisted videos)
+  if (host === "vimeo.com" || host === "player.vimeo.com") {
+    const m = url.pathname.match(/^\/(?:video\/)?(\d+)(?:\/([a-f0-9]+))?/)
+    if (m) {
+      const [, id, hash] = m
+      const src = hash
+        ? `https://player.vimeo.com/video/${id}?h=${hash}`
+        : `https://player.vimeo.com/video/${id}`
+      return { src, title: "Vimeo video", aspect: "16/9" }
+    }
+  }
+
+  return null
+}
+
+function ytEmbed(
+  id: string | null,
+  start: number | null,
+  aspect: VideoEmbed["aspect"] = "16/9",
+): VideoEmbed | null {
+  if (!id || !/^[A-Za-z0-9_-]{6,}$/.test(id)) return null
+  const qs = start ? `?start=${start}` : ""
+  return {
+    src: `https://www.youtube-nocookie.com/embed/${id}${qs}`,
+    title: "YouTube video",
+    aspect,
+  }
+}
+
+function parseTimecode(t: string): number | null {
+  if (!t) return null
+  if (/^\d+$/.test(t)) return Number(t) || null
+  const m = t.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/)
+  if (!m) return null
+  const [, h, mm, s] = m
+  const total = Number(h ?? 0) * 3600 + Number(mm ?? 0) * 60 + Number(s ?? 0)
+  return total || null
+}

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -31,8 +31,6 @@ import {
   Zap,
 } from "lucide-react"
 import { Suspense, useEffect, useMemo, useRef, useState } from "react"
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
 
 import {
   ArcaneRow,
@@ -58,6 +56,7 @@ import {
 } from "@/components/build-editor"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
+import { MarkdownBody } from "@/components/markdown-body"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -567,11 +566,10 @@ function BuildViewerBodyInner({
               <p className="mb-3 font-medium">{build.guide.summary}</p>
             ) : null}
             {build.guide.description ? (
-              <div className="prose prose-sm dark:prose-invert max-w-none">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                  {build.guide.description}
-                </ReactMarkdown>
-              </div>
+              <MarkdownBody
+                source={build.guide.description}
+                className="prose prose-sm dark:prose-invert max-w-none"
+              />
             ) : null}
           </div>
         ) : null}

--- a/packages/shared/src/warframe/arcanes.ts
+++ b/packages/shared/src/warframe/arcanes.ts
@@ -25,40 +25,31 @@ export type ArcaneSlotType =
   | "melee"
   | "weapon"
 
+// "Zaw Arcane" covers Exodia arcanes (Zaw-only in-game, surfaced for any
+// melee here to match the rest of the permissive pool).
+const PRIMARY_TOKENS = ["primary", "residua", "fractal"] as const
+const SECONDARY_TOKENS = ["secondary", "pax"] as const
+const MELEE_TOKENS = ["melee", "zaw"] as const
+
+const SLOT_TOKENS: Record<ArcaneSlotType, readonly string[]> = {
+  warframe: [], // exact-match below
+  operator: ["magus", "operator"],
+  primary: PRIMARY_TOKENS,
+  secondary: SECONDARY_TOKENS,
+  melee: MELEE_TOKENS,
+  weapon: [...PRIMARY_TOKENS, ...SECONDARY_TOKENS, ...MELEE_TOKENS],
+}
+
 export function getArcanesForSlot(
   arcanes: Arcane[],
   slotType: ArcaneSlotType,
 ): Arcane[] {
   return arcanes.filter((arcane) => {
     const type = arcane.type?.toLowerCase() ?? ""
-    switch (slotType) {
-      case "warframe":
-        return type === "arcane" || type === "warframe arcane"
-      case "operator":
-        return type.includes("magus") || type.includes("operator")
-      case "primary":
-        return (
-          type.includes("primary") ||
-          type.includes("residua") ||
-          type.includes("fractal")
-        )
-      case "secondary":
-        return type.includes("secondary") || type.includes("pax")
-      case "melee":
-        return type.includes("melee") || type.includes("exodia")
-      case "weapon":
-        return (
-          type.includes("primary") ||
-          type.includes("residua") ||
-          type.includes("fractal") ||
-          type.includes("secondary") ||
-          type.includes("pax") ||
-          type.includes("melee") ||
-          type.includes("exodia")
-        )
-      default:
-        return false
+    if (slotType === "warframe") {
+      return type === "arcane" || type === "warframe arcane"
     }
+    return SLOT_TOKENS[slotType].some((t) => type.includes(t))
   })
 }
 


### PR DESCRIPTION
## Summary

- **Video embeds in guides** — bare YouTube or Vimeo URLs on their own line in a build description now render as an embedded player. Inline links inside prose stay anchors. Strict allowlist (only these two providers); strings authored elsewhere can't smuggle in iframes. `youtube-nocookie.com` host, `loading="lazy"`, capped at 560px wide (320px for Shorts/portrait).
- **Exodia arcanes show up on Zaws now** — Exodia arcanes (Contagion, Force, Might, etc.) carry the WFCD type `"Zaw Arcane"`. The melee slot filter was matching the substring `"exodia"`, which never appears in the type field — so the picker silently excluded them. Switched the token to `"zaw"`. Refactored `getArcanesForSlot` to a small `SLOT_TOKENS` lookup table while there, removing the duplicated `weapon` branch that re-listed every other branch's tokens.

## Implementation notes

- New `apps/web/src/components/markdown-body.tsx` wraps `ReactMarkdown` and overrides the `p` renderer: if a paragraph's only child is an anchor whose href maps to a recognized video, swap in a `<VideoEmbed />` instead. Memoized preprocessing avoids re-walking the source on unrelated parent re-renders (likes, bookmarks, session updates).
- `isolateVideoLines` inserts blank lines around bare video URLs so markdown treats them as their own paragraph — otherwise a URL between two text lines would join them into one paragraph and the embed check would never match.
- The build page and the editor preview now share `MarkdownBody`. Editor placeholder updated so the feature is discoverable.
- react-markdown v10 passes **hast** nodes (HTML AST), not mdast — the override checks `type: "element"` + `tagName: "a"` rather than mdast `link` nodes (a subtle gotcha worth flagging for future markdown work).

## Test plan

- [x] Open an existing build; edit the description and paste `https://youtu.be/<id>` on its own line — confirm preview tab renders the embed.
- [x] Same with `https://vimeo.com/<id>` and an unlisted `https://vimeo.com/<id>/<hash>` link.
- [x] Confirm an inline YouTube link inside prose stays a normal anchor.
- [x] Confirm raw `<iframe>` tags in the source are escaped, not rendered.
- [x] Equip a Zaw strike on a melee build; open the arcane slot; search "Contagion" — confirm Exodia Contagion appears and can be socketed.
- [x] Confirm normal melee weapons (e.g. Nikana Prime) still show melee arcanes and now also show Exodia arcanes (intentional — matches existing permissive pool behavior).