### PR TITLE
Lock down privileged user fields and partner-link consent

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -81,11 +81,19 @@ export const auth = betterAuth({
   user: {
     deleteUser: { enabled: true },
     additionalFields: {
-      isVerified: { type: "boolean", defaultValue: false },
-      isCommunityLeader: { type: "boolean", defaultValue: false },
-      isModerator: { type: "boolean", defaultValue: false },
-      isAdmin: { type: "boolean", defaultValue: false },
-      isBanned: { type: "boolean", defaultValue: false },
+      // `input: false` is load-bearing — without it, /auth/update-user
+      // accepts these fields from the request body and a logged-in user
+      // can self-promote to admin / clear their own ban. Privileged flags
+      // are mutated only through the admin routes.
+      isVerified: { type: "boolean", defaultValue: false, input: false },
+      isCommunityLeader: {
+        type: "boolean",
+        defaultValue: false,
+        input: false,
+      },
+      isModerator: { type: "boolean", defaultValue: false, input: false },
+      isAdmin: { type: "boolean", defaultValue: false, input: false },
+      isBanned: { type: "boolean", defaultValue: false, input: false },
       defaultBuildVisibility: { type: "string", defaultValue: "PUBLIC" },
     },
   },

--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -481,11 +481,16 @@ builds.put(
 
     const { own, partner } = await loadPartnerContext(slug, partnerSlug)
     if (!own || !partner) return c.json({ error: "not_found" }, 404)
-    if (!(await canMutateBuild(own, viewerId))) {
+    // Both sides require mutate rights: the write is symmetric (mirrored
+    // below), so a viewer-only check on `partner` would let any user attach
+    // their own build to a third party's PUBLIC build and ride its
+    // reputation. Mutual ownership is the consent gate.
+    const [canMutateOwn, canMutatePartner] = await Promise.all([
+      canMutateBuild(own, viewerId),
+      canMutateBuild(partner, viewerId),
+    ])
+    if (!canMutateOwn || !canMutatePartner) {
       return c.json({ error: "forbidden" }, 403)
-    }
-    if (!(await canViewerSeeBuild(partner, viewerId))) {
-      return c.json({ error: "not_found" }, 404)
     }
 
     // Prisma's implicit self-many-to-many writes only one side of the join


### PR DESCRIPTION
## Summary

Two access-control fixes from a focused security review.

### 1. Privileged user flags writable via self-service profile update ([apps/api/src/auth.ts](apps/api/src/auth.ts))

`additionalFields` for `isAdmin`, `isModerator`, `isCommunityLeader`, `isVerified`, and `isBanned` were missing the Better Auth marker that excludes them from user-supplied input, so the self-service profile-update endpoint accepted writes to these fields. They're now marked non-writable; mutations go through the admin routes only. `defaultBuildVisibility` stays user-settable (downstream re-validates with `isVisibility()`).

### 2. One-sided partner-link write ([apps/api/src/routes/builds.ts](apps/api/src/routes/builds.ts))

`PUT /builds/:slug/partners/:partnerSlug` required mutate rights on one side and only view rights on the other, but the transaction mirrors the connect on both sides of the implicit self-M:N. Now requires mutate rights on both sides — partner links need consent from both build owners. DELETE remains either-owner so cleanup stays frictionless.

## Operational follow-up

- Audit the `User` table for unexpected privileged-flag values that weren't set via the admin tools.
- Audit existing partner links for pairs whose builds have no overlapping owner/org and surface for review.

(Details and exploit specifics are in the security-review notes off-PR.)

## Test plan

- [x] `bunx tsc --noEmit` in `apps/api/` passes (verified locally)
- [x] Self-service profile update no longer mutates the privileged flags on the DB row
- [x] Cross-owner partner attach via `PUT /builds/:slug/partners/:partnerSlug` returns 403
- [x] Mutual-ownership partner attach (same user or shared org) still succeeds
- [x] Existing partner links continue to resolve on `GET /builds/:slug/partners`
- [x] Either owner can still `DELETE` a partner link