### PR TITLE
Widen related-build chips to w-96 with flex-1 text fill

### DIFF
--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -589,9 +589,9 @@ function RelatedBuildsStrip({ slug }: { slug: string }) {
       <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
         Related builds
       </h2>
-      <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+      <ul className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:thin]">
         {partners.map((p) => (
-          <li key={p.id} className="min-w-0">
+          <li key={p.id} className="shrink-0">
             <RelatedBuildChip build={p} />
           </li>
         ))}
@@ -605,7 +605,8 @@ function RelatedBuildChip({ build }: { build: PartnerBuild }) {
     <RouterLink
       to="/builds/$slug"
       params={{ slug: build.slug }}
-      className="bg-card hover:bg-card/70 flex w-full items-center gap-3 rounded-md border py-2 pr-4 pl-2 transition-colors"
+      title={build.name}
+      className="bg-card hover:bg-card/70 flex w-80 items-center gap-3 rounded-md border py-2 pr-4 pl-2 transition-colors"
     >
       <span className="bg-muted/40 flex size-12 shrink-0 items-center justify-center overflow-hidden rounded">
         <img

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -589,9 +589,9 @@ function RelatedBuildsStrip({ slug }: { slug: string }) {
       <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
         Related builds
       </h2>
-      <ul className="flex flex-wrap gap-2">
+      <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {partners.map((p) => (
-          <li key={p.id}>
+          <li key={p.id} className="min-w-0">
             <RelatedBuildChip build={p} />
           </li>
         ))}
@@ -605,7 +605,7 @@ function RelatedBuildChip({ build }: { build: PartnerBuild }) {
     <RouterLink
       to="/builds/$slug"
       params={{ slug: build.slug }}
-      className="bg-card hover:bg-card/70 inline-flex w-96 items-center gap-3 rounded-md border py-2 pr-4 pl-2 transition-colors"
+      className="bg-card hover:bg-card/70 flex w-full items-center gap-3 rounded-md border py-2 pr-4 pl-2 transition-colors"
     >
       <span className="bg-muted/40 flex size-12 shrink-0 items-center justify-center overflow-hidden rounded">
         <img

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -605,7 +605,7 @@ function RelatedBuildChip({ build }: { build: PartnerBuild }) {
     <RouterLink
       to="/builds/$slug"
       params={{ slug: build.slug }}
-      className="bg-card hover:bg-card/70 inline-flex w-80 items-center gap-3 rounded-md border py-2 pr-4 pl-2 transition-colors"
+      className="bg-card hover:bg-card/70 inline-flex w-96 items-center gap-3 rounded-md border py-2 pr-4 pl-2 transition-colors"
     >
       <span className="bg-muted/40 flex size-12 shrink-0 items-center justify-center overflow-hidden rounded">
         <img
@@ -614,11 +614,9 @@ function RelatedBuildChip({ build }: { build: PartnerBuild }) {
           className="size-full object-contain"
         />
       </span>
-      <span className="flex min-w-0 flex-col leading-tight">
-        <span className="max-w-[28ch] truncate text-sm font-medium">
-          {build.name}
-        </span>
-        <span className="text-muted-foreground max-w-[28ch] truncate text-xs">
+      <span className="flex min-w-0 flex-1 flex-col leading-tight">
+        <span className="truncate text-sm font-medium">{build.name}</span>
+        <span className="text-muted-foreground truncate text-xs">
           {build.item.name}
         </span>
       </span>


### PR DESCRIPTION
## Summary
- Bump related-build chip width from `w-80` to `w-96` and remove the `max-w-[28ch]` cap on the text.
- Add `flex-1` to the text column so it fills the remaining chip width before truncating.

Up for review since the prior PR's w-80 + 28ch cap was capping name text inside the chip. Wanted to compare the wider/flex-1 variant against main.

## Test plan
- [x] Compare chip width and text truncation against main on a build with long related-build names.
- [x] Confirm short names still align cleanly (no awkward whitespace).