### PR TITLE
Lazily construct PrismaClient per request

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -11,7 +11,7 @@ import { PrismaClient } from "./generated/prisma/client"
 // `prisma` proxy unchanged.
 
 type RequestScope = {
-  client: PrismaClient
+  client: PrismaClient | null
   pending: Set<Promise<unknown>>
 }
 
@@ -40,12 +40,22 @@ function currentScope(): RequestScope {
   return scope
 }
 
+function currentClient(): PrismaClient {
+  const scope = currentScope()
+  if (!scope.client) scope.client = createPrismaClient()
+  return scope.client
+}
+
 export function withPrisma<T>(
   ctx: ExecutionContext,
   fn: () => T | Promise<T>,
 ): Promise<T> {
+  // Lazy: the client (and its WASM query engine init) is only constructed
+  // when a route actually touches `prisma.*`. Requests that satisfy from
+  // Better Auth's cookieCache (the common /auth/get-session path) never
+  // pay the Prisma init cost.
   const scope: RequestScope = {
-    client: createPrismaClient(),
+    client: null,
     pending: new Set(),
   }
   return als.run(scope, async () => {
@@ -54,11 +64,14 @@ export function withPrisma<T>(
     } finally {
       // Keep the client alive until all background work registered via
       // registerBackgroundWork() settles, then disconnect.
-      ctx.waitUntil(
-        Promise.allSettled([...scope.pending]).then(() =>
-          scope.client.$disconnect(),
-        ),
-      )
+      const client = scope.client
+      if (client || scope.pending.size > 0) {
+        ctx.waitUntil(
+          Promise.allSettled([...scope.pending]).then(() =>
+            client?.$disconnect(),
+          ),
+        )
+      }
     }
   })
 }
@@ -79,6 +92,6 @@ export function registerBackgroundWork(promise: Promise<unknown>): void {
 
 export const prisma = new Proxy({} as PrismaClient, {
   get(_, prop) {
-    return Reflect.get(currentScope().client as object, prop)
+    return Reflect.get(currentClient() as object, prop)
   },
 })


### PR DESCRIPTION
## Summary
- `/auth/get-session` was hitting `Worker exceeded CPU time limit` on Cloudflare. Root cause: `withPrisma` eagerly constructed a `PrismaClient` on every request, which on workerd compiles the WASM query engine — expensive CPU work.
- Most `/auth/get-session` calls are served from Better Auth's `cookieCache` (60s) and never touch the DB, so that init was pure waste.
- Defer `PrismaClient` construction until the `prisma` proxy is actually accessed. Cookie-cache hits now skip Prisma entirely. Also skip `$disconnect` / `waitUntil` when no client was ever created.

## Test plan
- [x] `bunx tsc --noEmit` in `apps/api`
- [x] Deploy and confirm `exceededCpu` errors on `/auth/get-session` drop in CF logs
- [x] Smoke test a logged-in session and a DB-touching route (e.g. `/builds`) to confirm lazy init still works