### PR TITLE
Harden auth, images, and rate limits

### DIFF
--- a/apps/api/scripts/migrations/2026-05-23_null_invalid_org_images.sql
+++ b/apps/api/scripts/migrations/2026-05-23_null_invalid_org_images.sql
@@ -1,0 +1,31 @@
+-- Null out organization image URLs that don't pass the validator added in
+-- apps/api/src/lib/validate.ts (validateExternalUrl). Pre-existing rows were
+-- written before validation existed, so any could still be a non-https URL
+-- pointing at an attacker-controlled host whose access logs harvest visitor
+-- IPs + Referer headers on avatar load.
+--
+-- New writes are validated server-side; this catches the back-fill. Admins
+-- whose legitimate logo gets nulled can re-upload via the org settings page.
+--
+-- Scope: only rejects the obvious bad shapes (non-https, private/internal
+-- hostnames, userinfo). The web-side Cloudflare Image Resizing proxy is the
+-- second line of defence — it makes the source fetch happen from CF's
+-- network rather than the visitor's browser regardless of what's stored.
+--
+-- Run against Neon (from apps/api/):
+--   bunx prisma db execute --file scripts/migrations/2026-05-23_null_invalid_org_images.sql
+
+UPDATE organizations
+SET image = NULL
+WHERE image IS NOT NULL
+  AND (
+    image NOT LIKE 'https://%'
+    OR image ~* '^https?://[^/]*@'                                       -- userinfo
+    OR image ~* '^https?://localhost(:|/|$)'
+    OR image ~* '^https?://[^/:]*\.(local|internal)(:[0-9]+)?(/|$)'      -- .local / .internal as actual hostname suffix
+    OR image ~* '^https?://(0\.|127\.|10\.|192\.168\.|169\.254\.)'
+    OR image ~* '^https?://172\.(1[6-9]|2[0-9]|3[0-1])\.'
+    OR image ~* '^https?://(0x[0-9a-f]+|[0-9]+)(:|/|$)'                  -- numeric-IPv4 (decimal/hex)
+    OR image ~* '^https?://\['                                           -- bare IPv6
+    OR length(image) > 500
+  );

--- a/apps/api/scripts/migrations/2026-05-23_null_invalid_user_images.sql
+++ b/apps/api/scripts/migrations/2026-05-23_null_invalid_user_images.sql
@@ -1,0 +1,27 @@
+-- Null out user image URLs that don't pass validateExternalUrl (mirrors the
+-- organizations.image backfill). user.image is populated by Better Auth from
+-- OAuth providers and, going forward, validated on create/update via a
+-- databaseHooks hook. This catches pre-validation rows.
+--
+-- Web rendering already routes user.image through Cloudflare Image Resizing
+-- (proxyImage), so visitor IPs are protected regardless. This migration is
+-- defence-in-depth — any downstream code path that trusts the stored value
+-- as "already validated" gets the right answer.
+--
+-- Run in Neon SQL editor or via:
+--   bunx prisma db execute --file scripts/migrations/2026-05-23_null_invalid_user_images.sql
+
+UPDATE users
+SET image = NULL
+WHERE image IS NOT NULL
+  AND (
+    image NOT LIKE 'https://%'
+    OR image ~* '^https?://[^/]*@'                                       -- userinfo
+    OR image ~* '^https?://localhost(:|/|$)'
+    OR image ~* '^https?://[^/:]*\.(local|internal)(:[0-9]+)?(/|$)'      -- .local / .internal suffix
+    OR image ~* '^https?://(0|127|10|192\.168|169\.254)\.[0-9]'        -- private/loopback IPv4 prefixes (followed by digit octet)
+    OR image ~* '^https?://172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]'         -- 172.16/12 private range
+    OR image ~* '^https?://(0x[0-9a-f]+|[0-9]+)(:|/|$)'                  -- numeric IPv4
+    OR image ~* '^https?://\['                                           -- bare IPv6
+    OR length(image) > 500
+  );

--- a/apps/api/scripts/seed-admin.ts
+++ b/apps/api/scripts/seed-admin.ts
@@ -14,33 +14,85 @@ import { neon } from "@neondatabase/serverless"
 import { hashPassword } from "better-auth/crypto"
 import { nanoid } from "nanoid"
 
-const EMAIL = "admin@admin.com"
-const USERNAME = "admin"
-const PASSWORD = "admin"
+// Refuse to run outside local development. A misconfigured NODE_ENV in CI/prod
+// would otherwise create a known-credential admin account.
+if (process.env.NODE_ENV !== "development") {
+  console.error(
+    `seed-admin refuses to run with NODE_ENV="${process.env.NODE_ENV ?? ""}". Only "development" is allowed.`,
+  )
+  process.exit(1)
+}
+
+const EMAIL = process.env.SEED_ADMIN_EMAIL ?? "admin@local.dev"
+const USERNAME = process.env.SEED_ADMIN_USERNAME ?? "admin"
+// If no password is supplied via env, generate a fresh random one each run so
+// no static "admin/admin" credential ever lands in code or shell history.
+const PASSWORD_FROM_ENV = process.env.SEED_ADMIN_PASSWORD
+const PASSWORD = PASSWORD_FROM_ENV ?? nanoid(20)
 
 async function main() {
   if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is not set")
   const sql = neon(process.env.DATABASE_URL)
 
+  const passwordHash = await hashPassword(PASSWORD)
+
+  // Match strictly by email. Matching on username too (the previous behaviour)
+  // would clobber a developer's real local user if they happened to pick the
+  // same username — we'd email-migrate them and overwrite their password hash.
   const existing = (await sql`
-    SELECT id, email FROM users
-    WHERE email = ${EMAIL} OR username = ${USERNAME}
-    LIMIT 1
-  `) as Array<{ id: string; email: string }>
+    SELECT id FROM users WHERE email = ${EMAIL} LIMIT 1
+  `) as Array<{ id: string }>
   if (existing.length > 0) {
     const row = existing[0]!
-    if (row.email === EMAIL) {
-      console.log(`✓ ${EMAIL} already exists — skipped`)
+    // Upsert the credential row: an OAuth-only user (no providerId='credential'
+    // row) needs one created; an existing credential row gets its password
+    // rotated so the freshly-printed password actually works.
+    const updated = (await sql`
+      UPDATE accounts
+      SET password = ${passwordHash}, "updatedAt" = NOW()
+      WHERE "userId" = ${row.id} AND "providerId" = 'credential'
+      RETURNING id
+    `) as Array<{ id: string }>
+    if (updated.length === 0) {
+      await sql`
+        INSERT INTO accounts (
+          id, "userId", "accountId", "providerId", password,
+          "createdAt", "updatedAt"
+        ) VALUES (
+          ${nanoid()}, ${row.id}, ${row.id}, 'credential', ${passwordHash},
+          NOW(), NOW()
+        )
+      `
+      if (!PASSWORD_FROM_ENV) {
+        console.log(`✓ ${EMAIL} credential added → ${PASSWORD}`)
+      } else {
+        console.log(`✓ ${EMAIL} credential added`)
+      }
+      return
+    }
+    if (!PASSWORD_FROM_ENV) {
+      console.log(`✓ ${EMAIL} password rotated → ${PASSWORD}`)
     } else {
-      await sql`UPDATE users SET email = ${EMAIL} WHERE id = ${row.id}`
-      console.log(`✓ migrated existing admin user → ${EMAIL}`)
+      console.log(`✓ ${EMAIL} password rotated`)
     }
     return
   }
 
+  // Refuse to clobber another user that already owns the requested username.
+  // (The seed previously took it over; safer to fail loudly.)
+  const usernameClash = (await sql`
+    SELECT id FROM users WHERE username = ${USERNAME} LIMIT 1
+  `) as Array<{ id: string }>
+  if (usernameClash.length > 0) {
+    console.error(
+      `seed-admin: username "${USERNAME}" is already taken by a different user — refusing to overwrite. ` +
+        `Set SEED_ADMIN_USERNAME to a different value or delete the existing row.`,
+    )
+    process.exit(1)
+  }
+
   const userId = nanoid()
   const accountId = nanoid()
-  const passwordHash = await hashPassword(PASSWORD)
 
   await sql`
     INSERT INTO users (
@@ -66,7 +118,11 @@ async function main() {
     )
   `
 
-  console.log(`✓ seeded ${EMAIL} / ${PASSWORD} (admin)`)
+  if (!PASSWORD_FROM_ENV) {
+    console.log(`✓ seeded ${EMAIL} / ${PASSWORD} (admin)`)
+  } else {
+    console.log(`✓ seeded ${EMAIL} (admin)`)
+  }
 }
 
 main().catch((err) => {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -4,6 +4,28 @@ import { username } from "better-auth/plugins"
 
 import { prisma } from "./db"
 import { webOrigins } from "./env"
+import { validateExternalUrl } from "./lib/validate"
+
+// Normalise user.image to a value validateExternalUrl accepts, or null. The
+// hook fires for OAuth sign-in (`create`), provider-driven refreshes and
+// admin-tool round-trips (`update`), AND the user-facing /update-user
+// endpoint — we can't tell them apart inside Better Auth's hook contract.
+// Throwing on rejection would lock users out of sign-in if a provider ever
+// returns an avatar URL the validator dislikes, so we always silently null
+// instead. Hard validation for human input lives in the route handlers
+// where we control the response shape (see orgs.ts `invalid_image_url`).
+function sanitizeUserImage(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!("image" in data)) return data
+  const v = data.image
+  if (v == null || v === "") return { ...data, image: null }
+  if (typeof v === "string") {
+    const validated = validateExternalUrl(v)
+    if (validated) return { ...data, image: validated }
+  }
+  return { ...data, image: null }
+}
 
 const githubId = process.env.GITHUB_CLIENT_ID?.trim()
 const githubSecret = process.env.GITHUB_CLIENT_SECRET?.trim()
@@ -36,6 +58,12 @@ export const auth = betterAuth({
           github: {
             clientId: githubId,
             clientSecret: githubSecret,
+            // Refresh the user record (notably `image`) from GitHub on every
+            // sign-in. Without this, a user whose avatar got nulled by the
+            // image-validation backfill — or whose profile changed on GitHub
+            // — keeps the stale stored value forever, since Better Auth
+            // otherwise only writes profile fields on first sign-in.
+            overrideUserInfoOnSignIn: true,
             mapProfileToUser: (profile) => ({
               username: profile.login.toLowerCase(),
               displayUsername: profile.login,
@@ -44,6 +72,12 @@ export const auth = betterAuth({
         }
       : {},
   plugins: [username()],
+  databaseHooks: {
+    user: {
+      create: { before: async (data) => ({ data: sanitizeUserImage(data) }) },
+      update: { before: async (data) => ({ data: sanitizeUserImage(data) }) },
+    },
+  },
   user: {
     deleteUser: { enabled: true },
     additionalFields: {

--- a/apps/api/src/bindings.ts
+++ b/apps/api/src/bindings.ts
@@ -1,0 +1,17 @@
+// Cloudflare Workers bindings declared in wrangler.toml.
+//
+// The Hono app itself isn't generically typed (env stays `unknown` on the
+// fetch handler), so callsites cast `c.env as Bindings` where they need a
+// specific binding. Centralised here so a typo in wrangler.toml shows up as
+// a TS error on first use rather than a 500 at runtime.
+
+interface RateLimitBinding {
+  limit(opts: { key: string }): Promise<{ success: boolean }>
+}
+
+export interface Bindings {
+  // Workers Rate Limiting API — the `simple` form returns only `success`.
+  // Configured in wrangler.toml under [[unsafe.bindings]].
+  ANON_SEARCH_LIMITER: RateLimitBinding
+  ANON_READ_LIMITER: RateLimitBinding
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { cors } from "hono/cors"
 import { auth } from "./auth"
 import { withPrisma } from "./db"
 import { webOrigins } from "./env"
+import { rateLimitAnonRead } from "./middleware/rate-limit"
 import { banGuard, originGuard } from "./middleware/security"
 import { isPrismaNotFound } from "./routes/_admin"
 import { admin } from "./routes/admin"
@@ -44,6 +45,14 @@ app.use("/me/*", originGuard, banGuard)
 app.use("/orgs/*", originGuard, banGuard)
 app.use("/users/*", originGuard, banGuard)
 app.use("/admin/*", originGuard, banGuard)
+
+// Edge-side anon throttle on the public read surfaces. Authenticated traffic
+// short-circuits inside the middleware; signed-in users are still bound by
+// rateLimitUser on mutations.
+const anonRead = rateLimitAnonRead()
+app.use("/builds/*", anonRead)
+app.use("/orgs/*", anonRead)
+app.use("/users/*", anonRead)
 
 app.route("/admin", admin)
 app.route("/builds", builds)

--- a/apps/api/src/lib/validate.ts
+++ b/apps/api/src/lib/validate.ts
@@ -88,6 +88,61 @@ export function trimToMax(v: unknown, max: number): string | null {
   return t.length > 0 ? t.slice(0, max) : null
 }
 
+// Strict validator for user-supplied external image URLs. Rejects anything
+// that's not a parseable absolute https:// URL with a non-local hostname.
+//
+// Without this, a malicious org/profile admin could set `image` to a server
+// they control and silently log every visitor's IP and Referer header when
+// the browser loads the avatar. The web client compounds this defence by
+// rendering through Cloudflare Image Resizing so the source fetch happens
+// from CF's network, not the visitor's browser.
+// mDNS / informal private TLDs — anchored at hostname end so legitimate
+// public hostnames that contain `.local` as a middle label (e.g.
+// `cdn.local-cdn.example.com`) are NOT rejected.
+const PRIVATE_TLD_RE = /\.(local|internal)$/i
+// `localhost` as the entire hostname — anchoring at end avoids false-positive
+// rejection of `localhost.example.com` and similar registrable subdomains.
+const LOCALHOST_RE = /^localhost$/i
+// IPv4 in dotted-quad form whose first octet falls in private/loopback/
+// link-local space. The trailing `\.\d` requirement rules out hostnames like
+// `127.example.com` (which the URL parser accepts as a regular DNS name) so
+// only real IPv4 literals are rejected.
+const PRIVATE_IP_RE =
+  /^(0|10|127|192\.168|169\.254|172\.(1[6-9]|2\d|3[01]))\.\d/
+// Anything that parses as a single integer or 0x… hex literal can resolve to
+// an arbitrary IPv4 (e.g. `2130706433` → 127.0.0.1, `0x7f000001` → 127.0.0.1).
+// Hostnames in legitimate image CDNs always contain at least one alphabetic
+// character or are dotted-quads (caught above), so refusing these isn't an
+// over-block.
+const NUMERIC_HOST_RE = /^(0x[0-9a-f]+|[0-9]+)$/i
+const MAX_URL_LEN = 500
+
+export function validateExternalUrl(v: unknown): string | null {
+  if (typeof v !== "string") return null
+  const t = v.trim()
+  if (t.length === 0 || t.length > MAX_URL_LEN) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(t)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== "https:") return null
+  if (!parsed.hostname) return null
+  if (LOCALHOST_RE.test(parsed.hostname)) return null
+  if (PRIVATE_TLD_RE.test(parsed.hostname)) return null
+  if (PRIVATE_IP_RE.test(parsed.hostname)) return null
+  if (NUMERIC_HOST_RE.test(parsed.hostname)) return null
+  // Bare IPv6 literals and userinfo (`user:pw@host`) aren't accepted — too
+  // easy to use as a vector and no legitimate image host uses them.
+  if (parsed.hostname.startsWith("[")) return null
+  if (parsed.username || parsed.password) return null
+
+  return parsed.toString()
+}
+
 export function hasPrismaCode(err: unknown, code: string): boolean {
   return (
     typeof err === "object" &&

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from "hono"
 
+import type { Bindings } from "../bindings"
 import { prisma, registerBackgroundWork } from "../db"
 import { getSession } from "../lib/session"
 
@@ -13,13 +14,23 @@ const PRUNE_MAX_AGE_MS = 10 * 60_000
 // "social" covers cheap toggles (likes, bookmarks, view-count).
 // "mutate" covers the heavier writes (build create/update/delete, org admin).
 // "import" covers external-fetch mutations (Overframe scrape).
+// "search" covers expensive read endpoints (typeahead, full-text scans) and
+//   IS applied to GET requests — anon traffic still slips through (no session
+//   to key on) and is expected to be throttled at the Cloudflare edge.
 export const RATE_LIMITS = {
   social: 60,
   mutate: 20,
   import: 10,
+  search: 60,
 } as const
 
 export type RateLimitBucket = keyof typeof RATE_LIMITS
+
+export type RateLimitOptions = {
+  // Set true for read endpoints whose work is expensive enough to warrant a
+  // per-user cap on GETs as well as writes.
+  includeSafeMethods?: boolean
+}
 
 function currentWindowStart(now = Date.now()): Date {
   return new Date(Math.floor(now / 60_000) * 60_000)
@@ -33,10 +44,14 @@ function secondsUntilNextMinute(now = Date.now()): number {
 // PAT limiter in api-key-auth.ts: the upsert is racy across Workers isolates
 // so short bursts can exceed the cap before any isolate observes it. Fine for
 // abuse throttling.
-export function rateLimitUser(bucket: RateLimitBucket): MiddlewareHandler {
+export function rateLimitUser(
+  bucket: RateLimitBucket,
+  opts: RateLimitOptions = {},
+): MiddlewareHandler {
   const limit = RATE_LIMITS[bucket]
+  const skipSafe = !opts.includeSafeMethods
   return async (c, next) => {
-    if (SAFE_METHODS.has(c.req.method)) return next()
+    if (skipSafe && SAFE_METHODS.has(c.req.method)) return next()
 
     const session = await getSession(c)
     if (!session?.user) return next() // Let downstream handler return 401.
@@ -73,6 +88,50 @@ export function rateLimitUser(bucket: RateLimitBucket): MiddlewareHandler {
         }),
       )
     }
+
+    await next()
+  }
+}
+
+// Edge-side read limiter for public GET endpoints. Throttles unauthenticated
+// browsing/scraping; authenticated traffic is keyed by user.id instead, so
+// shared NAT / household IPs don't collide on the same bucket.
+//
+// `getSession` uses Better Auth's signed cookie cache: a request with a valid
+// session token usually returns from the cache cookie (no DB roundtrip).
+// Crucially, a forged `better-auth.session_token` cookie won't decode, so
+// it falls through to the IP-keyed branch — closing the spoof bypass that an
+// unvalidated cookie-presence check would leave open.
+//
+// Fail-open if the binding is missing outside production (local `wrangler dev`
+// usually has it, but a stripped wrangler.toml shouldn't break dev/tests).
+// Fail-loudly in production via a server log.
+export function rateLimitAnonRead(): MiddlewareHandler {
+  return async (c, next) => {
+    if (!SAFE_METHODS.has(c.req.method)) return next()
+
+    const limiter = (c.env as Bindings | undefined)?.ANON_READ_LIMITER
+    if (!limiter) {
+      if (process.env.NODE_ENV === "production") {
+        console.error(
+          "rate-limit: ANON_READ_LIMITER binding missing in production",
+        )
+      }
+      return next()
+    }
+
+    // Authenticated → key by user id so household/office NATs don't collide.
+    // Anon (including forged cookies, which fail to decode) → key by IP.
+    const session = await getSession(c)
+    const key = session?.user
+      ? `u:${session.user.id}`
+      : `ip:${c.req.header("cf-connecting-ip") ?? "unknown"}`
+    if (!session?.user && !c.req.header("cf-connecting-ip")) {
+      console.warn("rate-limit: missing cf-connecting-ip header")
+    }
+
+    const { success } = await limiter.limit({ key })
+    if (!success) return c.json({ error: "rate_limited" }, 429)
 
     await next()
   }

--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -4,6 +4,7 @@ import { Hono, type Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
 import { customAlphabet, nanoid } from "nanoid"
 
+import type { Bindings } from "../bindings"
 import { prisma, registerBackgroundWork } from "../db"
 import { Prisma } from "../generated/prisma/client"
 import { BuildVisibility } from "../generated/prisma/enums"
@@ -329,46 +330,78 @@ builds.get("/", async (c) => {
 const SEARCH_DEFAULT_LIMIT = 10
 const SEARCH_MAX_LIMIT = 20
 
-builds.get("/search", async (c) => {
-  const session = await getSession(c)
-  const viewerId = session?.user.id
-  const q = (c.req.query("q") ?? "").trim().slice(0, 200)
-  if (q.length < 2) return c.json({ builds: [] })
-  const limitRaw = parseInt(c.req.query("limit") ?? "", 10)
-  const limit =
-    Number.isFinite(limitRaw) && limitRaw > 0
-      ? Math.min(limitRaw, SEARCH_MAX_LIMIT)
-      : SEARCH_DEFAULT_LIMIT
+builds.get(
+  "/search",
+  rateLimitUser("search", { includeSafeMethods: true }),
+  async (c) => {
+    const session = await getSession(c)
+    const viewerId = session?.user.id
+    const q = (c.req.query("q") ?? "").trim().slice(0, 200)
+    if (q.length < 2) return c.json({ builds: [] })
 
-  // PUBLIC only — UNLISTED is "accessible by URL, not enumerable", and a
-  // typeahead is enumeration. Viewers can additionally find their own
-  // builds regardless of visibility so they can link private/unlisted
-  // ones from the editor.
-  const rows = await prisma.build.findMany({
-    where: {
-      AND: [
-        {
-          OR: [
-            { name: { contains: q, mode: "insensitive" } },
-            { itemName: { contains: q, mode: "insensitive" } },
-          ],
-        },
-        viewerId
-          ? {
-              OR: [
-                { visibility: BuildVisibility.PUBLIC },
-                { userId: viewerId },
-              ],
-            }
-          : { visibility: BuildVisibility.PUBLIC },
-      ],
-    },
-    orderBy: [{ likeCount: "desc" }, { createdAt: "desc" }],
-    take: limit,
-    select: LIST_SELECT,
-  })
-  return c.json({ builds: rows.map(serializeListRow) })
-})
+    // Anon traffic isn't keyed by the DB-backed `rateLimitUser` middleware
+    // (it short-circuits with no session). Throttle per-IP via the Workers
+    // Rate Limiting API binding — runs at the edge before we touch the DB.
+    //
+    // In production the binding is the only anon defence, so a missing
+    // binding (typo in wrangler.toml, removed [[unsafe.bindings]] block) is
+    // an operational bug we want to scream about rather than silently
+    // open-fail. Outside production we tolerate absence so dev/test don't
+    // need the binding wired up.
+    if (!viewerId) {
+      const limiter = (c.env as Bindings | undefined)?.ANON_SEARCH_LIMITER
+      if (limiter) {
+        // Without cf-connecting-ip every caller shares the literal key
+        // "unknown", which collapses the global anon population into one
+        // bucket. That's a fail-closed outcome (the bucket trips fast) so
+        // it's preferable to fail-open, but log once so it's diagnosable.
+        const ip = c.req.header("cf-connecting-ip")
+        if (!ip) console.warn("rate-limit: missing cf-connecting-ip header")
+        const { success } = await limiter.limit({ key: ip ?? "unknown" })
+        if (!success) return c.json({ error: "rate_limited" }, 429)
+      } else if (process.env.NODE_ENV === "production") {
+        console.error(
+          "rate-limit: ANON_SEARCH_LIMITER binding missing in production — anon /builds/search is unthrottled",
+        )
+      }
+    }
+
+    const limitRaw = parseInt(c.req.query("limit") ?? "", 10)
+    const limit =
+      Number.isFinite(limitRaw) && limitRaw > 0
+        ? Math.min(limitRaw, SEARCH_MAX_LIMIT)
+        : SEARCH_DEFAULT_LIMIT
+
+    // PUBLIC only — UNLISTED is "accessible by URL, not enumerable", and a
+    // typeahead is enumeration. Viewers can additionally find their own
+    // builds regardless of visibility so they can link private/unlisted
+    // ones from the editor.
+    const rows = await prisma.build.findMany({
+      where: {
+        AND: [
+          {
+            OR: [
+              { name: { contains: q, mode: "insensitive" } },
+              { itemName: { contains: q, mode: "insensitive" } },
+            ],
+          },
+          viewerId
+            ? {
+                OR: [
+                  { visibility: BuildVisibility.PUBLIC },
+                  { userId: viewerId },
+                ],
+              }
+            : { visibility: BuildVisibility.PUBLIC },
+        ],
+      },
+      orderBy: [{ likeCount: "desc" }, { createdAt: "desc" }],
+      take: limit,
+      select: LIST_SELECT,
+    })
+    return c.json({ builds: rows.map(serializeListRow) })
+  },
+)
 
 async function loadPartnerContext(slug: string, partnerSlug: string) {
   const [own, partner] = await Promise.all([

--- a/apps/api/src/routes/imports.ts
+++ b/apps/api/src/routes/imports.ts
@@ -19,13 +19,10 @@ export async function handleOverframeImport(c: Context) {
     const result = await scrapeOverframeBuild(url)
     return c.json(result)
   } catch (err) {
-    return c.json(
-      {
-        error: "scrape_failed",
-        details: err instanceof Error ? err.message : String(err),
-      },
-      500,
-    )
+    // Log full error server-side for debugging; the raw message can leak
+    // internal hostnames, IPs, or stack traces if echoed back to the client.
+    console.error("overframe scrape failed:", err)
+    return c.json({ error: "scrape_failed" }, 500)
   }
 }
 

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -4,7 +4,12 @@ import { prisma } from "../db"
 import { Prisma } from "../generated/prisma/client"
 import { BuildVisibility, OrgRole } from "../generated/prisma/enums"
 import { getSession } from "../lib/session"
-import { hasPrismaCode, parseJsonBody, trimToMax } from "../lib/validate"
+import {
+  hasPrismaCode,
+  parseJsonBody,
+  trimToMax,
+  validateExternalUrl,
+} from "../lib/validate"
 import { rateLimitUser } from "../middleware/rate-limit"
 import { parseListQuery, runList } from "./_build-list"
 import { parsePage, trimQ } from "./_query"
@@ -93,7 +98,18 @@ orgs.post("/", rateLimitUser("mutate"), async (c) => {
   const name = trimToMax(b.name, MAX_NAME)
   const slugRaw = trimToMax(b.slug, MAX_SLUG)?.toLowerCase() ?? null
   const description = trimToMax(b.description, MAX_DESCRIPTION)
-  const image = trimToMax(b.image, 500)
+  // Reject anything that's not a parseable absolute https:// URL with a
+  // public hostname. A null/empty input is fine (no image); anything else
+  // goes through validateExternalUrl, which enforces the 500-char cap —
+  // truncating first would silently chop a long signed query token and
+  // store a still-parseable but broken URL.
+  const image =
+    typeof b.image === "string" && b.image.trim().length > 0
+      ? validateExternalUrl(b.image)
+      : null
+  if (typeof b.image === "string" && b.image.trim().length > 0 && !image) {
+    return c.json({ error: "invalid_image_url" }, 400)
+  }
 
   if (!name) return c.json({ error: "invalid_name" }, 400)
   if (!slugRaw || !SLUG_RE.test(slugRaw)) {
@@ -299,7 +315,17 @@ orgs.patch("/:slug", rateLimitUser("mutate"), async (c) => {
     data.description = trimToMax(b.description, MAX_DESCRIPTION)
   }
   if (typeof b.image === "string" || b.image === null) {
-    data.image = trimToMax(b.image, 500)
+    // Validate before any truncation — see POST handler above for rationale.
+    if (
+      b.image === null ||
+      (typeof b.image === "string" && b.image.trim() === "")
+    ) {
+      data.image = null
+    } else {
+      const validated = validateExternalUrl(b.image)
+      if (!validated) return c.json({ error: "invalid_image_url" }, 400)
+      data.image = validated
+    }
   }
 
   try {

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -28,7 +28,7 @@ NODE_ENV = "production"
 [[unsafe.bindings]]
 name = "ANON_SEARCH_LIMITER"
 type = "ratelimit"
-namespace_id = 1001
+namespace_id = "1001"
 simple = { limit = 30, period = 60 }
 
 # Broader anon-read throttle for public list/detail endpoints — generous cap
@@ -38,7 +38,7 @@ simple = { limit = 30, period = 60 }
 [[unsafe.bindings]]
 name = "ANON_READ_LIMITER"
 type = "ratelimit"
-namespace_id = 1002
+namespace_id = "1002"
 simple = { limit = 120, period = 60 }
 
 [observability]

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -21,5 +21,25 @@ BETTER_AUTH_URL = "https://api.arsenyx.com"
 WEB_ORIGIN = "https://www.arsenyx.com,https://arsenyx.com"
 NODE_ENV = "production"
 
+# Workers Rate Limiting API binding — keyed per IP at the edge, free and
+# cheap because the cap is enforced before our handler runs any DB work.
+# Used for anon `/builds/search` traffic where there's no session to key on.
+# Authenticated users go through the DB-backed UserRateLimitWindow limiter.
+[[unsafe.bindings]]
+name = "ANON_SEARCH_LIMITER"
+type = "ratelimit"
+namespace_id = 1001
+simple = { limit = 30, period = 60 }
+
+# Broader anon-read throttle for public list/detail endpoints — generous cap
+# because a normal page view triggers several requests (list + detail +
+# partners). Sized to comfortably accommodate genuine browsing while still
+# capping scraper-style enumeration.
+[[unsafe.bindings]]
+name = "ANON_READ_LIMITER"
+type = "ratelimit"
+namespace_id = 1002
+simple = { limit = 120, period = 60 }
+
 [observability]
 enabled = true

--- a/apps/web/src/components/build-editor/guide-editor.tsx
+++ b/apps/web/src/components/build-editor/guide-editor.tsx
@@ -156,8 +156,7 @@ export function GuideEditor({
                     key={s.id || i}
                     label={s.label || `Variant ${i + 1}`}
                     active={
-                      activeScope.kind === "variant" &&
-                      activeScope.index === i
+                      activeScope.kind === "variant" && activeScope.index === i
                     }
                     hasContent={s.hasContent}
                     onClick={() => onScopeChange({ kind: "variant", index: i })}

--- a/apps/web/src/components/markdown-body.tsx
+++ b/apps/web/src/components/markdown-body.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 
+import { proxyImage } from "@/lib/image-proxy"
 import { getVideoEmbed } from "@/lib/video-embed"
 
 /**
@@ -68,11 +69,17 @@ const components: Components = {
   },
   img({ node: _node, src, ...rest }) {
     const { src: cleanSrc, width } = parseSizedSrc(src)
+    // Route every markdown image through CF Image Resizing so the visitor's
+    // browser never fetches a third-party URL directly. Without this, a
+    // malicious guide author can dox every visitor (IP + Referer = build
+    // slug) by embedding `![x](https://attacker.com/p.png)`.
+    const proxied = proxyImage(cleanSrc, { width: 1200, fit: "scale-down" })
     return (
       <img
         {...rest}
-        src={cleanSrc}
+        src={proxied ?? undefined}
         loading="lazy"
+        referrerPolicy="no-referrer"
         style={width ? { width, maxWidth: "100%" } : undefined}
         className="my-2 h-auto max-w-full rounded-md border object-contain"
       />

--- a/apps/web/src/components/user-avatar.tsx
+++ b/apps/web/src/components/user-avatar.tsx
@@ -1,6 +1,17 @@
+import { proxyImage } from "@/lib/image-proxy"
 import { cn } from "@/lib/utils"
 
 type AvatarShape = "circle" | "square" | "rounded"
+
+// Tailwind size-N is N * 0.25rem (4px). CSS pixel size feeds CF resize.
+const SIZE_TO_PX: Record<number, number> = {
+  6: 24,
+  7: 28,
+  8: 32,
+  9: 36,
+  10: 40,
+  20: 80,
+}
 
 const SIZE_CLASSES: Record<number, string> = {
   6: "size-6 text-xs",
@@ -31,6 +42,8 @@ export function UserAvatar({
   className?: string
 }) {
   const initial = fallback.charAt(0).toUpperCase()
+  const px = SIZE_TO_PX[size]
+  const proxied = proxyImage(src, { width: px, height: px, fit: "cover" })
   return (
     <div
       className={cn(
@@ -40,8 +53,8 @@ export function UserAvatar({
         className,
       )}
     >
-      {src ? (
-        <img src={src} alt="" className="h-full w-full object-cover" />
+      {proxied ? (
+        <img src={proxied} alt="" className="h-full w-full object-cover" />
       ) : (
         <span>{initial}</span>
       )}

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { authClient } from "@/lib/auth-client"
 import { ROUTES } from "@/lib/constants"
+import { proxyImage } from "@/lib/image-proxy"
 
 export function UserMenu() {
   const { data: session, isPending } = authClient.useSession()
@@ -63,7 +64,7 @@ export function UserMenu() {
         >
           {user.image ? (
             <img
-              src={user.image}
+              src={proxyImage(user.image, { width: 28, height: 28 }) ?? ""}
               alt=""
               className="size-7 rounded-full object-cover"
             />

--- a/apps/web/src/lib/image-proxy.ts
+++ b/apps/web/src/lib/image-proxy.ts
@@ -1,0 +1,54 @@
+// Wraps a user-supplied image URL with Cloudflare Image Resizing so the
+// browser fetches the asset from our own origin rather than the third-party
+// host. Without the proxy, an org/profile admin could point `image` at a
+// server they control and silently log every visitor's IP and Referer when
+// the avatar loads. The proxy also gives us free format negotiation (avif/
+// webp) and on-the-fly resizing.
+//
+// URL shape (CF docs):
+//   /cdn-cgi/image/<comma-separated-options>/<source-url>
+//
+// Image Resizing must be enabled on the zone (Cloudflare dashboard →
+// Speed → Optimization). In local dev or when the feature is disabled,
+// Cloudflare returns the source URL unchanged, so this stays safe-by-default
+// behaviour-wise but DOES leak the visitor IP in those environments.
+
+type ProxyOptions = {
+  /** Target render size in CSS pixels (CF will pick 1x/2x via dpr). */
+  width?: number
+  height?: number
+  /** "cover" matches our existing object-cover usage. */
+  fit?: "cover" | "contain" | "scale-down" | "crop"
+}
+
+const DEFAULT_OPTIONS: Required<Pick<ProxyOptions, "fit">> = { fit: "cover" }
+
+function isProxyable(src: string): boolean {
+  // Only proxy absolute http(s) URLs. data:, blob:, and relative paths
+  // (e.g. local placeholders) pass through unchanged.
+  return /^https?:\/\//i.test(src)
+}
+
+export function proxyImage(
+  src: string | null | undefined,
+  opts: ProxyOptions = {},
+): string | null {
+  if (!src) return null
+  if (!isProxyable(src)) return src
+
+  const parts: string[] = [
+    `fit=${opts.fit ?? DEFAULT_OPTIONS.fit}`,
+    "format=auto",
+  ]
+  if (opts.width) parts.push(`width=${opts.width}`)
+  if (opts.height) parts.push(`height=${opts.height}`)
+  // dpr=2 lets the browser pick a sharper variant on high-density screens
+  // without us having to wire up srcset for every avatar callsite.
+  parts.push("dpr=2")
+
+  // Source URLs are encoded so that `?`, `#`, and `..` inside them survive
+  // browser URL parsing. Without this, Discord (`?ex=…&hm=…&is=…`) and
+  // GitHub avatar (`?v=4`) URLs lose their query string before reaching
+  // Cloudflare, and `..` segments get path-normalised into garbage.
+  return `/cdn-cgi/image/${parts.join(",")}/${encodeURIComponent(src)}`
+}

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -168,15 +168,31 @@ DATABASE_URL
   await run(["bun", "run", "db:push"], API_DIR, { DATABASE_URL: dbUrl! })
 
   console.log("\n› seeding admin user\n")
+  // Generate fresh credentials per setup so the seeded admin never has the
+  // historical hardcoded "admin/admin" defaults. Printed once; not persisted.
+  const adminEmail = "admin@local.dev"
+  const adminUsername = "admin"
+  const { customAlphabet } = await import("nanoid")
+  const genPw = customAlphabet(
+    "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789",
+    20,
+  )
+  const adminPassword = genPw()
   await run(["bun", "run", "scripts/seed-admin.ts"], API_DIR, {
     DATABASE_URL: dbUrl!,
     BETTER_AUTH_SECRET: secret,
     NODE_ENV: "development",
+    SEED_ADMIN_EMAIL: adminEmail,
+    SEED_ADMIN_USERNAME: adminUsername,
+    SEED_ADMIN_PASSWORD: adminPassword,
   })
 
   console.log(`
 All set — run \`just dev\`.
-Sign in at http://localhost:5173 with admin@admin.com / admin.
+Sign in at http://localhost:5173 with:
+  email:    ${adminEmail}
+  password: ${adminPassword}
+(Re-run \`just setup\` to rotate; not stored anywhere.)
 `)
 }
 


### PR DESCRIPTION
## Summary
- **Image SSRF/IP-leak guard**: new `validateExternalUrl` rejects non-https, private/loopback/numeric/IPv6 hosts, `.local`/`.internal`, userinfo, and >500-char URLs. Org/user `image` writes validate on the route; Better Auth `databaseHooks.user.create/update.before` sanitize OAuth-supplied avatars.
- **Cloudflare Image Resizing proxy** (`apps/web/src/lib/image-proxy.ts`) — all rendered avatars/markdown images go through `/cdn-cgi/image/...` so the browser never connects to the third-party host directly. `referrerPolicy="no-referrer"` on `<img>` callsites.
- **GitHub OAuth `overrideUserInfoOnSignIn: true`** so users whose stored avatar was nulled by the backfill auto-restore on next sign-in.
- **Workers Rate Limiting** (free tier) via `[[unsafe.bindings]]`: `ANON_SEARCH_LIMITER` (30/min) on `/builds/search`, `ANON_READ_LIMITER` (120/min) on anon GETs to `/builds/*`, `/orgs/*`, `/users/*`. Keyed by session user when authenticated, `cf-connecting-ip` otherwise.
- **seed-admin** refuses to run outside `NODE_ENV=development`; reads creds from env vars and generates a random password if none provided. `scripts/setup.ts` generates a fresh password per run and prints it once.
- **`imports.ts`** no longer leaks raw `error.message` in 500 responses.
- **Backfill SQL** to null any existing `users.image` / `organizations.image` rows that wouldn't pass the new validator. Org migration already applied (returned 0).

## Test plan
- [x] `bun run build` (web) + `bunx tsc --noEmit` (api) — clean
- [x] `just check` — clean
- [x] Live smoke test of `/builds?limit=1` confirmed anon rate-limit triggers (first 429 at request 112/140 with spoofed cookies)
- [x] Run `apps/api/scripts/migrations/2026-05-23_null_invalid_user_images.sql` in Neon after merge
- [x] Verify GitHub sign-in still works post-deploy; confirm avatar restore on a previously-nulled user