### PR TITLE
Add markdown image sizing and Discord URL warning in build guides

### DIFF
--- a/apps/web/src/components/build-editor/guide-editor.tsx
+++ b/apps/web/src/components/build-editor/guide-editor.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
-import { ChevronDown, Link2, X } from "lucide-react"
-import { useRef, useState } from "react"
+import { ChevronDown, Link2, TriangleAlert, X } from "lucide-react"
+import { useMemo, useRef, useState } from "react"
 
 import { MarkdownBody } from "@/components/markdown-body"
 import { Button } from "@/components/ui/button"
@@ -93,6 +93,7 @@ export function GuideEditor({
               onChange={onDescriptionChange}
               placeholder="Write your build guide in markdown — headings, lists, links, code blocks all work. Paste a YouTube or Vimeo link on its own line to embed the video."
             />
+            <DiscordImageWarning source={description} />
           </TabsContent>
           <TabsContent value="preview">
             <div className="border-input min-h-64 rounded-lg border px-3 py-2">
@@ -387,6 +388,33 @@ function MarkdownTextarea({
       placeholder={placeholder}
       className="min-h-64 font-mono text-sm [font-variant-ligatures:none]"
     />
+  )
+}
+
+function DiscordImageWarning({ source }: { source: string }) {
+  const hasDiscordUrl = useMemo(() => {
+    return /https?:\/\/(?:cdn\.discordapp\.com|media\.discordapp\.net|discord\.com\/channels)\/\S+/i.test(
+      source,
+    )
+  }, [source])
+  if (!hasDiscordUrl) return null
+  return (
+    <div className="text-foreground/90 mt-2 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs">
+      <TriangleAlert className="mt-0.5 size-4 shrink-0 text-amber-500" />
+      <p>
+        Discord image links expire and will eventually 404 for other viewers.
+        Re-upload images to{" "}
+        <a
+          href="https://imgur.com/upload"
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          Imgur
+        </a>{" "}
+        or another permanent host instead.
+      </p>
+    </div>
   )
 }
 

--- a/apps/web/src/components/markdown-body.tsx
+++ b/apps/web/src/components/markdown-body.tsx
@@ -66,6 +66,35 @@ const components: Components = {
     if (embed) return <VideoEmbed {...embed} />
     return <p {...rest}>{children}</p>
   },
+  img({ node: _node, src, ...rest }) {
+    const { src: cleanSrc, width } = parseSizedSrc(src)
+    return (
+      <img
+        {...rest}
+        src={cleanSrc}
+        loading="lazy"
+        style={width ? { width, maxWidth: "100%" } : undefined}
+        className="my-2 h-auto max-w-full rounded-md border object-contain"
+      />
+    )
+  },
+}
+
+/**
+ * Parses a custom `url|<width>` suffix on image URLs. The width can be a
+ * bare number (treated as px) or include a unit (`200px`, `50%`). Anything
+ * else is left alone so real `|` characters in URLs still work.
+ */
+function parseSizedSrc(src: string | Blob | undefined): {
+  src: string | undefined
+  width: string | undefined
+} {
+  if (typeof src !== "string") return { src: undefined, width: undefined }
+  // Match a trailing `|<size>` or `%7C<size>` (remark URL-encodes `|`).
+  const m = src.match(/(?:\||%7C)(\d+)(px|%|%25)?$/i)
+  if (!m) return { src, width: undefined }
+  const unit = m[2]?.toLowerCase() === "%25" ? "%" : (m[2] ?? "px")
+  return { src: src.slice(0, m.index), width: `${m[1]}${unit}` }
 }
 
 function VideoEmbed({


### PR DESCRIPTION
## Summary
- Support `![alt](url|N)` syntax in guide markdown to resize images. Width accepts a bare number (px), `Npx`, or `N%`. The suffix is stripped before the image loads so the URL stays clean.
- Warn build authors in the editor when the description contains a Discord URL (`cdn.discordapp.com`, `media.discordapp.net`, or `discord.com/channels/...`), since those links expire and 404 for other viewers.

Triggered by a user pasting a Discord message link as an image in their guide — Discord CDN URLs are now signed and time-limited, so they break for everyone else once the window closes.

## Test plan
- [x] `![foo](https://i.ibb.co/.../x.png|300)` renders 300px wide
- [x] `|150`, `|50%`, `|400px` all work; no suffix loads at natural width
- [x] URLs without a numeric suffix (e.g. real `|` in a query string) are left untouched
- [x] Warning banner appears under the description textarea when a Discord URL is present and hides when it isn't
- [x] `bun run build` in apps/web passes