### PR TITLE
Polish related-builds chips and default ability stat order

### DIFF
--- a/apps/web/src/components/build-editor/use-ability-stat-order.ts
+++ b/apps/web/src/components/build-editor/use-ability-stat-order.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react"
 
 export const ABILITY_STAT_KEYS = [
-  "strength",
   "duration",
   "efficiency",
   "range",
+  "strength",
 ] as const
 export type AbilityStatKey = (typeof ABILITY_STAT_KEYS)[number]
 

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -605,9 +605,9 @@ function RelatedBuildChip({ build }: { build: PartnerBuild }) {
     <RouterLink
       to="/builds/$slug"
       params={{ slug: build.slug }}
-      className="bg-card hover:bg-card/70 inline-flex items-center gap-2 rounded-md border py-1 pr-3 pl-1 transition-colors"
+      className="bg-card hover:bg-card/70 inline-flex w-80 items-center gap-3 rounded-md border py-2 pr-4 pl-2 transition-colors"
     >
-      <span className="bg-muted/40 flex size-8 shrink-0 items-center justify-center overflow-hidden rounded">
+      <span className="bg-muted/40 flex size-12 shrink-0 items-center justify-center overflow-hidden rounded">
         <img
           src={getImageUrl(build.item.imageName ?? undefined)}
           alt=""
@@ -615,10 +615,10 @@ function RelatedBuildChip({ build }: { build: PartnerBuild }) {
         />
       </span>
       <span className="flex min-w-0 flex-col leading-tight">
-        <span className="max-w-[20ch] truncate text-xs font-medium">
+        <span className="max-w-[28ch] truncate text-sm font-medium">
           {build.name}
         </span>
-        <span className="text-muted-foreground max-w-[20ch] truncate text-[11px]">
+        <span className="text-muted-foreground max-w-[28ch] truncate text-xs">
           {build.item.name}
         </span>
       </span>


### PR DESCRIPTION
## Summary
- Enlarge related-build chips on the build viewer (image 8→12, more padding, sm/xs text) and lock them to a fixed `w-80` width so names truncate in a consistent column instead of producing ragged variable-width chips.
- Change the default ability stat order to **Duration | Efficiency | Range | Strength** to match the natural English ordering users expect. Users who have previously reordered stats still see their saved order from localStorage; only the default changes.

## Test plan
- [x] Open a build viewer with multiple related builds — chips are uniform width and the larger image/text reads cleanly.
- [x] Open a build in the editor with no prior `arsenyx-ability-stat-order` in localStorage — stats render in D/E/R/S order.
- [x] Clear localStorage and reload to confirm the new default.