### PR TITLE
Add build variants (up to 4 loadouts per build)

### DIFF
--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -1,3 +1,4 @@
+import { MAX_VARIANTS } from "@arsenyx/shared/warframe/build-doc"
 import { isValidCategory } from "@arsenyx/shared/warframe/categories"
 import { Hono, type Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
@@ -42,6 +43,15 @@ function isVisibility(v: unknown): v is BuildVisibility {
     typeof v === "string" &&
     Object.values(BuildVisibility).includes(v as BuildVisibility)
   )
+}
+
+// Defense in depth: the editor caps `variants` at MAX_VARIANTS, but a
+// crafted request could send more. Persisting an unbounded array would
+// bloat the Build.buildData JSON column.
+function variantsOverCap(buildData: unknown): boolean {
+  if (!buildData || typeof buildData !== "object") return false
+  const variants = (buildData as Record<string, unknown>).variants
+  return Array.isArray(variants) && variants.length > MAX_VARIANTS
 }
 
 function hasShardsInBuildData(buildData: unknown): boolean {
@@ -94,6 +104,9 @@ builds.post("/", rateLimitUser("mutate"), async (c) => {
     return c.json({ error: "invalid_name" }, 400)
   if (!b.buildData || typeof b.buildData !== "object") {
     return c.json({ error: "invalid_build_data" }, 400)
+  }
+  if (variantsOverCap(b.buildData)) {
+    return c.json({ error: "too_many_variants" }, 400)
   }
 
   const buildData = b.buildData as InputJsonValue
@@ -189,6 +202,9 @@ builds.patch("/:slug", rateLimitUser("mutate"), async (c) => {
     data.organizationId = orgResult.value
   }
   if (b.buildData && typeof b.buildData === "object") {
+    if (variantsOverCap(b.buildData)) {
+      return c.json({ error: "too_many_variants" }, 400)
+    }
     data.buildData = b.buildData as InputJsonValue
     data.hasShards = hasShardsInBuildData(b.buildData)
   }

--- a/apps/web/src/components/build-editor/guide-editor.tsx
+++ b/apps/web/src/components/build-editor/guide-editor.tsx
@@ -28,9 +28,12 @@ import {
   useUnlinkPartner,
   type PartnerBuild,
 } from "@/lib/partner-builds-query"
+import { cn } from "@/lib/utils"
 import { getImageUrl } from "@/lib/warframe"
 
 const SUMMARY_MAX = 160
+
+export type GuideScope = { kind: "build" } | { kind: "variant"; index: number }
 
 export function GuideEditor({
   summary,
@@ -38,6 +41,10 @@ export function GuideEditor({
   description,
   onDescriptionChange,
   buildSlug,
+  scopes,
+  activeScope,
+  onScopeChange,
+  buildScopeHasContent,
 }: {
   summary: string
   onSummaryChange: (v: string) => void
@@ -49,7 +56,27 @@ export function GuideEditor({
    * after the build exists server-side.
    */
   buildSlug?: string
+  /**
+   * Variant scopes available for per-variant guides. When omitted (or
+   * length <= 1), the chip row is hidden and the editor behaves as a
+   * single build-wide guide editor.
+   */
+  scopes?: { id: string; label: string; hasContent: boolean }[]
+  /**
+   * Currently-edited scope. `build` edits the build-wide guide;
+   * `variant` edits the per-variant guide at the given index.
+   */
+  activeScope?: GuideScope
+  onScopeChange?: (scope: GuideScope) => void
+  /** Whether the build-wide guide has any content — drives the
+   *  build-wide chip's content indicator dot. */
+  buildScopeHasContent?: boolean
 }) {
+  const showScopeChips =
+    scopes !== undefined &&
+    scopes.length > 1 &&
+    activeScope !== undefined &&
+    onScopeChange !== undefined
   return (
     <div className="flex flex-col gap-6">
       <div>
@@ -60,9 +87,35 @@ export function GuideEditor({
           </span>
         </h2>
         <p className="text-muted-foreground text-sm">
-          A short summary and a markdown write-up about your build.
+          {showScopeChips
+            ? "Build-wide is shown for every variant unless that variant has its own guide. Pick a variant below to write one just for it."
+            : "A short summary and a markdown write-up about your build."}
         </p>
       </div>
+
+      {showScopeChips ? (
+        <div
+          role="tablist"
+          aria-label="Guide scope"
+          className="flex flex-wrap items-center gap-1.5"
+        >
+          <ScopeChip
+            label="Build-wide"
+            active={activeScope.kind === "build"}
+            hasContent={buildScopeHasContent ?? false}
+            onClick={() => onScopeChange({ kind: "build" })}
+          />
+          {scopes.map((s, i) => (
+            <ScopeChip
+              key={s.id || i}
+              label={s.label || `Variant ${i + 1}`}
+              active={activeScope.kind === "variant" && activeScope.index === i}
+              hasContent={s.hasContent}
+              onClick={() => onScopeChange({ kind: "variant", index: i })}
+            />
+          ))}
+        </div>
+      ) : null}
 
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
@@ -133,6 +186,44 @@ export function GuideEditor({
         )}
       </div>
     </div>
+  )
+}
+
+function ScopeChip({
+  label,
+  active,
+  hasContent,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  hasContent: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "bg-muted/30 hover:bg-muted text-muted-foreground hover:text-foreground border-transparent",
+      )}
+    >
+      <span>{label}</span>
+      {hasContent ? (
+        <span
+          aria-hidden
+          className={cn(
+            "size-1.5 rounded-full",
+            active ? "bg-primary-foreground/80" : "bg-emerald-500",
+          )}
+        />
+      ) : null}
+    </button>
   )
 }
 

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -6,7 +6,7 @@ export {
   type ArcaneSlotsState,
   type PlacedArcane,
 } from "./use-arcane-slots"
-export { GuideEditor } from "./guide-editor"
+export { GuideEditor, type GuideScope } from "./guide-editor"
 export { KeyboardHintBanner, KeyboardHintsStrip } from "./keyboard-hints"
 export { ItemSidebar, ItemSidebarPopover } from "./item-sidebar"
 export {

--- a/apps/web/src/lib/build-codec-adapter.ts
+++ b/apps/web/src/lib/build-codec-adapter.ts
@@ -280,6 +280,16 @@ export function normalizeBuildData(
   return refreshHelminthImage(base, helminthAbilities)
 }
 
+// Synthetic single-variant identity used when a legacy / single-loadout build
+// has no `variants` array. Save logic compares against these to decide whether
+// emitting `variants` would just re-persist the synthetic placeholder.
+export const SYNTHETIC_VARIANT_ID = "v0"
+export const SYNTHETIC_VARIANT_LABEL = "Main"
+
+export function isSyntheticVariant(v: SavedVariant): boolean {
+  return v.id === SYNTHETIC_VARIANT_ID && v.label === SYNTHETIC_VARIANT_LABEL
+}
+
 /**
  * Returns the variants array, or a single synthetic "Main" variant
  * synthesized from the top-level fields when the build has no
@@ -289,8 +299,8 @@ export function getVariants(data: SavedBuildData): SavedVariant[] {
   if (data.variants && data.variants.length > 0) return data.variants
   return [
     {
-      id: "v0",
-      label: "Main",
+      id: SYNTHETIC_VARIANT_ID,
+      label: SYNTHETIC_VARIANT_LABEL,
       slots: data.slots ?? {},
       arcanes: data.arcanes ?? [],
       helminth: data.helminth,

--- a/apps/web/src/lib/build-codec-adapter.ts
+++ b/apps/web/src/lib/build-codec-adapter.ts
@@ -13,7 +13,7 @@ import type {
 } from "@arsenyx/shared/warframe/types"
 
 import type { PlacedArcane, PlacedMod, SlotId } from "@/components/build-editor"
-import type { SavedBuildData } from "@/lib/build-query"
+import type { SavedBuildData, SavedVariant } from "@/lib/build-query"
 import type { HelminthAbility } from "@/lib/helminth-query"
 import type { PlacedShard } from "@/lib/shards"
 
@@ -280,6 +280,63 @@ export function normalizeBuildData(
   return refreshHelminthImage(base, helminthAbilities)
 }
 
+/**
+ * Returns the variants array, or a single synthetic "Main" variant
+ * synthesized from the top-level fields when the build has no
+ * `variants`. Always returns at least one entry.
+ */
+export function getVariants(data: SavedBuildData): SavedVariant[] {
+  if (data.variants && data.variants.length > 0) return data.variants
+  return [
+    {
+      id: "v0",
+      label: "Main",
+      slots: data.slots ?? {},
+      arcanes: data.arcanes ?? [],
+      helminth: data.helminth,
+      incarnonEnabled: data.incarnonEnabled,
+      incarnonPerks: data.incarnonPerks,
+      deploymentContext: data.deploymentContext,
+    },
+  ]
+}
+
+/**
+ * Project a single variant back into a `SavedBuildData` shape that the
+ * existing viewer/editor pipelines consume unchanged. Shared fields
+ * (shards, forma, reactor, helminth, lich, zaw, name) come from the
+ * top-level doc; per-variant fields override.
+ */
+export function selectVariant(
+  data: SavedBuildData,
+  index: number,
+): SavedBuildData {
+  const variants = getVariants(data)
+  const clamped =
+    index < 0
+      ? 0
+      : index >= variants.length
+        ? variants.length - 1
+        : Math.floor(index)
+  const v = variants[clamped]
+  // Per-variant fields come from `v` verbatim. No fallback to top-level —
+  // top-level mirrors whichever variant was active at save time, so falling
+  // back would leak that variant's state into other variants that happen to
+  // have undefined fields. Legacy single-variant docs are safe because
+  // getVariants() already populates the synthetic variant from top-level.
+  return {
+    ...data,
+    slots: v.slots,
+    arcanes: v.arcanes,
+    helminth: v.helminth,
+    incarnonEnabled: v.incarnonEnabled,
+    incarnonPerks: v.incarnonPerks,
+    deploymentContext: v.deploymentContext,
+    // formaPolarities, shards, hasReactor, zaw, lich, buildName are
+    // shared across variants and stay as-is.
+  }
+}
+
 // Older builds were saved when wfcd shipped content-hashed image filenames
 // (e.g. `roar-e206197372.png`); the newer `@wfcd/items` package uses canonical
 // names and the upstream CDN no longer maps the old hashed slugs. Mods and
@@ -290,16 +347,33 @@ function refreshHelminthImage(
   data: SavedBuildData,
   helminthAbilities: HelminthAbility[],
 ): SavedBuildData {
-  if (!data.helminth || helminthAbilities.length === 0) return data
+  if (helminthAbilities.length === 0) return data
   const byUnique = new Map(helminthAbilities.map((h) => [h.uniqueName, h]))
-  const next: Record<number, HelminthAbility> = {}
-  for (const [slotIndex, ability] of Object.entries(data.helminth)) {
-    const fresh = byUnique.get(ability.uniqueName)
-    next[Number(slotIndex)] = fresh
-      ? { ...ability, imageName: fresh.imageName }
-      : ability
+  const refreshOne = (
+    helminth: Record<number, HelminthAbility>,
+  ): Record<number, HelminthAbility> => {
+    const next: Record<number, HelminthAbility> = {}
+    for (const [slotIndex, ability] of Object.entries(helminth)) {
+      const fresh = byUnique.get(ability.uniqueName)
+      next[Number(slotIndex)] = fresh
+        ? { ...ability, imageName: fresh.imageName }
+        : ability
+    }
+    return next
   }
-  return { ...data, helminth: next }
+  let result = data
+  if (data.helminth) {
+    result = { ...result, helminth: refreshOne(data.helminth) }
+  }
+  if (data.variants && data.variants.length > 0) {
+    result = {
+      ...result,
+      variants: data.variants.map((v) =>
+        v.helminth ? { ...v, helminth: refreshOne(v.helminth) } : v,
+      ),
+    }
+  }
+  return result
 }
 
 /**

--- a/apps/web/src/lib/build-query.ts
+++ b/apps/web/src/lib/build-query.ts
@@ -11,6 +11,25 @@ import { apiFetch, ApiError } from "@/lib/api-client"
 import type { HelminthAbility } from "@/lib/helminth-query"
 import type { PlacedShard } from "@/lib/shards"
 
+/**
+ * Per-variant slice stored inside `SavedBuildData.variants`. When the
+ * `variants` array is present (length >= 1), the per-variant fields here
+ * supersede the legacy top-level `slots`/`arcanes`/`incarnon*`/
+ * `deploymentContext` fields. Top-level fields stay populated for the
+ * active variant so old clients that ignore `variants` still render the
+ * default loadout — graceful degradation, not a hard cutover.
+ */
+export type SavedVariant = {
+  id: string
+  label: string
+  slots: Partial<Record<SlotId, PlacedMod>>
+  arcanes: (PlacedArcane | null)[]
+  helminth?: Record<number, HelminthAbility>
+  incarnonEnabled?: boolean
+  incarnonPerks?: (string | null)[]
+  deploymentContext?: DeploymentContext
+}
+
 /** Shape stored in `Build.buildData` (Prisma JSON). */
 export type SavedBuildData = {
   version?: number
@@ -25,6 +44,11 @@ export type SavedBuildData = {
   incarnonEnabled?: boolean
   incarnonPerks?: (string | null)[]
   deploymentContext?: DeploymentContext
+
+  // Multi-variant support (added 2026-05-23). When present, length >= 1
+  // and the top-level mod/arcane fields mirror variants[0] for legacy
+  // viewer compatibility.
+  variants?: SavedVariant[]
 }
 
 export type BuildDetail = {

--- a/apps/web/src/lib/build-query.ts
+++ b/apps/web/src/lib/build-query.ts
@@ -28,6 +28,11 @@ export type SavedVariant = {
   incarnonEnabled?: boolean
   incarnonPerks?: (string | null)[]
   deploymentContext?: DeploymentContext
+  /** Optional per-variant guide. When absent, the viewer falls back to
+   *  the build-wide guide from BuildDetail.guide. Stored inside
+   *  `buildData.variants[i]` (JSON column) — no separate DB row. */
+  guideSummary?: string
+  guideDescription?: string
 }
 
 /** Shape stored in `Build.buildData` (Prisma JSON). */

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -90,8 +90,10 @@ import { arcanesQuery } from "@/lib/arcanes-query"
 import { authClient } from "@/lib/auth-client"
 import { useDeleteBuild, useForkBuild } from "@/lib/build-actions"
 import {
+  getVariants,
   isLegacyBuildData,
   normalizeBuildData,
+  selectVariant,
 } from "@/lib/build-codec-adapter"
 import { buildQuery, type BuildDetail } from "@/lib/build-query"
 import { useToggleBookmark, useToggleLike } from "@/lib/build-social"
@@ -133,6 +135,9 @@ interface BuildSearch {
   /** Optional background colour (CSS value without #, e.g. `22272e`).
    *  Applied to the iframe body so the embed blends with the host page. */
   bg?: string
+  /** Active variant index for multi-variant builds. Clamped to a valid
+   *  index by the viewer; omitted (default 0) for single-variant builds. */
+  v?: number
 }
 
 export const Route = createFileRoute("/builds/$slug")({
@@ -146,10 +151,19 @@ export const Route = createFileRoute("/builds/$slug")({
     const scale =
       rawScale !== undefined ? Math.min(2, Math.max(0.1, rawScale)) : undefined
     const bg = typeof s.bg === "string" && s.bg.length > 0 ? s.bg : undefined
+    const rawV = num(s.v)
+    // 0-indexed; default (undefined) means "first variant". Clamped to a
+    // generous upper bound here; the viewer further clamps to the actual
+    // variant count.
+    const v =
+      rawV !== undefined && rawV >= 0
+        ? Math.min(50, Math.floor(rawV))
+        : undefined
     return {
       ...(embed && { embed }),
       ...(scale !== undefined && { scale }),
       ...(bg !== undefined && { bg }),
+      ...(v !== undefined && { v }),
     }
   },
   loader: ({ context, params }) =>
@@ -251,6 +265,7 @@ function EmbedShell({
 
 function BuildViewer({ embed = false }: { embed?: boolean }) {
   const { slug } = Route.useParams()
+  const { v } = Route.useSearch()
   const { data: build } = useSuspenseQuery(buildQuery(slug))
 
   if (!isValidCategory(build.item.category)) {
@@ -259,10 +274,14 @@ function BuildViewer({ embed = false }: { embed?: boolean }) {
   const category = build.item.category as BrowseCategory
   const itemSlug = slugify(build.item.name)
 
+  // Re-key on variant switch so the per-variant hooks (useBuildSlots /
+  // useArcaneSlots) re-initialize from the new variant's projected
+  // data. Without this, the hooks keep their initial state across
+  // ?v= changes and the loadout grid stays frozen on variant 0.
   return (
     <Suspense fallback={<p className="text-muted-foreground">Loading item…</p>}>
       <BuildViewerBody
-        key={slug}
+        key={`${slug}-${v ?? 0}`}
         build={build}
         category={category}
         itemSlug={itemSlug}
@@ -332,8 +351,10 @@ function BuildViewerBodyInner({
   embed: boolean
 }) {
   const { data: item } = useSuspenseQuery(itemQuery(category, itemSlug))
+  const search = Route.useSearch()
+  const navigate = useNavigate()
 
-  const saved = useMemo(
+  const savedAll = useMemo(
     () =>
       normalizeBuildData(
         build.buildData,
@@ -343,6 +364,27 @@ function BuildViewerBodyInner({
       ),
     [build.buildData, allMods, allArcanes, helminthAbilities],
   )
+
+  const variants = useMemo(() => getVariants(savedAll), [savedAll])
+  const activeIndex = useMemo(() => {
+    const raw = search.v ?? 0
+    if (raw < 0) return 0
+    if (raw >= variants.length) return variants.length - 1
+    return raw
+  }, [search.v, variants.length])
+  const saved = useMemo(
+    () => selectVariant(savedAll, activeIndex),
+    [savedAll, activeIndex],
+  )
+
+  const setActiveIndex = (i: number) => {
+    navigate({
+      to: ".",
+      params: true,
+      search: (s) => (i === 0 ? { ...s, v: undefined } : { ...s, v: i }),
+      replace: true,
+    })
+  }
 
   const categoryLabel = getCategoryLabel(category)
   const isCompanion = category === "companions"
@@ -547,13 +589,33 @@ function BuildViewerBodyInner({
               !embed && "xl:ml-[calc(260px+1rem)]",
             )}
           >
-            <ItemSidebarPopover
-              {...sidebarProps}
-              className={cn(
-                "self-start",
-                !embed && "hidden sm:inline-flex xl:hidden",
-              )}
-            />
+            {variants.length > 1 ? (
+              // Stats popover absolutely positioned so it doesn't push
+              // the tabs off-center. Tabs are visually centered in the
+              // loadout container at every breakpoint.
+              <div className="relative flex min-h-8 items-center justify-center">
+                <ItemSidebarPopover
+                  {...sidebarProps}
+                  className={cn(
+                    "absolute top-0 left-0",
+                    !embed && "hidden sm:inline-flex xl:hidden",
+                  )}
+                />
+                <VariantTabs
+                  variants={variants}
+                  activeIndex={activeIndex}
+                  onSelect={setActiveIndex}
+                />
+              </div>
+            ) : (
+              <ItemSidebarPopover
+                {...sidebarProps}
+                className={cn(
+                  "self-start",
+                  !embed && "hidden sm:inline-flex xl:hidden",
+                )}
+              />
+            )}
             <ModGrid
               item={item}
               category={category}
@@ -575,6 +637,8 @@ function BuildViewerBodyInner({
           </div>
         </div>
 
+        {!embed ? <RelatedBuildsStrip slug={build.slug} /> : null}
+
         {!embed && (build.guide?.description || build.guide?.summary) ? (
           <div className="bg-card rounded-lg border p-4">
             {build.guide.summary ? (
@@ -588,10 +652,47 @@ function BuildViewerBodyInner({
             ) : null}
           </div>
         ) : null}
-
-        {!embed ? <RelatedBuildsStrip slug={build.slug} /> : null}
       </div>
     </>
+  )
+}
+
+function VariantTabs({
+  variants,
+  activeIndex,
+  onSelect,
+}: {
+  variants: { id: string; label: string }[]
+  activeIndex: number
+  onSelect: (index: number) => void
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Build variants"
+      className="flex flex-wrap items-center justify-center gap-1.5 pb-1"
+    >
+      {variants.map((v, i) => {
+        const active = i === activeIndex
+        return (
+          <button
+            key={v.id || i}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onSelect(i)}
+            className={cn(
+              "rounded-md border px-3 py-1 text-sm transition-colors",
+              active
+                ? "border-primary bg-primary text-primary-foreground"
+                : "bg-muted/30 hover:bg-muted text-muted-foreground hover:text-foreground border-transparent",
+            )}
+          >
+            {v.label || `Variant ${i + 1}`}
+          </button>
+        )
+      })}
+    </div>
   )
 }
 

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -641,10 +641,14 @@ function BuildViewerBodyInner({
 
         {!embed &&
           (() => {
-            // Per-variant guide overrides the build-wide one when present.
-            // Empty per-variant guide = use the build-wide as the default
-            // for that variant (mirrors how per-variant loadout fields
-            // already fall back to shared state).
+            // Doc-level fallback: if the active variant has *any* per-variant
+            // guide content (summary OR description), that guide replaces the
+            // build-wide one wholesale — we don't mix-and-match fields.
+            // Rationale: a per-variant summary like "Use this for Steel Path"
+            // shouldn't get paired with the build-wide long description that
+            // describes the default variant's playstyle. Authors who want
+            // both showing should duplicate the build-wide text into the
+            // variant guide.
             const activeVariantGuide = variants[activeIndex]
             const variantSummary = activeVariantGuide?.guideSummary?.trim()
             const variantDescription =

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -639,19 +639,40 @@ function BuildViewerBodyInner({
 
         {!embed ? <RelatedBuildsStrip slug={build.slug} /> : null}
 
-        {!embed && (build.guide?.description || build.guide?.summary) ? (
-          <div className="bg-card rounded-lg border p-4">
-            {build.guide.summary ? (
-              <p className="mb-3 font-medium">{build.guide.summary}</p>
-            ) : null}
-            {build.guide.description ? (
-              <MarkdownBody
-                source={build.guide.description}
-                className="prose prose-sm dark:prose-invert max-w-none"
-              />
-            ) : null}
-          </div>
-        ) : null}
+        {!embed &&
+          (() => {
+            // Per-variant guide overrides the build-wide one when present.
+            // Empty per-variant guide = use the build-wide as the default
+            // for that variant (mirrors how per-variant loadout fields
+            // already fall back to shared state).
+            const activeVariantGuide = variants[activeIndex]
+            const variantSummary = activeVariantGuide?.guideSummary?.trim()
+            const variantDescription =
+              activeVariantGuide?.guideDescription?.trim()
+            const hasVariantGuide = Boolean(
+              variantSummary || variantDescription,
+            )
+            const effectiveSummary = hasVariantGuide
+              ? (variantSummary ?? "")
+              : (build.guide?.summary ?? "")
+            const effectiveDescription = hasVariantGuide
+              ? (variantDescription ?? "")
+              : (build.guide?.description ?? "")
+            if (!effectiveSummary && !effectiveDescription) return null
+            return (
+              <div className="bg-card rounded-lg border p-4">
+                {effectiveSummary ? (
+                  <p className="mb-3 font-medium">{effectiveSummary}</p>
+                ) : null}
+                {effectiveDescription ? (
+                  <MarkdownBody
+                    source={effectiveDescription}
+                    className="prose prose-sm dark:prose-invert max-w-none"
+                  />
+                ) : null}
+              </div>
+            )
+          })()}
       </div>
     </>
   )

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,4 +1,13 @@
-import { decodeBuild, encodeBuild } from "@arsenyx/shared/warframe/build-codec"
+import {
+  decodeBuild,
+  decodeBuildDoc,
+  encodeBuild,
+  encodeBuildDoc,
+} from "@arsenyx/shared/warframe/build-codec"
+import {
+  projectVariant,
+  type BuildDoc,
+} from "@arsenyx/shared/warframe/build-doc"
 import {
   getIncarnonGenesisImage,
   isInnateIncarnon,
@@ -21,7 +30,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query"
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
-import { Suspense, useEffect, useMemo, useState } from "react"
+import { Suspense, useEffect, useMemo, useRef, useState } from "react"
 
 import {
   ArcaneRow,
@@ -60,15 +69,33 @@ import { SearchPanel } from "@/components/create-editor/search-panel"
 import { useRivenDialog } from "@/components/create-editor/use-riven-dialog"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { apiErrorMessage, apiFetch } from "@/lib/api-client"
 import { arcanesQuery } from "@/lib/arcanes-query"
 import { authClient } from "@/lib/auth-client"
 import {
   buildStateToSavedData,
+  getVariants,
   normalizeBuildData,
   savedDataToBuildState,
+  selectVariant,
 } from "@/lib/build-codec-adapter"
-import { buildQuery, type SavedBuildData } from "@/lib/build-query"
+import {
+  buildQuery,
+  type SavedBuildData,
+  type SavedVariant,
+} from "@/lib/build-query"
 import { helminthQuery, type HelminthAbility } from "@/lib/helminth-query"
 import { useHotkey } from "@/lib/hotkeys"
 import { consumeDraft } from "@/lib/import-draft"
@@ -77,6 +104,7 @@ import { modsQuery } from "@/lib/mods-query"
 import { myOrgsQuery } from "@/lib/org-query"
 import { padShards, type PlacedShard } from "@/lib/shards"
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard"
+import { cn } from "@/lib/utils"
 import {
   getCategoryLabel,
   isValidCategory,
@@ -89,6 +117,9 @@ type CreateSearch = {
   build?: string
   draft?: string
   share?: string
+  /** Active variant index for multi-variant builds. 0 (or undefined) =
+   *  first variant. */
+  v?: number
 }
 
 export const Route = createFileRoute("/create")({
@@ -101,7 +132,24 @@ export const Route = createFileRoute("/create")({
     const build = typeof search.build === "string" ? search.build : undefined
     const draft = typeof search.draft === "string" ? search.draft : undefined
     const share = typeof search.share === "string" ? search.share : undefined
-    return { item, category, build, draft, share }
+    const rawV =
+      typeof search.v === "string"
+        ? Number(search.v)
+        : typeof search.v === "number"
+          ? search.v
+          : undefined
+    const v =
+      rawV !== undefined && Number.isFinite(rawV) && rawV >= 0
+        ? Math.min(50, Math.floor(rawV))
+        : undefined
+    return {
+      item,
+      category,
+      build,
+      draft,
+      share,
+      ...(v !== undefined && { v }),
+    }
   },
   beforeLoad: ({ search }) => {
     if (!search.item) {
@@ -131,6 +179,22 @@ export const Route = createFileRoute("/create")({
 })
 
 function CreatePage() {
+  // Re-key EditorShell on variant switch so the per-variant hooks
+  // (useBuildSlots / useArcaneSlots) re-initialize from the projected
+  // variant's data. Cheaper than extracting + threading callbacks for
+  // every per-variant setter through every subcomponent.
+  const { build: buildSlug, v } = Route.useSearch()
+  const variantKey = `${buildSlug ?? "new"}-${v ?? 0}`
+  // Drop the in-memory editor cache on every navigation away from
+  // /create (Cancel, route change). Without this, an unsaved variant
+  // added before Cancel would silently re-appear next time the user
+  // opened the same build's editor.
+  useEffect(
+    () => () => {
+      cachedVariants = null
+    },
+    [],
+  )
   return (
     <div className="relative flex min-h-screen flex-col">
       <Header />
@@ -139,7 +203,7 @@ function CreatePage() {
           <Suspense
             fallback={<p className="text-muted-foreground">Loading item…</p>}
           >
-            <EditorShell />
+            <EditorShell key={variantKey} />
           </Suspense>
         </div>
       </main>
@@ -148,6 +212,28 @@ function CreatePage() {
   )
 }
 
+// Survives EditorShell remounts (the editor is re-keyed on variant switch
+// so per-variant hooks can re-initialize from the new variant's data).
+// Single-entry cache keyed by buildSlug — replaced when editing a
+// different build. Cleared on successful save below.
+type SharedEditorOverrides = {
+  hasReactor?: boolean
+  shards?: (PlacedShard | null)[]
+  zawComponents?: { grip: string; link: string } | undefined
+  lichBonusElement?: LichBonusElement | null
+  formaPolarities?: Partial<
+    Record<string, import("@arsenyx/shared/warframe/types").Polarity>
+  >
+  buildName?: string
+  guideSummary?: string
+  guideDescription?: string
+}
+let cachedVariants: {
+  key: string
+  data: SavedVariant[]
+  shared?: SharedEditorOverrides
+} | null = null
+
 function EditorShell() {
   const {
     item: slug,
@@ -155,6 +241,7 @@ function EditorShell() {
     build: buildSlug,
     draft: draftId,
     share: shareEncoded,
+    v: activeVariantIndex = 0,
   } = Route.useSearch()
   const { data: item } = useSuspenseQuery(itemQuery(category, slug))
   const { data: existingBuild } = useQuery({
@@ -167,11 +254,42 @@ function EditorShell() {
   const [draft] = useState(() => consumeDraft(draftId))
   const [shareHydrated] = useState(() => {
     if (!shareEncoded) return null
+    // decodeBuildDoc handles both v1 (wrapped as single-variant doc) and v2.
+    const doc = decodeBuildDoc(shareEncoded)
+    if (doc) {
+      const activeIdx = 0
+      const activeState = projectVariant(doc, activeIdx)
+      const { data: activeData } = buildStateToSavedData(
+        activeState,
+        allMods,
+        allArcanes,
+      )
+      if (doc.variants.length === 1) return { data: activeData }
+      const savedVariants: SavedVariant[] = doc.variants.map((v, i) => {
+        const state = projectVariant(doc, i)
+        const { data } = buildStateToSavedData(state, allMods, allArcanes)
+        return {
+          id: v.id,
+          label: v.label,
+          slots: data.slots ?? {},
+          arcanes: data.arcanes ?? [],
+          helminth: data.helminth,
+          incarnonEnabled: data.incarnonEnabled,
+          incarnonPerks: data.incarnonPerks,
+          deploymentContext: data.deploymentContext,
+        }
+      })
+      return { data: { ...activeData, variants: savedVariants } }
+    }
+    // Last-ditch: try the v1 decoder directly in case decodeBuildDoc
+    // rejects the payload (e.g. unknown version added later by a
+    // newer client).
     const decoded = decodeBuild(shareEncoded)
     if (!decoded) return null
     return buildStateToSavedData(decoded, allMods, allArcanes)
   })
-  const savedData: SavedBuildData = useMemo(() => {
+  // Full normalized saved data (all variants intact); used when persisting.
+  const savedDataAll: SavedBuildData = useMemo(() => {
     if (draft) return draft.data
     if (existingBuild)
       return normalizeBuildData(
@@ -191,6 +309,93 @@ function EditorShell() {
     helminthAbilities,
   ])
 
+  // Track the variants list as mutable state so add/duplicate/delete can
+  // mutate it before save without round-tripping through the URL.
+  // EditorShell is re-keyed on variant switch, which would normally reset
+  // useState. The module-level cache below preserves the in-progress
+  // variants array across those remounts (keyed by buildSlug, single
+  // entry — replaced when switching to a different build).
+  // Include `item` and `category` so two consecutive new-build sessions on
+  // different items don't share the same cache bucket (the EditorShell isn't
+  // re-keyed on item change, but the cache lookup must still distinguish).
+  const storeKey = buildSlug ?? `__new_build__:${category}:${slug}`
+  const [variants, _setVariants] = useState<SavedVariant[]>(() => {
+    if (cachedVariants && cachedVariants.key === storeKey) {
+      return cachedVariants.data
+    }
+    const initial = getVariants(savedDataAll)
+    cachedVariants = { key: storeKey, data: initial }
+    return initial
+  })
+  const setVariants = (
+    next: SavedVariant[] | ((prev: SavedVariant[]) => SavedVariant[]),
+  ) => {
+    _setVariants((prev) => {
+      const value =
+        typeof next === "function"
+          ? (next as (p: SavedVariant[]) => SavedVariant[])(prev)
+          : next
+      // Preserve `shared` — setVariants only owns the variants array.
+      const sharedSlot =
+        cachedVariants?.key === storeKey ? cachedVariants.shared : undefined
+      cachedVariants = { key: storeKey, data: value, shared: sharedSlot }
+      return value
+    })
+  }
+  const clampedActiveIndex = Math.min(
+    Math.max(0, activeVariantIndex),
+    variants.length - 1,
+  )
+
+  // Slice projected for this variant — feeds the existing slot/arcane
+  // hooks below. EditorShell is re-keyed by activeIndex in CreatePage,
+  // so this useMemo only runs at mount (the right semantics). Reads
+  // from the in-memory `variants` state (which may contain unsaved
+  // add/duplicate/rename edits) rather than re-deriving from server
+  // data.
+  const savedData: SavedBuildData = useMemo(() => {
+    const active = variants[clampedActiveIndex]
+    if (!active) return selectVariant(savedDataAll, clampedActiveIndex)
+    // No fallback to savedDataAll for per-variant fields. savedDataAll's
+    // top-level mirrors the saved-active variant; falling back to it would
+    // pre-fill a freshly-added blank variant with the previous variant's
+    // helminth/incarnon/dc. Downstream useState initializers supply their
+    // own defaults (isInnateIncarnon, DEFAULT_DEPLOYMENT_CONTEXT, empty
+    // helminth) when these are undefined.
+    return {
+      ...savedDataAll,
+      slots: active.slots,
+      arcanes: active.arcanes,
+      helminth: active.helminth,
+      incarnonEnabled: active.incarnonEnabled,
+      incarnonPerks: active.incarnonPerks,
+      deploymentContext: active.deploymentContext,
+    }
+    // Read once at mount — EditorShell re-keys on switch, so reading
+    // stale variants[] state during this mount is the desired behavior.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Build-wide shared field overrides (not in variants[]). Persist
+  // across variant-switch remounts via the cache so unsaved edits to
+  // shards/forma/reactor/lich/zaw/buildName aren't lost.
+  const cachedShared =
+    cachedVariants?.key === storeKey ? cachedVariants.shared : undefined
+  const writeShared = (patch: Partial<SharedEditorOverrides>) => {
+    if (!cachedVariants || cachedVariants.key !== storeKey) {
+      // Key mismatch (or empty cache) means the previous bucket belongs to a
+      // different build — do NOT carry its shared overrides forward, that
+      // would leak forma/shards/buildName/etc. across builds.
+      cachedVariants = {
+        key: storeKey,
+        data: variants,
+        shared: { ...patch },
+      }
+      return
+    }
+    cachedVariants.shared = { ...(cachedVariants.shared ?? {}), ...patch }
+  }
+
   const categoryLabel = getCategoryLabel(category)
 
   const isCompanion = category === "companions"
@@ -200,7 +405,9 @@ function EditorShell() {
   const showStance = hasStanceSlot(item, category)
   const slots = useBuildSlots(normalSlotCount, {
     placed: savedData.slots,
-    formaPolarities: savedData.formaPolarities,
+    // Forma is build-wide (shared across variants); use the cached
+    // override so unsaved forma edits survive variant switches.
+    formaPolarities: cachedShared?.formaPolarities ?? savedData.formaPolarities,
     auraSlotCount,
     showExilus,
     showStance,
@@ -238,7 +445,11 @@ function EditorShell() {
   const { data: session } = authClient.useSession()
 
   const [buildName, setBuildName] = useState(
-    () => existingBuild?.name ?? draft?.buildName ?? item.name,
+    () =>
+      cachedShared?.buildName ??
+      existingBuild?.name ??
+      draft?.buildName ??
+      item.name,
   )
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "error">(
     "idle",
@@ -260,10 +471,10 @@ function EditorShell() {
   const organizations = myOrgs?.memberships.map((m) => m.organization) ?? []
 
   const [hasReactor, setHasReactor] = useState(
-    () => savedData.hasReactor ?? true,
+    () => cachedShared?.hasReactor ?? savedData.hasReactor ?? true,
   )
-  const [shards, setShards] = useState<(PlacedShard | null)[]>(() =>
-    padShards(savedData.shards),
+  const [shards, setShards] = useState<(PlacedShard | null)[]>(
+    () => cachedShared?.shards ?? padShards(savedData.shards),
   )
   const setShard = (i: number, s: PlacedShard | null) => {
     setShards((prev) => {
@@ -284,15 +495,19 @@ function EditorShell() {
   }
 
   const [guideSummary, setGuideSummary] = useState(
-    () => existingBuild?.guide?.summary ?? "",
+    () => cachedShared?.guideSummary ?? existingBuild?.guide?.summary ?? "",
   )
   const [guideDescription, setGuideDescription] = useState(
-    () => existingBuild?.guide?.description ?? "",
+    () =>
+      cachedShared?.guideDescription ?? existingBuild?.guide?.description ?? "",
   )
 
   const [zawComponents, setZawComponents] = useState<
     { grip: string; link: string } | undefined
   >(() => {
+    if (cachedShared && "zawComponents" in cachedShared) {
+      return cachedShared.zawComponents
+    }
     if (savedData.zawComponents) return savedData.zawComponents
     if (isZawStrike(item.name)) {
       return { grip: ZAW_DEFAULT_GRIP, link: ZAW_DEFAULT_LINK }
@@ -310,7 +525,10 @@ function EditorShell() {
   }, [item.name])
 
   const [lichBonusElement, setLichBonusElement] =
-    useState<LichBonusElement | null>(() => savedData.lichBonusElement ?? null)
+    useState<LichBonusElement | null>(
+      () =>
+        cachedShared?.lichBonusElement ?? savedData.lichBonusElement ?? null,
+    )
 
   // Innate incarnons (no separate Genesis adapter) default-on; Steel Path
   // Circuit weapons require installing the adapter, so default-off.
@@ -324,6 +542,35 @@ function EditorShell() {
   const [deploymentContext, setDeploymentContext] = useState<DeploymentContext>(
     () => savedData.deploymentContext ?? DEFAULT_DEPLOYMENT_CONTEXT,
   )
+
+  // Sync shared field edits into the module cache so they survive
+  // the EditorShell remount that fires on every variant switch.
+  // Per-variant fields (slots/arcanes/incarnon/dc/helminth) live in
+  // the variants array; these effects only mirror build-wide state.
+  useEffect(() => {
+    writeShared({ hasReactor })
+  }, [hasReactor]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    writeShared({ shards })
+  }, [shards]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    writeShared({ zawComponents })
+  }, [zawComponents]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    writeShared({ lichBonusElement })
+  }, [lichBonusElement]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    writeShared({ buildName })
+  }, [buildName]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    writeShared({ guideSummary })
+  }, [guideSummary]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    writeShared({ guideDescription })
+  }, [guideDescription]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    writeShared({ formaPolarities: slots.formaPolarities })
+  }, [slots.formaPolarities]) // eslint-disable-line react-hooks/exhaustive-deps
   const setIncarnonPerkAt = (tierIndex: number, perk: string | null) => {
     setIncarnonPerks((prev) => {
       const next = [...prev]
@@ -413,7 +660,73 @@ function EditorShell() {
       auraSlotCount,
       showStance,
     })
-    const encoded = encodeBuild(state)
+    let encoded: string
+    if (variants.length > 1) {
+      // Build a BuildDoc that mirrors the current editor state: shared
+      // fields from `state`, per-variant data from the in-memory variants
+      // array (with the active variant's slice replaced by the live
+      // editor state so unsaved tweaks make it into the share URL).
+      const activeSnapshot = captureActiveSnapshot()
+      const allVariants = variants.map((v, i) =>
+        i === clampedActiveIndex ? activeSnapshot : v,
+      )
+      const doc: BuildDoc = {
+        itemUniqueName: state.itemUniqueName,
+        itemName: state.itemName,
+        itemCategory: state.itemCategory,
+        itemImageName: state.itemImageName,
+        hasReactor: state.hasReactor,
+        shardSlots: state.shardSlots,
+        helminthAbility: state.helminthAbility,
+        zawComponents: state.zawComponents,
+        lichBonusElement: state.lichBonusElement,
+        buildName: state.buildName,
+        variants: allVariants.map((sv) => {
+          // Project each saved variant into a BuildVariant shape. The
+          // expensive slot reconstruction (ModSlot[]) is reused via
+          // savedDataToBuildState by overlaying the variant's slots
+          // onto the same shared editor state.
+          const variantState = savedDataToBuildState({
+            item: {
+              uniqueName: state.itemUniqueName,
+              name: state.itemName,
+              imageName: state.itemImageName,
+            },
+            category,
+            buildName: state.buildName,
+            hasReactor,
+            slots: sv.slots,
+            formaPolarities: slots.formaPolarities,
+            arcanes: sv.arcanes,
+            shards,
+            helminth,
+            zawComponents,
+            lichBonusElement: lichBonusElement ?? undefined,
+            incarnonEnabled: sv.incarnonEnabled ?? incarnonEnabled,
+            incarnonPerks: sv.incarnonPerks ?? incarnonPerks,
+            deploymentContext: sv.deploymentContext ?? deploymentContext,
+            normalSlotCount,
+            auraSlotCount,
+            showStance,
+          })
+          return {
+            id: sv.id,
+            label: sv.label,
+            auraSlots: variantState.auraSlots,
+            exilusSlot: variantState.exilusSlot,
+            stanceSlot: variantState.stanceSlot,
+            normalSlots: variantState.normalSlots,
+            arcaneSlots: variantState.arcaneSlots,
+            incarnonEnabled: variantState.incarnonEnabled,
+            incarnonPerks: variantState.incarnonPerks,
+            deploymentContext: variantState.deploymentContext,
+          }
+        }),
+      }
+      encoded = encodeBuildDoc(doc, clampedActiveIndex)
+    } else {
+      encoded = encodeBuild(state)
+    }
     const url = `${window.location.origin}/create?item=${encodeURIComponent(slug)}&category=${encodeURIComponent(category)}&share=${encodeURIComponent(encoded)}`
     void copyShare(url)
   }
@@ -442,6 +755,15 @@ function EditorShell() {
     setSaveStatus("saving")
     setSaveError(null)
     try {
+      // Snapshot the active variant's current editor state, then merge
+      // back into the full variants array. Single-variant builds emit
+      // a v1-shape payload (no `variants` field) for backwards-compat;
+      // multi-variant builds emit both top-level (mirroring active for
+      // legacy clients) and the variants array.
+      const activeSnapshot = captureActiveSnapshot()
+      const nextVariants = variants.map((v, i) =>
+        i === clampedActiveIndex ? activeSnapshot : v,
+      )
       const body = {
         name: buildName.trim() || item.name,
         visibility: nextVisibility,
@@ -459,6 +781,16 @@ function EditorShell() {
           incarnonEnabled,
           incarnonPerks,
           deploymentContext,
+          // Emit `variants` whenever there's more than one OR the single
+          // remaining variant has a user-assigned label/id — otherwise the
+          // synthetic "Main"/"v0" from getVariants() would silently
+          // overwrite the user's label after delete-down-to-one.
+          ...((nextVariants.length > 1 ||
+            (nextVariants.length === 1 &&
+              (nextVariants[0].label !== "Main" ||
+                nextVariants[0].id !== "v0"))) && {
+            variants: nextVariants,
+          }),
         },
         guide: {
           summary: guideSummary.trim() || null,
@@ -482,6 +814,9 @@ function EditorShell() {
         json: body,
       })
       await queryClient.invalidateQueries({ queryKey: ["build", slug] })
+      // Drop the in-memory variants cache so a follow-up edit re-hydrates
+      // from the persisted server state rather than stale local edits.
+      cachedVariants = null
       navigate({ to: "/builds/$slug", params: { slug } })
     } catch (err) {
       setSaveStatus("error")
@@ -551,6 +886,105 @@ function EditorShell() {
       normalSlotConsumesDrain,
     ],
   )
+
+  // ─── Variant management ────────────────────────────────────────────
+  // Switching captures the in-progress edits into `variants` and updates
+  // the URL ?v=N — the remount on the new key reinitializes hooks from
+  // the new variant's data. Unsaved per-variant edits live in `variants`
+  // until the next save.
+  const captureActiveSnapshot = (): SavedVariant => ({
+    id: variants[clampedActiveIndex]?.id ?? "v0",
+    label: variants[clampedActiveIndex]?.label ?? "Main",
+    slots: slots.placed,
+    arcanes: arcanes.placed,
+    helminth,
+    incarnonEnabled,
+    incarnonPerks,
+    deploymentContext,
+  })
+
+  const newVariantId = () =>
+    `v${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`
+
+  const switchVariant = (i: number) => {
+    if (i === clampedActiveIndex) return
+    const snapshot = captureActiveSnapshot()
+    const next = variants.map((v, idx) =>
+      idx === clampedActiveIndex ? snapshot : v,
+    )
+    setVariants(next)
+    navigate({
+      to: ".",
+      search: (s) => ({ ...s, v: i === 0 ? undefined : i }),
+      replace: true,
+    })
+  }
+
+  const addVariant = () => {
+    const MAX = 4
+    if (variants.length >= MAX) return
+    const snapshot = captureActiveSnapshot()
+    const seeded = variants.map((v, idx) =>
+      idx === clampedActiveIndex ? snapshot : v,
+    )
+    const blank: SavedVariant = {
+      id: newVariantId(),
+      label: `Variant ${seeded.length + 1}`,
+      slots: {},
+      arcanes: [],
+    }
+    const next = [...seeded, blank]
+    setVariants(next)
+    navigate({
+      to: ".",
+      search: (s) => ({ ...s, v: next.length - 1 }),
+      replace: true,
+    })
+  }
+
+  const duplicateActive = () => {
+    const MAX = 4
+    if (variants.length >= MAX) return
+    const snapshot = captureActiveSnapshot()
+    const dup: SavedVariant = {
+      ...snapshot,
+      id: newVariantId(),
+      label: `${snapshot.label} (copy)`,
+    }
+    const seeded = variants.map((v, idx) =>
+      idx === clampedActiveIndex ? snapshot : v,
+    )
+    const insertAt = clampedActiveIndex + 1
+    const next = [...seeded.slice(0, insertAt), dup, ...seeded.slice(insertAt)]
+    setVariants(next)
+    navigate({
+      to: ".",
+      search: (s) => ({ ...s, v: insertAt === 0 ? undefined : insertAt }),
+      replace: true,
+    })
+  }
+
+  const deleteActive = () => {
+    if (variants.length <= 1) return
+    const next = variants.filter((_, i) => i !== clampedActiveIndex)
+    setVariants(next)
+    const newIdx = Math.min(clampedActiveIndex, next.length - 1)
+    navigate({
+      to: ".",
+      search: (s) => ({ ...s, v: newIdx === 0 ? undefined : newIdx }),
+      replace: true,
+    })
+  }
+
+  const renameActive = (label: string) => {
+    const trimmed =
+      label.trim().slice(0, 24) || `Variant ${clampedActiveIndex + 1}`
+    setVariants((prev) =>
+      prev.map((v, i) =>
+        i === clampedActiveIndex ? { ...v, label: trimmed } : v,
+      ),
+    )
+  }
 
   return (
     <>
@@ -625,31 +1059,44 @@ function EditorShell() {
                 }
               }}
             >
-              <ItemSidebarPopover
-                className="hidden self-start sm:inline-flex xl:hidden"
-                item={item}
-                category={category}
-                capacityUsed={capacity.used}
-                capacityMax={capacity.max}
-                hasReactor={hasReactor}
-                onToggleReactor={() => setHasReactor((v) => !v)}
-                shards={shards}
-                onSetShard={setShard}
-                helminth={helminth}
-                onSetHelminth={setHelminthAt}
-                zawComponents={zawComponents}
-                onSetZawComponents={setZawComponents}
-                lichBonusElement={lichBonusElement}
-                onSetLichBonusElement={setLichBonusElement}
-                incarnonEnabled={incarnonEnabled}
-                onToggleIncarnon={() => setIncarnonEnabled((v) => !v)}
-                incarnonPerks={incarnonPerks}
-                onSetIncarnonPerk={setIncarnonPerkAt}
-                deploymentContext={deploymentContext}
-                onSetDeploymentContext={setDeploymentContext}
-                placedMods={slots.placed}
-                placedArcanes={arcanes.placed}
-              />
+              <div className="flex items-center gap-2">
+                <ItemSidebarPopover
+                  className="hidden shrink-0 sm:inline-flex xl:hidden"
+                  item={item}
+                  category={category}
+                  capacityUsed={capacity.used}
+                  capacityMax={capacity.max}
+                  hasReactor={hasReactor}
+                  onToggleReactor={() => setHasReactor((v) => !v)}
+                  shards={shards}
+                  onSetShard={setShard}
+                  helminth={helminth}
+                  onSetHelminth={setHelminthAt}
+                  zawComponents={zawComponents}
+                  onSetZawComponents={setZawComponents}
+                  lichBonusElement={lichBonusElement}
+                  onSetLichBonusElement={setLichBonusElement}
+                  incarnonEnabled={incarnonEnabled}
+                  onToggleIncarnon={() => setIncarnonEnabled((v) => !v)}
+                  incarnonPerks={incarnonPerks}
+                  onSetIncarnonPerk={setIncarnonPerkAt}
+                  deploymentContext={deploymentContext}
+                  onSetDeploymentContext={setDeploymentContext}
+                  placedMods={slots.placed}
+                  placedArcanes={arcanes.placed}
+                />
+                <div className="min-w-0 flex-1">
+                  <EditorVariantBar
+                    variants={variants}
+                    activeIndex={clampedActiveIndex}
+                    onSwitch={switchVariant}
+                    onAdd={addVariant}
+                    onDuplicate={duplicateActive}
+                    onDelete={deleteActive}
+                    onRename={renameActive}
+                  />
+                </div>
+              </div>
               <ModGrid
                 item={item}
                 category={category}
@@ -741,5 +1188,232 @@ function EditorShell() {
 
       {riven.dialog}
     </>
+  )
+}
+
+const MAX_EDITOR_VARIANTS = 4
+
+function EditorVariantBar({
+  variants,
+  activeIndex,
+  onSwitch,
+  onAdd,
+  onDuplicate,
+  onDelete,
+  onRename,
+}: {
+  variants: SavedVariant[]
+  activeIndex: number
+  onSwitch: (index: number) => void
+  onAdd: () => void
+  onDuplicate: () => void
+  onDelete: () => void
+  onRename: (label: string) => void
+}) {
+  // Hide the bar for single-variant builds until the user opts in via
+  // "+ Variant". Keeps the editor visually identical to before for
+  // anyone not using variants.
+  if (variants.length === 1) {
+    return (
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          onClick={onAdd}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted/40 rounded-md border border-dashed px-2 py-1 text-xs"
+          title="Add a build variant"
+        >
+          + Variant
+        </button>
+      </div>
+    )
+  }
+  const active = variants[activeIndex]
+  const atCap = variants.length >= MAX_EDITOR_VARIANTS
+  return (
+    <EditorVariantBarMulti
+      variants={variants}
+      activeIndex={activeIndex}
+      active={active}
+      atCap={atCap}
+      onSwitch={onSwitch}
+      onAdd={onAdd}
+      onDuplicate={onDuplicate}
+      onDelete={onDelete}
+      onRename={onRename}
+    />
+  )
+}
+
+function EditorVariantBarMulti({
+  variants,
+  activeIndex,
+  active,
+  atCap,
+  onSwitch,
+  onAdd,
+  onDuplicate,
+  onDelete,
+  onRename,
+}: {
+  variants: SavedVariant[]
+  activeIndex: number
+  active: SavedVariant
+  atCap: boolean
+  onSwitch: (index: number) => void
+  onAdd: () => void
+  onDuplicate: () => void
+  onDelete: () => void
+  onRename: (label: string) => void
+}) {
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [labelDraft, setLabelDraft] = useState(active.label)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const onlyVariant = variants.length <= 1
+  // Mirror renameActive's fallback so the input shows the normalized value
+  // after blur — otherwise clearing the input and tabbing away leaves an
+  // empty draft in the popover while the underlying variant has "Variant N".
+  const commitRename = () => {
+    const normalized =
+      labelDraft.trim().slice(0, 24) || `Variant ${activeIndex + 1}`
+    if (normalized !== labelDraft) setLabelDraft(normalized)
+    onRename(normalized)
+  }
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-1.5 pb-1">
+      {variants.map((v, i) => {
+        const isActive = i === activeIndex
+        return (
+          <div key={v.id || i} className="flex items-center gap-0.5">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onSwitch(i)}
+              className={cn(
+                "rounded-l-md border px-3 py-1 text-sm transition-colors",
+                isActive
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "bg-muted/30 hover:bg-muted text-muted-foreground hover:text-foreground rounded-md border-transparent",
+              )}
+            >
+              {v.label || `Variant ${i + 1}`}
+            </button>
+            {isActive ? (
+              <Popover
+                open={settingsOpen}
+                onOpenChange={(o) => {
+                  setSettingsOpen(o)
+                  if (o) {
+                    setLabelDraft(active.label)
+                    requestAnimationFrame(() => {
+                      inputRef.current?.focus()
+                      inputRef.current?.select()
+                    })
+                  }
+                }}
+              >
+                <PopoverTrigger
+                  render={
+                    <button
+                      type="button"
+                      title="Variant settings"
+                      className="border-primary bg-primary text-primary-foreground rounded-r-md border border-l-0 px-1.5 py-1 text-sm"
+                    >
+                      ⚙
+                    </button>
+                  }
+                />
+                <PopoverContent
+                  side="bottom"
+                  align="center"
+                  className="w-64 p-3"
+                >
+                  <div className="flex flex-col gap-2">
+                    <label className="text-muted-foreground text-xs">
+                      Name
+                    </label>
+                    <Input
+                      ref={inputRef}
+                      value={labelDraft}
+                      maxLength={24}
+                      onChange={(e) => setLabelDraft(e.target.value)}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          commitRename()
+                          setSettingsOpen(false)
+                        } else if (e.key === "Escape") {
+                          setSettingsOpen(false)
+                        }
+                      }}
+                      className="h-8 text-sm"
+                    />
+                    <div className="mt-1 flex gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => {
+                          commitRename()
+                          onDuplicate()
+                          setSettingsOpen(false)
+                        }}
+                        disabled={atCap}
+                        title={
+                          atCap
+                            ? "Maximum of 4 variants per build"
+                            : "Duplicate this variant"
+                        }
+                        className="flex-1"
+                      >
+                        Duplicate
+                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => {
+                                onDelete()
+                                setSettingsOpen(false)
+                              }}
+                              disabled={onlyVariant}
+                              className="flex-1"
+                            />
+                          }
+                        >
+                          Delete
+                        </TooltipTrigger>
+                        {onlyVariant ? (
+                          <TooltipContent>
+                            Can't delete the last variant
+                          </TooltipContent>
+                        ) : null}
+                      </Tooltip>
+                    </div>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            ) : null}
+          </div>
+        )
+      })}
+      <button
+        type="button"
+        onClick={onAdd}
+        disabled={atCap}
+        title={
+          atCap ? "Maximum of 4 variants per build" : "Add a build variant"
+        }
+        className={cn(
+          "rounded-md border border-dashed px-2.5 py-1 text-sm",
+          atCap
+            ? "border-muted-foreground/20 text-muted-foreground/40 cursor-not-allowed"
+            : "border-muted-foreground/40 text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+        )}
+      >
+        + Variant
+      </button>
+    </div>
   )
 }

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,10 +1,10 @@
 import {
-  decodeBuild,
   decodeBuildDoc,
   encodeBuild,
   encodeBuildDoc,
 } from "@arsenyx/shared/warframe/build-codec"
 import {
+  MAX_VARIANTS,
   projectVariant,
   type BuildDoc,
 } from "@arsenyx/shared/warframe/build-doc"
@@ -48,6 +48,7 @@ import {
   getNormalSlotCount,
   getPlexusGroupForIndex,
   GuideEditor,
+  type GuideScope,
   hasExilusSlot,
   hasStanceSlot,
   ItemSidebar,
@@ -76,20 +77,18 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { apiErrorMessage, apiFetch } from "@/lib/api-client"
 import { arcanesQuery } from "@/lib/arcanes-query"
 import { authClient } from "@/lib/auth-client"
 import {
   buildStateToSavedData,
   getVariants,
+  isSyntheticVariant,
   normalizeBuildData,
   savedDataToBuildState,
   selectVariant,
+  SYNTHETIC_VARIANT_ID,
+  SYNTHETIC_VARIANT_LABEL,
 } from "@/lib/build-codec-adapter"
 import {
   buildQuery,
@@ -281,12 +280,7 @@ function EditorShell() {
       })
       return { data: { ...activeData, variants: savedVariants } }
     }
-    // Last-ditch: try the v1 decoder directly in case decodeBuildDoc
-    // rejects the payload (e.g. unknown version added later by a
-    // newer client).
-    const decoded = decodeBuild(shareEncoded)
-    if (!decoded) return null
-    return buildStateToSavedData(decoded, allMods, allArcanes)
+    return null
   })
   // Full normalized saved data (all variants intact); used when persisting.
   const savedDataAll: SavedBuildData = useMemo(() => {
@@ -501,6 +495,11 @@ function EditorShell() {
     () =>
       cachedShared?.guideDescription ?? existingBuild?.guide?.description ?? "",
   )
+  // Scope of the GuideEditor — build-wide vs a specific variant. Resets
+  // to "build" on EditorShell remount (variant switches) which keeps the
+  // UX predictable: switching variants doesn't silently change what
+  // guide you're editing.
+  const [guideScope, setGuideScope] = useState<GuideScope>({ kind: "build" })
 
   const [zawComponents, setZawComponents] = useState<
     { grip: string; link: string } | undefined
@@ -543,34 +542,36 @@ function EditorShell() {
     () => savedData.deploymentContext ?? DEFAULT_DEPLOYMENT_CONTEXT,
   )
 
-  // Sync shared field edits into the module cache so they survive
-  // the EditorShell remount that fires on every variant switch.
-  // Per-variant fields (slots/arcanes/incarnon/dc/helminth) live in
-  // the variants array; these effects only mirror build-wide state.
+  // Sync shared field edits into the module cache so they survive the
+  // EditorShell remount on every variant switch. Per-variant fields
+  // (slots/arcanes/incarnon/dc/helminth) live in the variants array;
+  // this only mirrors build-wide state. One effect with a fresh patch
+  // each render — React shallow-compares deps, so unchanged fields
+  // no-op cheaply.
   useEffect(() => {
-    writeShared({ hasReactor })
-  }, [hasReactor]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    writeShared({ shards })
-  }, [shards]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    writeShared({ zawComponents })
-  }, [zawComponents]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    writeShared({ lichBonusElement })
-  }, [lichBonusElement]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    writeShared({ buildName })
-  }, [buildName]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    writeShared({ guideSummary })
-  }, [guideSummary]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    writeShared({ guideDescription })
-  }, [guideDescription]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    writeShared({ formaPolarities: slots.formaPolarities })
-  }, [slots.formaPolarities]) // eslint-disable-line react-hooks/exhaustive-deps
+    writeShared({
+      hasReactor,
+      shards,
+      zawComponents,
+      lichBonusElement,
+      buildName,
+      guideSummary,
+      guideDescription,
+      formaPolarities: slots.formaPolarities,
+    })
+    // writeShared closes over storeKey; intentionally excluded — storeKey
+    // changes trigger a full EditorShell remount, not a re-sync.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    hasReactor,
+    shards,
+    zawComponents,
+    lichBonusElement,
+    buildName,
+    guideSummary,
+    guideDescription,
+    slots.formaPolarities,
+  ])
   const setIncarnonPerkAt = (tierIndex: number, perk: string | null) => {
     setIncarnonPerks((prev) => {
       const next = [...prev]
@@ -783,12 +784,10 @@ function EditorShell() {
           deploymentContext,
           // Emit `variants` whenever there's more than one OR the single
           // remaining variant has a user-assigned label/id — otherwise the
-          // synthetic "Main"/"v0" from getVariants() would silently
+          // synthetic placeholder from getVariants() would silently
           // overwrite the user's label after delete-down-to-one.
           ...((nextVariants.length > 1 ||
-            (nextVariants.length === 1 &&
-              (nextVariants[0].label !== "Main" ||
-                nextVariants[0].id !== "v0"))) && {
+            !isSyntheticVariant(nextVariants[0])) && {
             variants: nextVariants,
           }),
         },
@@ -892,16 +891,24 @@ function EditorShell() {
   // the URL ?v=N — the remount on the new key reinitializes hooks from
   // the new variant's data. Unsaved per-variant edits live in `variants`
   // until the next save.
-  const captureActiveSnapshot = (): SavedVariant => ({
-    id: variants[clampedActiveIndex]?.id ?? "v0",
-    label: variants[clampedActiveIndex]?.label ?? "Main",
-    slots: slots.placed,
-    arcanes: arcanes.placed,
-    helminth,
-    incarnonEnabled,
-    incarnonPerks,
-    deploymentContext,
-  })
+  const captureActiveSnapshot = (): SavedVariant => {
+    const existing = variants[clampedActiveIndex]
+    return {
+      id: existing?.id ?? SYNTHETIC_VARIANT_ID,
+      label: existing?.label ?? SYNTHETIC_VARIANT_LABEL,
+      slots: slots.placed,
+      arcanes: arcanes.placed,
+      helminth,
+      incarnonEnabled,
+      incarnonPerks,
+      deploymentContext,
+      // Per-variant guide fields are owned by `variants[i]` directly
+      // (GuideEditor writes through setVariants). Preserve them on
+      // snapshot so a save while editing build-wide doesn't wipe them.
+      guideSummary: existing?.guideSummary,
+      guideDescription: existing?.guideDescription,
+    }
+  }
 
   const newVariantId = () =>
     `v${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`
@@ -921,8 +928,7 @@ function EditorShell() {
   }
 
   const addVariant = () => {
-    const MAX = 4
-    if (variants.length >= MAX) return
+    if (variants.length >= MAX_VARIANTS) return
     const snapshot = captureActiveSnapshot()
     const seeded = variants.map((v, idx) =>
       idx === clampedActiveIndex ? snapshot : v,
@@ -943,8 +949,7 @@ function EditorShell() {
   }
 
   const duplicateActive = () => {
-    const MAX = 4
-    if (variants.length >= MAX) return
+    if (variants.length >= MAX_VARIANTS) return
     const snapshot = captureActiveSnapshot()
     const dup: SavedVariant = {
       ...snapshot,
@@ -1154,11 +1159,54 @@ function EditorShell() {
 
           <div className="bg-card rounded-lg border p-4 select-text">
             <GuideEditor
-              summary={guideSummary}
-              onSummaryChange={setGuideSummary}
-              description={guideDescription}
-              onDescriptionChange={setGuideDescription}
+              summary={
+                guideScope.kind === "build"
+                  ? guideSummary
+                  : (variants[guideScope.index]?.guideSummary ?? "")
+              }
+              onSummaryChange={(v) => {
+                if (guideScope.kind === "build") {
+                  setGuideSummary(v)
+                  return
+                }
+                const idx = guideScope.index
+                setVariants((prev) =>
+                  prev.map((sv, i) =>
+                    i === idx ? { ...sv, guideSummary: v } : sv,
+                  ),
+                )
+              }}
+              description={
+                guideScope.kind === "build"
+                  ? guideDescription
+                  : (variants[guideScope.index]?.guideDescription ?? "")
+              }
+              onDescriptionChange={(v) => {
+                if (guideScope.kind === "build") {
+                  setGuideDescription(v)
+                  return
+                }
+                const idx = guideScope.index
+                setVariants((prev) =>
+                  prev.map((sv, i) =>
+                    i === idx ? { ...sv, guideDescription: v } : sv,
+                  ),
+                )
+              }}
               buildSlug={isUpdate ? existingBuild?.slug : undefined}
+              scopes={variants.map((v) => ({
+                id: v.id,
+                label: v.label,
+                hasContent: Boolean(
+                  (v.guideSummary && v.guideSummary.trim()) ||
+                  (v.guideDescription && v.guideDescription.trim()),
+                ),
+              }))}
+              activeScope={guideScope}
+              onScopeChange={setGuideScope}
+              buildScopeHasContent={Boolean(
+                guideSummary.trim() || guideDescription.trim(),
+              )}
             />
           </div>
         </div>
@@ -1190,8 +1238,6 @@ function EditorShell() {
     </>
   )
 }
-
-const MAX_EDITOR_VARIANTS = 4
 
 function EditorVariantBar({
   variants,
@@ -1228,7 +1274,7 @@ function EditorVariantBar({
     )
   }
   const active = variants[activeIndex]
-  const atCap = variants.length >= MAX_EDITOR_VARIANTS
+  const atCap = variants.length >= MAX_VARIANTS
   return (
     <EditorVariantBarMulti
       variants={variants}
@@ -1268,7 +1314,6 @@ function EditorVariantBarMulti({
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [labelDraft, setLabelDraft] = useState(active.label)
   const inputRef = useRef<HTMLInputElement>(null)
-  const onlyVariant = variants.length <= 1
   // Mirror renameActive's fallback so the input shows the normalized value
   // after blur — otherwise clearing the input and tabbing away leaves an
   // empty draft in the popover while the underlying variant has "Variant N".
@@ -1360,36 +1405,24 @@ function EditorVariantBarMulti({
                         disabled={atCap}
                         title={
                           atCap
-                            ? "Maximum of 4 variants per build"
+                            ? `Maximum of ${MAX_VARIANTS} variants per build`
                             : "Duplicate this variant"
                         }
                         className="flex-1"
                       >
                         Duplicate
                       </Button>
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              size="sm"
-                              variant="destructive"
-                              onClick={() => {
-                                onDelete()
-                                setSettingsOpen(false)
-                              }}
-                              disabled={onlyVariant}
-                              className="flex-1"
-                            />
-                          }
-                        >
-                          Delete
-                        </TooltipTrigger>
-                        {onlyVariant ? (
-                          <TooltipContent>
-                            Can't delete the last variant
-                          </TooltipContent>
-                        ) : null}
-                      </Tooltip>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => {
+                          onDelete()
+                          setSettingsOpen(false)
+                        }}
+                        className="flex-1"
+                      >
+                        Delete
+                      </Button>
                     </div>
                   </div>
                 </PopoverContent>
@@ -1403,7 +1436,7 @@ function EditorVariantBarMulti({
         onClick={onAdd}
         disabled={atCap}
         title={
-          atCap ? "Maximum of 4 variants per build" : "Add a build variant"
+          atCap ? `Maximum of ${MAX_VARIANTS} variants per build` : "Add a build variant"
         }
         className={cn(
           "rounded-md border border-dashed px-2.5 py-1 text-sm",

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -276,6 +276,8 @@ function EditorShell() {
           incarnonEnabled: data.incarnonEnabled,
           incarnonPerks: data.incarnonPerks,
           deploymentContext: data.deploymentContext,
+          guideSummary: v.guideSummary,
+          guideDescription: v.guideDescription,
         }
       })
       return { data: { ...activeData, variants: savedVariants } }
@@ -1436,7 +1438,9 @@ function EditorVariantBarMulti({
         onClick={onAdd}
         disabled={atCap}
         title={
-          atCap ? `Maximum of ${MAX_VARIANTS} variants per build` : "Add a build variant"
+          atCap
+            ? `Maximum of ${MAX_VARIANTS} variants per build`
+            : "Add a build variant"
         }
         className={cn(
           "rounded-md border border-dashed px-2.5 py-1 text-sm",

--- a/packages/shared/src/warframe/build-codec.test.ts
+++ b/packages/shared/src/warframe/build-codec.test.ts
@@ -71,6 +71,25 @@ describe("encodeBuildDoc / decodeBuildDoc round-trip", () => {
     expect(decoded.variants[1].incarnonEnabled).toBe(false)
   })
 
+  it("round-trips per-variant guides on multi-variant docs", () => {
+    const doc = makeDoc([
+      makeVariant({
+        id: "a",
+        label: "A",
+        guideSummary: "use this for steel path",
+        guideDescription: "long-form notes\n\n- bullet",
+      }),
+      makeVariant({ id: "b", label: "B" }),
+    ])
+    const decoded = decodeBuildDoc(encodeBuildDoc(doc))!
+    expect(decoded.variants[0].guideSummary).toBe("use this for steel path")
+    expect(decoded.variants[0].guideDescription).toBe(
+      "long-form notes\n\n- bullet",
+    )
+    expect(decoded.variants[1].guideSummary).toBeUndefined()
+    expect(decoded.variants[1].guideDescription).toBeUndefined()
+  })
+
   it("rejects unknown lichBonusElement on v2 decode", () => {
     const doc = makeDoc([makeVariant(), makeVariant({ id: "v1", label: "B" })])
     const encoded = encodeBuildDoc({

--- a/packages/shared/src/warframe/build-codec.test.ts
+++ b/packages/shared/src/warframe/build-codec.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeBuildDoc, encodeBuildDoc } from "./build-codec"
+import type { BuildDoc, BuildVariant } from "./build-doc"
+import type { ModSlot } from "./types"
+
+function emptyAuraSlot(i: number): ModSlot {
+  return { id: `aura-${i}`, type: "aura" }
+}
+function emptyNormalSlot(i: number): ModSlot {
+  return { id: `normal-${i}`, type: "normal" }
+}
+
+function makeVariant(overrides: Partial<BuildVariant> = {}): BuildVariant {
+  return {
+    id: "v0",
+    label: "Main",
+    auraSlots: [emptyAuraSlot(0)],
+    normalSlots: Array.from({ length: 8 }, (_, i) => emptyNormalSlot(i)),
+    arcaneSlots: [],
+    ...overrides,
+  }
+}
+
+function makeDoc(variants: BuildVariant[]): BuildDoc {
+  return {
+    itemUniqueName: "/Lotus/Powersuits/Excalibur/Excalibur",
+    itemName: "Excalibur",
+    itemCategory: "warframes",
+    hasReactor: true,
+    shardSlots: [],
+    variants,
+  }
+}
+
+describe("encodeBuildDoc / decodeBuildDoc round-trip", () => {
+  it("single-variant doc round-trips via v1 encoder", () => {
+    const doc = makeDoc([makeVariant()])
+    const encoded = encodeBuildDoc(doc)
+    const decoded = decodeBuildDoc(encoded)
+    expect(decoded).not.toBeNull()
+    expect(decoded!.variants).toHaveLength(1)
+    expect(decoded!.itemUniqueName).toBe(doc.itemUniqueName)
+    expect(decoded!.hasReactor).toBe(true)
+  })
+
+  it("multi-variant doc preserves variant identity and order", () => {
+    const doc = makeDoc([
+      makeVariant({ id: "vA", label: "General" }),
+      makeVariant({ id: "vB", label: "Melee" }),
+      makeVariant({ id: "vC", label: "Eidolon" }),
+    ])
+    const encoded = encodeBuildDoc(doc)
+    const decoded = decodeBuildDoc(encoded)
+    expect(decoded).not.toBeNull()
+    expect(decoded!.variants.map((v) => v.id)).toEqual(["vA", "vB", "vC"])
+    expect(decoded!.variants.map((v) => v.label)).toEqual([
+      "General",
+      "Melee",
+      "Eidolon",
+    ])
+  })
+
+  it("preserves explicit incarnonEnabled=false on multi-variant doc", () => {
+    const doc = makeDoc([
+      makeVariant({ id: "vA", label: "On", incarnonEnabled: true }),
+      makeVariant({ id: "vB", label: "Off", incarnonEnabled: false }),
+    ])
+    const decoded = decodeBuildDoc(encodeBuildDoc(doc))!
+    expect(decoded.variants[0].incarnonEnabled).toBe(true)
+    expect(decoded.variants[1].incarnonEnabled).toBe(false)
+  })
+
+  it("rejects unknown lichBonusElement on v2 decode", () => {
+    const doc = makeDoc([makeVariant(), makeVariant({ id: "v1", label: "B" })])
+    const encoded = encodeBuildDoc({
+      ...doc,
+      lichBonusElement: "Bogus" as unknown as BuildDoc["lichBonusElement"],
+    })
+    const decoded = decodeBuildDoc(encoded)!
+    expect(decoded.lichBonusElement).toBeUndefined()
+  })
+
+  it("preserves activeIndex via the v2 `ai` field", () => {
+    const doc = makeDoc([
+      makeVariant({ id: "a", label: "A" }),
+      makeVariant({ id: "b", label: "B" }),
+    ])
+    // ai is encoded but `decodeBuildDoc` doesn't surface it on the returned
+    // BuildDoc — the caller threads activeIndex separately. Smoke-test that
+    // the encoder produces something decodeBuildDoc accepts when ai > 0.
+    const encoded = encodeBuildDoc(doc, 1)
+    expect(decodeBuildDoc(encoded)).not.toBeNull()
+  })
+
+  it("returns null for garbage input", () => {
+    expect(decodeBuildDoc("not-base64-!@#")).toBeNull()
+  })
+})

--- a/packages/shared/src/warframe/build-codec.ts
+++ b/packages/shared/src/warframe/build-codec.ts
@@ -1,3 +1,4 @@
+import type { BuildDoc, BuildVariant } from "./build-doc"
 import { normalizePolarity } from "./mods"
 import { RIVEN_IMAGE_NAME, RIVEN_UNIQUE_NAME } from "./rivens"
 import { SHARD_COLORS, getStatByIndex, getStatIndex } from "./shards"
@@ -347,6 +348,248 @@ function decodeSlot(
   }
 
   return slot
+}
+
+// =============================================================================
+// V2 — multi-variant share links
+// =============================================================================
+
+interface EncodedBuildV2 {
+  v: 2
+  i: string
+  c: string
+  r: boolean
+  sh?: number[]
+  h?: EncodedHelminth
+  zc?: { g: string; l: string }
+  lb?: string
+  n?: string
+  ai?: number
+  vs: EncodedVariant[]
+}
+
+interface EncodedVariant {
+  l: string
+  id?: string
+  a?: EncodedSlot
+  A?: EncodedSlot[]
+  e?: EncodedSlot
+  st?: EncodedSlot
+  s: EncodedSlot[]
+  ar?: EncodedArcane[]
+  ic?: { e?: boolean; p?: (string | null)[] }
+  dc?: DeploymentContext
+}
+
+function encodeVariant(v: BuildVariant): EncodedVariant {
+  const ev: EncodedVariant = {
+    l: v.label,
+    id: v.id,
+    s: v.normalSlots.map(encodeSlot),
+  }
+  if (v.auraSlots.length === 1) ev.a = encodeSlot(v.auraSlots[0])
+  else if (v.auraSlots.length > 1) ev.A = v.auraSlots.map(encodeSlot)
+  if (v.exilusSlot?.mod || v.exilusSlot?.formaPolarity)
+    ev.e = encodeSlot(v.exilusSlot)
+  if (v.stanceSlot?.mod || v.stanceSlot?.formaPolarity)
+    ev.st = encodeSlot(v.stanceSlot)
+  const placedArcanes = (v.arcaneSlots ?? []).filter(
+    (a): a is PlacedArcane => a !== null,
+  )
+  if (placedArcanes.length > 0) {
+    ev.ar = placedArcanes.map((a) => ({ u: a.uniqueName, r: a.rank }))
+  }
+  const hasPickedPerks = v.incarnonPerks?.some((p) => p) ?? false
+  if (v.incarnonEnabled !== undefined || hasPickedPerks) {
+    ev.ic = {}
+    if (v.incarnonEnabled !== undefined) ev.ic.e = v.incarnonEnabled
+    if (hasPickedPerks) ev.ic.p = v.incarnonPerks
+  }
+  if (v.deploymentContext && v.deploymentContext !== DEFAULT_DEPLOYMENT_CONTEXT)
+    ev.dc = v.deploymentContext
+  return ev
+}
+
+function decodeVariant(ev: EncodedVariant, index: number): BuildVariant {
+  const variant: BuildVariant = {
+    id: ev.id ?? `v${index}`,
+    label: ev.l,
+    auraSlots: ev.A
+      ? ev.A.map((s, i) => decodeSlot(s, "aura", `aura-${i}`))
+      : ev.a
+        ? [decodeSlot(ev.a, "aura", "aura-0")]
+        : [],
+    exilusSlot: ev.e ? decodeSlot(ev.e, "exilus", "exilus-0") : undefined,
+    stanceSlot: ev.st ? decodeSlot(ev.st, "stance", "stance") : undefined,
+    normalSlots: ev.s.map((s, i) => decodeSlot(s, "normal", `normal-${i}`)),
+    arcaneSlots:
+      ev.ar && ev.ar.length > 0
+        ? ev.ar.map((a) => ({
+            uniqueName: a.u,
+            name: "",
+            rank: a.r,
+            rarity: "",
+          }))
+        : [],
+  }
+  if (ev.ic) {
+    variant.incarnonEnabled = ev.ic.e
+    variant.incarnonPerks = ev.ic.p
+  }
+  if (ev.dc) variant.deploymentContext = ev.dc
+  return variant
+}
+
+/**
+ * Encode a `BuildDoc` for a share link. Single-variant docs round-trip
+ * through the v1 encoder so existing URLs / outside consumers see no
+ * change. Multi-variant docs emit v2.
+ */
+export function encodeBuildDoc(doc: BuildDoc, activeIndex = 0): string {
+  if (doc.variants.length === 1) {
+    return encodeBuild(buildDocToBuildState(doc, 0))
+  }
+  const encoded: EncodedBuildV2 = {
+    v: 2,
+    i: doc.itemUniqueName,
+    c: doc.itemCategory,
+    r: doc.hasReactor,
+    vs: doc.variants.map(encodeVariant),
+  }
+  if (doc.shardSlots?.length > 0 && doc.shardSlots.some((s) => s !== null))
+    encoded.sh = encodeShards(doc.shardSlots)
+  if (doc.helminthAbility) {
+    encoded.h = {
+      si: doc.helminthAbility.slotIndex,
+      u: doc.helminthAbility.ability.uniqueName,
+      n: doc.helminthAbility.ability.name,
+      s: doc.helminthAbility.ability.source,
+      im: doc.helminthAbility.ability.imageName,
+      d: doc.helminthAbility.ability.description,
+    }
+  }
+  if (doc.zawComponents) {
+    encoded.zc = { g: doc.zawComponents.grip, l: doc.zawComponents.link }
+  }
+  if (doc.lichBonusElement) encoded.lb = doc.lichBonusElement
+  if (doc.buildName) encoded.n = doc.buildName
+  if (activeIndex > 0) encoded.ai = activeIndex
+
+  const jsonString = JSON.stringify(encoded)
+  if (typeof window !== "undefined") {
+    return btoa(encodeURIComponent(jsonString))
+  }
+  return Buffer.from(jsonString, "utf-8").toString("base64")
+}
+
+/**
+ * Decode a share link to a `BuildDoc`. Accepts both v1 (wrapped as a
+ * single-variant doc) and v2. Returns `null` on parse failure or an
+ * unsupported version, matching `decodeBuild`'s tolerant contract.
+ */
+export function decodeBuildDoc(base64String: string): BuildDoc | null {
+  try {
+    let jsonString: string
+    if (typeof window !== "undefined") {
+      jsonString = decodeURIComponent(atob(base64String))
+    } else {
+      jsonString = Buffer.from(base64String, "base64").toString("utf-8")
+    }
+    const raw = JSON.parse(jsonString) as { v?: number }
+    if (raw.v === 1) {
+      const v1 = decodeBuild(base64String)
+      if (!v1) return null
+      return buildStateToBuildDoc(v1)
+    }
+    if (raw.v === 2) return decodeV2(raw as unknown as EncodedBuildV2)
+    return null
+  } catch {
+    return null
+  }
+}
+
+function decodeV2(encoded: EncodedBuildV2): BuildDoc {
+  return {
+    itemUniqueName: encoded.i,
+    itemCategory: encoded.c as BrowseCategory,
+    itemName: "",
+    hasReactor: encoded.r,
+    shardSlots: encoded.sh ? decodeShards(encoded.sh) : [],
+    helminthAbility: encoded.h
+      ? {
+          slotIndex: encoded.h.si,
+          ability: {
+            uniqueName: encoded.h.u,
+            name: encoded.h.n,
+            source: encoded.h.s,
+            imageName: encoded.h.im,
+            description: encoded.h.d,
+          },
+        }
+      : undefined,
+    zawComponents: encoded.zc
+      ? { grip: encoded.zc.g, link: encoded.zc.l }
+      : undefined,
+    lichBonusElement: encoded.lb as BuildDoc["lichBonusElement"],
+    buildName: encoded.n,
+    variants: encoded.vs.map(decodeVariant),
+  }
+}
+
+function buildDocToBuildState(doc: BuildDoc, index: number): BuildState {
+  const v = doc.variants[index]
+  return {
+    itemUniqueName: doc.itemUniqueName,
+    itemName: doc.itemName,
+    itemCategory: doc.itemCategory,
+    itemImageName: doc.itemImageName,
+    hasReactor: doc.hasReactor,
+    shardSlots: doc.shardSlots,
+    helminthAbility: doc.helminthAbility,
+    zawComponents: doc.zawComponents,
+    lichBonusElement: doc.lichBonusElement,
+    buildName: doc.buildName,
+    auraSlots: v.auraSlots,
+    exilusSlot: v.exilusSlot,
+    stanceSlot: v.stanceSlot,
+    normalSlots: v.normalSlots,
+    arcaneSlots: v.arcaneSlots,
+    incarnonEnabled: v.incarnonEnabled,
+    incarnonPerks: v.incarnonPerks,
+    deploymentContext: v.deploymentContext,
+    baseCapacity: 0,
+    currentCapacity: 0,
+    formaCount: 0,
+  }
+}
+
+function buildStateToBuildDoc(state: Partial<BuildState>): BuildDoc {
+  return {
+    itemUniqueName: state.itemUniqueName ?? "",
+    itemName: state.itemName ?? "",
+    itemCategory: (state.itemCategory ?? "warframes") as BrowseCategory,
+    itemImageName: state.itemImageName,
+    hasReactor: state.hasReactor ?? false,
+    shardSlots: state.shardSlots ?? [],
+    helminthAbility: state.helminthAbility,
+    zawComponents: state.zawComponents,
+    lichBonusElement: state.lichBonusElement,
+    buildName: state.buildName,
+    variants: [
+      {
+        id: "v0",
+        label: "Main",
+        auraSlots: state.auraSlots ?? [],
+        exilusSlot: state.exilusSlot,
+        stanceSlot: state.stanceSlot,
+        normalSlots: state.normalSlots ?? [],
+        arcaneSlots: state.arcaneSlots ?? [],
+        incarnonEnabled: state.incarnonEnabled,
+        incarnonPerks: state.incarnonPerks,
+        deploymentContext: state.deploymentContext,
+      },
+    ],
+  }
 }
 
 export function generateBuildUrl(state: BuildState, baseUrl?: string): string {

--- a/packages/shared/src/warframe/build-codec.ts
+++ b/packages/shared/src/warframe/build-codec.ts
@@ -389,6 +389,8 @@ interface EncodedVariant {
   ar?: EncodedArcane[]
   ic?: { e?: boolean; p?: (string | null)[] }
   dc?: DeploymentContext
+  gs?: string
+  gd?: string
 }
 
 function encodeVariant(v: BuildVariant): EncodedVariant {
@@ -417,6 +419,8 @@ function encodeVariant(v: BuildVariant): EncodedVariant {
   }
   if (v.deploymentContext && v.deploymentContext !== DEFAULT_DEPLOYMENT_CONTEXT)
     ev.dc = v.deploymentContext
+  if (v.guideSummary) ev.gs = v.guideSummary
+  if (v.guideDescription) ev.gd = v.guideDescription
   return ev
 }
 
@@ -447,6 +451,8 @@ function decodeVariant(ev: EncodedVariant, index: number): BuildVariant {
     variant.incarnonPerks = ev.ic.p
   }
   if (ev.dc) variant.deploymentContext = ev.dc
+  if (ev.gs) variant.guideSummary = ev.gs
+  if (ev.gd) variant.guideDescription = ev.gd
   return variant
 }
 

--- a/packages/shared/src/warframe/build-codec.ts
+++ b/packages/shared/src/warframe/build-codec.ts
@@ -2,7 +2,7 @@ import type { BuildDoc, BuildVariant } from "./build-doc"
 import { normalizePolarity } from "./mods"
 import { RIVEN_IMAGE_NAME, RIVEN_UNIQUE_NAME } from "./rivens"
 import { SHARD_COLORS, getStatByIndex, getStatIndex } from "./shards"
-import { DEFAULT_DEPLOYMENT_CONTEXT } from "./types"
+import { DEFAULT_DEPLOYMENT_CONTEXT, LICH_BONUS_ELEMENTS } from "./types"
 import type {
   BrowseCategory,
   BuildState,
@@ -13,6 +13,13 @@ import type {
   PlacedMod,
   PlacedShard,
 } from "./types"
+
+function parseLichBonusElement(raw: unknown): LichBonusElement | undefined {
+  return typeof raw === "string" &&
+    (LICH_BONUS_ELEMENTS as readonly string[]).includes(raw)
+    ? (raw as LichBonusElement)
+    : undefined
+}
 
 declare const Buffer: {
   from(data: string, encoding: string): { toString(encoding: string): string }
@@ -294,9 +301,8 @@ export function decodeBuild(base64String: string): Partial<BuildState> | null {
       }
     }
 
-    if (encoded.lb) {
-      state.lichBonusElement = encoded.lb as LichBonusElement
-    }
+    const lb = parseLichBonusElement(encoded.lb)
+    if (lb) state.lichBonusElement = lb
 
     if (encoded.ic) {
       state.incarnonEnabled = encoded.ic.e
@@ -354,6 +360,10 @@ function decodeSlot(
 // V2 — multi-variant share links
 // =============================================================================
 
+// v2 intentionally drops `itemName` / `itemImageName` from the payload — the
+// receiving client re-fetches them via `itemQuery(category, uniqueName)`
+// when rendering, so encoding them would just bloat the URL. v1 carried
+// them (`state.itemName`) for the same reason — also unused on decode.
 interface EncodedBuildV2 {
   v: 2
   i: string
@@ -530,7 +540,7 @@ function decodeV2(encoded: EncodedBuildV2): BuildDoc {
     zawComponents: encoded.zc
       ? { grip: encoded.zc.g, link: encoded.zc.l }
       : undefined,
-    lichBonusElement: encoded.lb as BuildDoc["lichBonusElement"],
+    lichBonusElement: parseLichBonusElement(encoded.lb),
     buildName: encoded.n,
     variants: encoded.vs.map(decodeVariant),
   }

--- a/packages/shared/src/warframe/build-doc.ts
+++ b/packages/shared/src/warframe/build-doc.ts
@@ -1,0 +1,94 @@
+import type {
+  BrowseCategory,
+  BuildState,
+  DeploymentContext,
+  LichBonusElement,
+  ModSlot,
+  PlacedArcane,
+  PlacedShard,
+} from "./types"
+
+export const MAX_VARIANTS = 4
+
+/**
+ * Per-variant slice of a build. Mods/arcanes/incarnon perks/deployment
+ * context vary between variants; everything else (item, shards, forma,
+ * reactor, helminth, lich element, guide, name) is shared across all
+ * variants of one build.
+ *
+ * `formaPolarity` still lives on individual `ModSlot`s for backward
+ * compatibility with `BuildState`; the editor must keep formaPolarity
+ * synchronized across variants for the same slot id.
+ */
+export interface BuildVariant {
+  id: string
+  label: string
+  auraSlots: ModSlot[]
+  exilusSlot?: ModSlot
+  stanceSlot?: ModSlot
+  normalSlots: ModSlot[]
+  arcaneSlots: (PlacedArcane | null)[]
+  incarnonEnabled?: boolean
+  incarnonPerks?: (string | null)[]
+  deploymentContext?: DeploymentContext
+}
+
+/**
+ * Top-level build document. Holds shared metadata + 1..MAX_VARIANTS
+ * variants. Legacy single-loadout builds are wrapped as a one-entry
+ * variants array via `normalizeToBuildDoc` (web adapter).
+ */
+export interface BuildDoc {
+  itemUniqueName: string
+  itemName: string
+  itemCategory: BrowseCategory
+  itemImageName?: string
+  hasReactor: boolean
+  shardSlots: (PlacedShard | null)[]
+  helminthAbility?: BuildState["helminthAbility"]
+  zawComponents?: BuildState["zawComponents"]
+  lichBonusElement?: LichBonusElement
+  buildName?: string
+
+  variants: BuildVariant[]
+}
+
+/**
+ * Project a (doc, index) pair back into a `BuildState` that the existing
+ * stat engine, capacity calc, and mod search already understand. Capacity
+ * fields are zeroed because every consumer recomputes them downstream.
+ */
+export function projectVariant(doc: BuildDoc, index: number): BuildState {
+  const v = doc.variants[index] ?? doc.variants[0]
+  return {
+    itemUniqueName: doc.itemUniqueName,
+    itemName: doc.itemName,
+    itemCategory: doc.itemCategory,
+    itemImageName: doc.itemImageName,
+    hasReactor: doc.hasReactor,
+    shardSlots: doc.shardSlots,
+    helminthAbility: doc.helminthAbility,
+    zawComponents: doc.zawComponents,
+    lichBonusElement: doc.lichBonusElement,
+    buildName: doc.buildName,
+    auraSlots: v.auraSlots,
+    exilusSlot: v.exilusSlot,
+    stanceSlot: v.stanceSlot,
+    normalSlots: v.normalSlots,
+    arcaneSlots: v.arcaneSlots,
+    incarnonEnabled: v.incarnonEnabled,
+    incarnonPerks: v.incarnonPerks,
+    deploymentContext: v.deploymentContext,
+    baseCapacity: 0,
+    currentCapacity: 0,
+    formaCount: 0,
+  }
+}
+
+export function clampVariantIndex(doc: BuildDoc, index: number): number {
+  if (!Number.isFinite(index)) return 0
+  const n = Math.floor(index)
+  if (n < 0) return 0
+  const max = doc.variants.length - 1
+  return n > max ? max : n
+}

--- a/packages/shared/src/warframe/build-doc.ts
+++ b/packages/shared/src/warframe/build-doc.ts
@@ -31,6 +31,8 @@ export interface BuildVariant {
   incarnonEnabled?: boolean
   incarnonPerks?: (string | null)[]
   deploymentContext?: DeploymentContext
+  guideSummary?: string
+  guideDescription?: string
 }
 
 /**

--- a/packages/shared/src/warframe/build-doc.ts
+++ b/packages/shared/src/warframe/build-doc.ts
@@ -8,7 +8,7 @@ import type {
   PlacedShard,
 } from "./types"
 
-export const MAX_VARIANTS = 4
+export const MAX_VARIANTS = 5
 
 /**
  * Per-variant slice of a build. Mods/arcanes/incarnon perks/deployment

--- a/packages/shared/src/warframe/index.ts
+++ b/packages/shared/src/warframe/index.ts
@@ -1,5 +1,6 @@
 export * from "./arcanes"
 export * from "./build-codec"
+export * from "./build-doc"
 export * from "./categories"
 export * from "./categorize"
 export * from "./mods"


### PR DESCRIPTION
## Summary

One build can now hold up to 4 alternative mod/arcane loadouts (e.g. "General Use" / "DPS") swappable via tabs in both the viewer and editor.

## What's per-variant vs shared

- **Per-variant**: mods, arcanes, helminth, incarnon enabled/perks, deployment context
- **Shared (build-wide)**: forma polarities, shards, reactor toggle, lich element, zaw components, guide, build name

## Shape & codec

- New `BuildDoc` / `BuildVariant` types in `@arsenyx/shared/warframe/build-doc`
- `SavedBuildData` gains an optional `variants` array. Top-level fields mirror the active variant for legacy-client / external-surface compatibility
- New v2 share-link codec (`encodeBuildDoc` / `decodeBuildDoc`). Single-variant docs still round-trip through v1 for byte-compat with existing share URLs

## Viewer

- `?v=` deep link, clamped to a valid index
- `BuildViewerBody` is re-keyed by `${slug}-${v}` so per-variant hooks re-initialize on tab switch
- `VariantTabs` rendered above the loadout, centered, with the Stats popover absolutely-positioned on the left so the tabs stay visually centered at every breakpoint

## Editor

- Variant tabs + settings popover (rename / duplicate / delete) inside the loadout container
- Module-level cache keyed by `buildSlug` (or `category:item` for new builds) survives the remount that happens on every variant switch, so unsaved edits to shared fields aren't lost
- Save body emits `variants` when length > 1 OR the lone variant has a user-assigned label — preserves labels after delete-down-to-one

## Correctness fixes folded in (from `/code-review high`)

- `writeShared` no longer spreads the previous build's overrides when the cache key changes (prevents shards/forma/buildName leaking across builds)
- `savedData` useMemo dropped `?? savedDataAll` fallbacks for per-variant fields — freshly-added variants open truly blank instead of pre-filled with the previously-active variant's helminth/incarnon
- `selectVariant` returns per-variant fields verbatim (no fallback to top-level mirror)
- `refreshHelminthImage` walks `data.variants[i].helminth` too — stale image hashes self-heal across all variants
- `encodeVariant` only emits `ev.ic.e` when `incarnonEnabled` is explicitly defined — innate-incarnon weapons aren't force-disabled on share-link round-trip
- New `__new_build__` cache bucket includes `category:item` so two new-build sessions on different items don't share state
- Variant rename input normalizes empty values to `Variant N` on blur/Enter

## Test plan

- [x] Multi-variant build: switch tabs in viewer, confirm helminth/incarnon don't bleed
- [x] Add fresh variant on a Warframe with a subsumed ability — opens blank
- [x] Edit build A → navigate to build B without leaving /create — no shared-field leak
- [x] Rename a variant to empty + blur — input shows `Variant N`
- [x] Delete multi-variant build down to one renamed variant, save, reload — label persists
- [x] Single-variant builds emit v1-shape payload (no `variants` field), legacy URLs round-trip unchanged
- [x] `bun run build` in `apps/web/` passes
- [x] Forma stays shared across variants (confirmed by user)
- [x] Fork / Embed flows (confirmed working by user pre-PR)

## Known follow-ups (not in this PR)

- "Unsaved changes" warning on Cancel — needs UX decision (confirm dialog vs `beforeunload`)
- Top-level mirrors-active-variant intent: external surfaces (embeds, OG cards) reflect whichever variant was last active at save. If we'd rather have them always pin to variants[0], that's a small follow-up.