### PR TITLE
Fix stale state leaking between related builds

### DIFF
--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -260,6 +260,7 @@ function BuildViewer({ embed = false }: { embed?: boolean }) {
   return (
     <Suspense fallback={<p className="text-muted-foreground">Loading item…</p>}>
       <BuildViewerBody
+        key={slug}
         build={build}
         category={category}
         itemSlug={itemSlug}


### PR DESCRIPTION
## Summary
- Clicking a chip in the **Related builds** strip navigated `/builds/A` → `/builds/B`, but TanStack Router reused the same component instance. `useBuildSlots` / `useArcaneSlots` lazy-init their `useState` from the loaded build, so the previous build's placed mods, arcanes, and forma persisted into the next render.
- Symptoms: wrong mods rendered, capacity over budget (e.g. 86/60), stance slot mis-rendered, totals nonsensical.
- Fix: key `BuildViewerBody` on `slug` so each build gets a fresh mount.

## Test plan
- [x] Open a melee build, click a related warframe build chip, then navigate back — mods, capacity, and stance slot match the original build.
- [x] Direct loads of either build still render correctly.