### PR TITLE
Add cards/rows layout toggle for build lists

### DIFF
--- a/apps/web/src/components/build-editor/guide-editor.tsx
+++ b/apps/web/src/components/build-editor/guide-editor.tsx
@@ -385,7 +385,7 @@ function MarkdownTextarea({
       onKeyDown={onKeyDown}
       onPaste={onPaste}
       placeholder={placeholder}
-      className="min-h-64 font-mono text-sm"
+      className="min-h-64 font-mono text-sm [font-variant-ligatures:none]"
     />
   )
 }

--- a/apps/web/src/components/builds/build-card.tsx
+++ b/apps/web/src/components/builds/build-card.tsx
@@ -30,7 +30,9 @@ export function BuildCard({ build }: { build: BuildListItem }) {
         />
       </div>
       <div className="flex flex-col gap-1 p-3">
-        <h3 className="line-clamp-1 text-sm font-semibold">{build.name}</h3>
+        <h3 className="line-clamp-1 text-sm font-semibold" title={build.name}>
+          {build.name}
+        </h3>
         <p className="text-muted-foreground line-clamp-1 text-xs">
           {build.item.name}
         </p>
@@ -61,6 +63,78 @@ export function BuildCard({ build }: { build: BuildListItem }) {
         </div>
       </div>
     </Link>
+  )
+}
+
+export function BuildRow({ build }: { build: BuildListItem }) {
+  const author = authorName(build.user)
+  const timeAgo = relativeTime(build.updatedAt)
+
+  return (
+    <Link
+      to="/builds/$slug"
+      params={{ slug: build.slug }}
+      className="bg-card hover:bg-card/80 flex items-center gap-3 overflow-hidden rounded-lg border p-2 transition-colors sm:gap-4 sm:p-3"
+    >
+      <div className="bg-muted/20 relative size-14 shrink-0 overflow-hidden rounded-md sm:size-16">
+        <img
+          src={getImageUrl(build.item.imageName ?? undefined)}
+          alt={build.item.name}
+          className="absolute inset-0 h-full w-full object-contain p-1"
+        />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <h3 className="line-clamp-1 text-sm font-semibold sm:text-base">
+          {build.name}
+        </h3>
+        <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 text-xs">
+          <span className="line-clamp-1">{build.item.name}</span>
+          <span aria-hidden>·</span>
+          {build.organization ? (
+            <span className="text-[#a78bfa] line-clamp-1">
+              {build.organization.name}
+            </span>
+          ) : (
+            <span className="line-clamp-1">by {author}</span>
+          )}
+        </div>
+      </div>
+      <div className="text-muted-foreground flex shrink-0 items-center gap-3 text-xs">
+        <span className="flex items-center gap-1">
+          <Heart className="size-3" />
+          <span className="tabular-nums">{build.likeCount}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <Eye className="size-3" />
+          <span className="tabular-nums">{build.viewCount}</span>
+        </span>
+        <Tooltip>
+          <TooltipTrigger
+            render={<span className="hidden w-12 text-right sm:inline">{timeAgo}</span>}
+          />
+          <TooltipContent>
+            Updated {formatAbsoluteTime(build.updatedAt)}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </Link>
+  )
+}
+
+export function BuildRowSkeleton() {
+  return (
+    <div className="bg-card flex items-center gap-3 overflow-hidden rounded-lg border p-2 sm:gap-4 sm:p-3">
+      <Skeleton className="size-14 shrink-0 rounded-md sm:size-16" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-3 w-1/3" />
+      </div>
+      <div className="flex shrink-0 items-center gap-3">
+        <Skeleton className="h-3 w-8" />
+        <Skeleton className="h-3 w-8" />
+        <Skeleton className="hidden h-3 w-12 sm:block" />
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/src/components/builds/builds-list-view.tsx
+++ b/apps/web/src/components/builds/builds-list-view.tsx
@@ -2,9 +2,18 @@ import { useQuery } from "@tanstack/react-query"
 import { Filter } from "lucide-react"
 import { useEffect, useState, type ReactNode } from "react"
 
-import { BuildCard, BuildCardSkeleton } from "@/components/builds/build-card"
+import {
+  BuildCard,
+  BuildCardSkeleton,
+  BuildRow,
+  BuildRowSkeleton,
+} from "@/components/builds/build-card"
 import { BuildsCategoryTabs } from "@/components/builds/builds-category-tabs"
 import { BuildsSortDropdown } from "@/components/builds/builds-sort-dropdown"
+import {
+  BuildsLayoutToggle,
+  buildLayoutClass,
+} from "@/components/builds/layout-toggle"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -25,6 +34,7 @@ import {
   publicBuildsQuery,
   type BuildListSort,
 } from "@/lib/builds-list-query"
+import { useBuildLayout } from "@/lib/use-build-layout"
 import { cn } from "@/lib/utils"
 import { isValidCategory, type BrowseCategory } from "@/lib/warframe"
 
@@ -109,8 +119,7 @@ export function nextBuildsListSearch(
 
 const SEARCH_DEBOUNCE_MS = 200
 
-export const BUILDS_GRID_CLASS =
-  "grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+export const BUILDS_GRID_CLASS = buildLayoutClass("cards")
 
 export function BuildsListView({
   title,
@@ -190,6 +199,7 @@ export function BuildsListView({
           <div className="flex-1" />
         )}
         <div className="flex gap-3">
+          <BuildsLayoutToggle />
           <BuildsSortDropdown
             value={sort}
             onChange={(value) =>
@@ -304,6 +314,7 @@ function Results({
   emptyState: ReactNode
 }) {
   const { data, isPending, isFetching } = useQuery(query)
+  const [layout] = useBuildLayout()
 
   if (isPending || !data) return <ResultsSkeleton />
 
@@ -322,14 +333,18 @@ function Results({
         <div
           aria-busy={isFetching}
           className={cn(
-            BUILDS_GRID_CLASS,
+            buildLayoutClass(layout),
             "transition-opacity",
             isFetching && "opacity-60",
           )}
         >
-          {data.builds.map((b) => (
-            <BuildCard key={b.id} build={b} />
-          ))}
+          {data.builds.map((b) =>
+            layout === "rows" ? (
+              <BuildRow key={b.id} build={b} />
+            ) : (
+              <BuildCard key={b.id} build={b} />
+            ),
+          )}
         </div>
       )}
 
@@ -381,6 +396,7 @@ function Results({
 }
 
 function ResultsSkeleton() {
+  const [layout] = useBuildLayout()
   return (
     <div
       role="status"
@@ -390,10 +406,14 @@ function ResultsSkeleton() {
     >
       <span className="sr-only">Loading builds…</span>
       <Skeleton className="h-4 w-32" />
-      <div className={BUILDS_GRID_CLASS}>
-        {Array.from({ length: LIST_PAGE_SIZE }).map((_, i) => (
-          <BuildCardSkeleton key={i} />
-        ))}
+      <div className={buildLayoutClass(layout)}>
+        {Array.from({ length: LIST_PAGE_SIZE }).map((_, i) =>
+          layout === "rows" ? (
+            <BuildRowSkeleton key={i} />
+          ) : (
+            <BuildCardSkeleton key={i} />
+          ),
+        )}
       </div>
     </div>
   )
@@ -407,6 +427,7 @@ export function BuildsListSkeleton({
   showFilters?: boolean
   showHeader?: boolean
 }) {
+  const [layout] = useBuildLayout()
   return (
     <div
       role="status"
@@ -424,16 +445,21 @@ export function BuildsListSkeleton({
       <div className="flex flex-col gap-3 sm:flex-row">
         <Skeleton className="h-9 flex-1" />
         <div className="flex gap-3">
+          <Skeleton className="h-9 w-20" />
           <Skeleton className="h-9 w-32" />
           {showFilters && <Skeleton className="h-9 w-24" />}
         </div>
       </div>
       {showFilters && <Skeleton className="h-8 w-full max-w-md" />}
       <Skeleton className="h-4 w-32" />
-      <div className={BUILDS_GRID_CLASS}>
-        {Array.from({ length: LIST_PAGE_SIZE }).map((_, i) => (
-          <BuildCardSkeleton key={i} />
-        ))}
+      <div className={buildLayoutClass(layout)}>
+        {Array.from({ length: LIST_PAGE_SIZE }).map((_, i) =>
+          layout === "rows" ? (
+            <BuildRowSkeleton key={i} />
+          ) : (
+            <BuildCardSkeleton key={i} />
+          ),
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/builds/layout-toggle.tsx
+++ b/apps/web/src/components/builds/layout-toggle.tsx
@@ -1,0 +1,62 @@
+import { LayoutGrid, Rows3 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { useBuildLayout, type BuildLayout } from "@/lib/use-build-layout"
+import { cn } from "@/lib/utils"
+
+export function BuildsLayoutToggle() {
+  const [layout, setLayout] = useBuildLayout()
+  return (
+    <div className="bg-card inline-flex shrink-0 items-center rounded-md border p-0.5">
+      <ToggleButton
+        active={layout === "cards"}
+        label="Card view"
+        onClick={() => setLayout("cards")}
+      >
+        <LayoutGrid className="size-4" />
+      </ToggleButton>
+      <ToggleButton
+        active={layout === "rows"}
+        label="Row view"
+        onClick={() => setLayout("rows")}
+      >
+        <Rows3 className="size-4" />
+      </ToggleButton>
+    </div>
+  )
+}
+
+function ToggleButton({
+  active,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-label={label}
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "h-7 w-8 px-0",
+        active && "bg-muted text-foreground",
+      )}
+    >
+      {children}
+    </Button>
+  )
+}
+
+export function buildLayoutClass(layout: BuildLayout) {
+  return layout === "rows"
+    ? "flex flex-col gap-2"
+    : "grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+}

--- a/apps/web/src/components/item-detail/top-builds-section.tsx
+++ b/apps/web/src/components/item-detail/top-builds-section.tsx
@@ -1,14 +1,20 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { BuildCard, BuildCardSkeleton } from "@/components/builds/build-card"
+import {
+  BuildCard,
+  BuildCardSkeleton,
+  BuildRow,
+  BuildRowSkeleton,
+} from "@/components/builds/build-card"
 import { publicBuildsQuery } from "@/lib/builds-list-query"
+import { useBuildLayout } from "@/lib/use-build-layout"
 import type { DetailItem } from "@/lib/warframe"
 
-// Flex-wrap with fixed-width cards so a small number of builds (e.g. 2)
-// don't get stretched across the full row by `1fr` grid tracks. Cards
-// align left, wrap to fill rows, and leave natural unused space on the
-// right rather than ballooning each card.
-const GRID_CLASS = "flex flex-wrap gap-3 [&>*]:w-[240px] [&>*]:max-w-full"
+// Cards: flex-wrap with fixed-width tiles so a small number of builds (e.g. 2)
+// don't get stretched across the full row by `1fr` grid tracks. They align
+// left, wrap, and leave natural unused space on the right.
+const CARDS_CLASS = "flex flex-wrap gap-3 [&>*]:w-[240px] [&>*]:max-w-full"
+const ROWS_CLASS = "flex flex-col gap-2"
 
 const TOP_BUILDS_LIMIT = 6
 
@@ -21,6 +27,8 @@ export function TopBuildsSection({ item }: { item: DetailItem }) {
       limit: TOP_BUILDS_LIMIT,
     }),
   )
+  const [layout] = useBuildLayout()
+  const containerClass = layout === "rows" ? ROWS_CLASS : CARDS_CLASS
 
   if (isLoading) {
     return (
@@ -28,12 +36,16 @@ export function TopBuildsSection({ item }: { item: DetailItem }) {
         role="status"
         aria-busy="true"
         aria-live="polite"
-        className={GRID_CLASS}
+        className={containerClass}
       >
         <span className="sr-only">Loading top builds…</span>
-        {Array.from({ length: TOP_BUILDS_LIMIT }).map((_, i) => (
-          <BuildCardSkeleton key={i} />
-        ))}
+        {Array.from({ length: TOP_BUILDS_LIMIT }).map((_, i) =>
+          layout === "rows" ? (
+            <BuildRowSkeleton key={i} />
+          ) : (
+            <BuildCardSkeleton key={i} />
+          ),
+        )}
       </div>
     )
   }
@@ -54,10 +66,14 @@ export function TopBuildsSection({ item }: { item: DetailItem }) {
   }
 
   return (
-    <div className={GRID_CLASS}>
-      {builds.map((b) => (
-        <BuildCard key={b.id} build={b} />
-      ))}
+    <div className={containerClass}>
+      {builds.map((b) =>
+        layout === "rows" ? (
+          <BuildRow key={b.id} build={b} />
+        ) : (
+          <BuildCard key={b.id} build={b} />
+        ),
+      )}
     </div>
   )
 }

--- a/apps/web/src/lib/use-build-layout.ts
+++ b/apps/web/src/lib/use-build-layout.ts
@@ -1,0 +1,43 @@
+import { useSyncExternalStore } from "react"
+
+export type BuildLayout = "cards" | "rows"
+
+const STORAGE_KEY = "arsenyx-build-layout"
+const EVENT = "arsenyx:build-layout-change"
+const DEFAULT: BuildLayout = "cards"
+
+function read(): BuildLayout {
+  if (typeof window === "undefined") return DEFAULT
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw === "rows" || raw === "cards" ? raw : DEFAULT
+  } catch {
+    return DEFAULT
+  }
+}
+
+function subscribe(cb: () => void) {
+  if (typeof window === "undefined") return () => {}
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) cb()
+  }
+  window.addEventListener("storage", onStorage)
+  window.addEventListener(EVENT, cb)
+  return () => {
+    window.removeEventListener("storage", onStorage)
+    window.removeEventListener(EVENT, cb)
+  }
+}
+
+export function useBuildLayout(): [BuildLayout, (next: BuildLayout) => void] {
+  const layout = useSyncExternalStore(subscribe, read, () => DEFAULT)
+  const set = (next: BuildLayout) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // Quota / disabled — same-tab listeners still fire below.
+    }
+    window.dispatchEvent(new Event(EVENT))
+  }
+  return [layout, set]
+}


### PR DESCRIPTION
## Summary
- Site-wide Cards / Rows toggle for build lists (persisted in localStorage, syncs across tabs and across the /builds list + per-item Top Builds section).
- New `BuildRow` variant displays the full build title without truncation; small icon toggle lives next to the sort dropdown.
- Disable font ligatures on the markdown guide textarea so `--` / `---` / `->` render as the literal characters typed (Cascadia Code et al. were collapsing them into en/em-dashes).
- Truncated build names in cards view now expose the full name via a native `title` tooltip.

## Test plan
- [x] /builds renders both layouts; toggle persists across reload
- [x] Open a second tab on /builds — flipping the toggle in tab A updates tab B
- [x] Item detail page's Top Builds section respects the same preference
- [x] In the build guide editor, typing `---` shows three discrete dashes
- [x] Hovering a truncated card title shows the full name