### PR TITLE
Fix rank hotkey while picker open, refresh about/orgs copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ yarn-error.log*
 # prisma generated files
 /apps/api/src/generated/
 
+# rust crates (local experiments — dps-calc target, etc.)
+/crates/
+
 # claude temp files
 .claude/
 .agents/

--- a/apps/web/src/components/build-editor/mod-slot.tsx
+++ b/apps/web/src/components/build-editor/mod-slot.tsx
@@ -101,8 +101,11 @@ export function ModSlot({
   // on the previously-clicked slot without a separate close effect.
   const popoverOpen = pickerOpen && !!selected
 
+  // Enable on `selected` too, not just `hovered`: the picker popover steals
+  // hover when the user mouses onto it, and a clicked-but-not-hovered slot
+  // should still respond to -/+ for ranking down/up.
   useRankHotkey({
-    enabled: !readOnly && !!mod && hovered && !!onRankChange,
+    enabled: !readOnly && !!mod && (hovered || !!selected) && !!onRankChange,
     onDelta: (d) => onRankChange?.(d),
   })
 

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -27,20 +27,19 @@ function AboutPage() {
           </div>
 
           <article className="prose prose-neutral dark:prose-invert max-w-none">
-            <h2>Our Mission</h2>
+            <h2>How it started</h2>
             <p>
-              Arsenyx was built with one goal in mind: to be the fastest, most
-              modern Warframe build planner. We believe that planning your
-              loadout should be as fluid and fast as the game itself. Focused on
-              keyboard-first navigation and immediate feedback, we&apos;re
-              rethinking how Tennos share and optimize their builds.
+              Arsenyx exists because the other planners weren&apos;t open
+              source and didn&apos;t look the way we wanted them to. It was
+              built first with the Profit-Taker Community &mdash; they helped
+              test it, shaped early decisions, and pushed it past being just a
+              loadout tool. From there it grew into a whole platform.
             </p>
 
             <h2>Open Source</h2>
             <p>
-              We believe in the power of community. That&apos;s why Arsenyx is
-              fully open source. Anyone can contribute code, suggest features,
-              or report bugs. We&apos;re building this together.
+              Arsenyx is fully open source. Anyone can contribute code, suggest
+              features, or report bugs.
             </p>
             <div className="not-prose">
               <Button

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -30,10 +30,17 @@ function AboutPage() {
             <h2>How it started</h2>
             <p>
               Arsenyx exists because the other planners weren&apos;t open
-              source and didn&apos;t look the way we wanted them to. It was
+              source and didn&apos;t look the way I wanted them to. It was
               built first with the Profit-Taker Community &mdash; they helped
               test it, shaped early decisions, and pushed it past being just a
               loadout tool. From there it grew into a whole platform.
+            </p>
+
+            <h2>Who&apos;s behind it</h2>
+            <p>
+              It&apos;s just me. No team, no company, no roadmap meetings
+              &mdash; just one Tenno building the tool I wished existed, for
+              the love of the game.
             </p>
 
             <h2>Open Source</h2>

--- a/apps/web/src/routes/orgs.tsx
+++ b/apps/web/src/routes/orgs.tsx
@@ -40,8 +40,8 @@ function OrgsDirectoryPage() {
           <div className="flex flex-col gap-2">
             <h1 className="text-3xl font-bold tracking-tight">Organizations</h1>
             <p className="text-muted-foreground text-sm">
-              Communities on Arsenyx. Join one to share builds under a shared
-              banner, or browse their public builds.
+              Communities on Arsenyx. Browse their public builds — joining is
+              invite-only.
             </p>
           </div>
           <Suspense


### PR DESCRIPTION
## Summary

- **Rank hotkey while picker is open / slot is selected** — `useRankHotkey` was gated on `hovered`, so opening the polarity picker (which steals hover when the cursor moves onto the popover) left `-`/`+` silently dead. Now also fires when the slot is `selected`. Selection is single-slot, so this can't multi-fire.
- **Orgs subtitle** — previous copy implied users could join an org. Reworded to make it clear joining is invite-only.
- **About page** — replaced the generic "fastest, most modern" mission blurb with the actual origin story: built because other planners weren't open source / didn't look right, shaped with the Profit-Taker Community early on, grew into a platform from there. Trimmed the open-source paragraph of filler.
- **.gitignore** — ignore `/crates/` so the local Rust experiment stops showing up in `git status`.

## Notes on forma counts (no change)

User flagged forma counts as potentially wrong "when moving polarities around." Traced [`calculations.ts`](apps/web/src/components/build-editor/calculations.ts) against the wiki Polarization mechanics — `max(additions, removals)` for normal slots correctly models Swap Polarity (free permutation of polarized slots, including innates) and `singleSlotForma` for aura/exilus/stance correctly charges per-change (those can't be Swap-Polarity'd). If unforma exists in-game, the current "innate → cleared = 1 forma" cost also lines up. Left untouched; will revisit with a concrete repro if one surfaces.

## Test plan
- [x] Open a build, click a slot to select it, open the polarity picker; press `-` / `+` → mod rank should change
- [x] Click a slot without hovering it (e.g. via keyboard nav), press `-` / `+` → rank changes
- [x] Visit `/orgs` — subtitle reads "joining is invite-only"
- [x] Visit `/about` — first section is now "How it started" with the Profit-Taker Community origin story
- [x] `git status` no longer lists `crates/`