### PR TITLE
Fix exalted weapon mod filter (Regulators showed melee mods)

### DIFF
--- a/apps/web/src/components/create-editor/search-panel.tsx
+++ b/apps/web/src/components/create-editor/search-panel.tsx
@@ -34,6 +34,8 @@ export function SearchPanel({
         type: item.type,
         category: item.category,
         name: item.name,
+        trigger: item.trigger,
+        meleeClass: item.meleeClass,
       },
       allMods,
     )


### PR DESCRIPTION
## Summary
- `SearchPanel` (create editor) was calling `getModsForItem` without forwarding `item.trigger`, so the exalted-weapon branch in `packages/shared/src/warframe/mods.ts` couldn't distinguish trigger-bearing exalteds (Regulators, Balefire) from melee ones and fell through to the melee pool.
- Pass `trigger` and `meleeClass` through so Regulators / Regulators Prime / Balefire Charger now correctly surface pistol mods.

## Test plan
- [x] Open `/create?item=regulators-prime&category=exalted-weapons` and confirm mod search shows pistol mods (PistolElectricityDamage, SecondaryFirestorm, etc.) instead of melee mods (Primed Fever Strike, Blood Rush, Sacrificial Steel).