### PR TITLE
Show build author alongside org + publish-time opt-out

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -155,6 +155,11 @@ model Build {
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
 
+  // When true and the build is published under an organization, the
+  // author's handle is suppressed in card / detail UI. No effect on
+  // solo (no-org) builds — the author is the only attribution there.
+  hideAuthor Boolean @default(false)
+
   // Denormalized WFCD item reference
   itemUniqueName String
   itemCategory   String

--- a/apps/api/scripts/migrations/2026-05-24_build_hide_author.sql
+++ b/apps/api/scripts/migrations/2026-05-24_build_hide_author.sql
@@ -1,0 +1,8 @@
+-- Adds an opt-in flag for org builds: when true, the author's handle is
+-- hidden from card / detail UI. No effect on solo builds.
+--
+-- Run against Neon (from apps/api/):
+--   bunx prisma db execute --file scripts/migrations/2026-05-24_build_hide_author.sql
+
+ALTER TABLE builds
+  ADD COLUMN IF NOT EXISTS "hideAuthor" boolean NOT NULL DEFAULT false;

--- a/apps/api/src/routes/_build-list.ts
+++ b/apps/api/src/routes/_build-list.ts
@@ -23,6 +23,7 @@ export const LIST_SELECT = {
   viewCount: true,
   hasGuide: true,
   hasShards: true,
+  hideAuthor: true,
   createdAt: true,
   updatedAt: true,
   itemName: true,
@@ -92,6 +93,7 @@ export function serializeBuildDetail(b: DetailRow, viewer: ViewerState | null) {
     buildData: b.buildData,
     hasShards: b.hasShards,
     hasGuide: b.hasGuide,
+    hideAuthor: b.hideAuthor,
     likeCount: b.likeCount,
     bookmarkCount: b.bookmarkCount,
     viewCount: b.viewCount,
@@ -121,6 +123,7 @@ export function serializeListRow(b: ListRow) {
     viewCount: b.viewCount,
     hasGuide: b.hasGuide,
     hasShards: b.hasShards,
+    hideAuthor: b.hideAuthor,
     createdAt: b.createdAt.toISOString(),
     updatedAt: b.updatedAt.toISOString(),
     item: {

--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -119,6 +119,9 @@ builds.post("/", rateLimitUser("mutate"), async (c) => {
   )
   if (!orgResult.ok) return c.json({ error: orgResult.error }, orgResult.status)
   const organizationId = orgResult.value
+  // Author can opt to suppress their handle on org-published builds.
+  // Always false when there's no org (no-op).
+  const hideAuthor = organizationId !== null && b.hideAuthor === true
 
   // Retry on the astronomically-unlikely slug collision.
   for (let attempt = 0; attempt < SLUG_COLLISION_RETRIES; attempt++) {
@@ -136,6 +139,7 @@ builds.post("/", rateLimitUser("mutate"), async (c) => {
           description,
           visibility,
           organizationId,
+          hideAuthor,
           buildData,
           hasShards: hasShardsInBuildData(buildData),
           hasGuide: guide?.hasGuide ?? false,
@@ -201,6 +205,19 @@ builds.patch("/:slug", rateLimitUser("mutate"), async (c) => {
     if (!orgResult.ok)
       return c.json({ error: orgResult.error }, orgResult.status)
     data.organizationId = orgResult.value
+  }
+  // hideAuthor only makes sense when the build is org-published. We use the
+  // effective org after this PATCH (incoming value if provided, else the
+  // existing one) so toggling org off forces hideAuthor back to false in the
+  // same write — no stale flag pointing at a now-null org.
+  if (typeof b.hideAuthor === "boolean") {
+    const effectiveOrgId =
+      data.organizationId !== undefined
+        ? data.organizationId
+        : existing.organizationId
+    data.hideAuthor = effectiveOrgId !== null && b.hideAuthor === true
+  } else if (data.organizationId === null) {
+    data.hideAuthor = false
   }
   if (b.buildData && typeof b.buildData === "object") {
     if (variantsOverCap(b.buildData)) {

--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -216,7 +216,14 @@ builds.patch("/:slug", rateLimitUser("mutate"), async (c) => {
         ? data.organizationId
         : existing.organizationId
     data.hideAuthor = effectiveOrgId !== null && b.hideAuthor === true
-  } else if (data.organizationId === null) {
+  } else if (
+    data.organizationId !== undefined &&
+    data.organizationId !== existing.organizationId
+  ) {
+    // The org is being changed in this PATCH and the client didn't supply
+    // a fresh hideAuthor. Reset to false so a flag chosen for the previous
+    // org (or no org) can't silently bleed into the new attribution — the
+    // publisher must re-opt in for each org.
     data.hideAuthor = false
   }
   if (b.buildData && typeof b.buildData === "object") {

--- a/apps/web/src/components/build-editor/publish-dialog.tsx
+++ b/apps/web/src/components/build-editor/publish-dialog.tsx
@@ -2,6 +2,7 @@ import { Check, Globe, Link2, Lock, Users, type LucideIcon } from "lucide-react"
 import { useState, type ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -20,6 +21,7 @@ export type PublishVisibility = BuildDetail["visibility"]
 export type PublishDialogValues = {
   visibility: PublishVisibility
   organizationId: string | null
+  hideAuthor: boolean
 }
 
 type PublishDialogProps = {
@@ -27,6 +29,7 @@ type PublishDialogProps = {
   onOpenChange: (open: boolean) => void
   initialVisibility: PublishVisibility
   initialOrganizationId: string | null
+  initialHideAuthor: boolean
   owner: {
     name: string
     username: string | null
@@ -68,6 +71,7 @@ export function PublishDialog({
   onOpenChange,
   initialVisibility,
   initialOrganizationId,
+  initialHideAuthor,
   owner,
   organizations,
   confirmLabel = "Save build",
@@ -78,11 +82,15 @@ export function PublishDialog({
   const [organizationId, setOrganizationId] = useState<string | null>(
     initialOrganizationId,
   )
+  // UI state is the inverse of the persisted `hideAuthor` flag: the checkbox
+  // reads "Show me as the author" so it stays an opt-in affirmation.
+  const [showAuthor, setShowAuthor] = useState(!initialHideAuthor)
 
   const handleOpenChange = (o: boolean) => {
     if (o) {
       setVisibility(initialVisibility)
       setOrganizationId(initialOrganizationId)
+      setShowAuthor(!initialHideAuthor)
     }
     onOpenChange(o)
   }
@@ -106,7 +114,7 @@ export function PublishDialog({
                 key={value}
                 selected={visibility === value}
                 onSelect={() => setVisibility(value)}
-                leading={<Icon className="mt-0.5 size-4 shrink-0" />}
+                leading={<Icon className="size-4 shrink-0" />}
                 title={label}
                 subtitle={description}
               />
@@ -148,6 +156,34 @@ export function PublishDialog({
                 />
               ))
             )}
+            {organizationId !== null ? (
+              <label className="hover:bg-muted/40 mt-1 flex cursor-pointer items-center gap-3 rounded-md border border-dashed p-3 text-left">
+                <Checkbox
+                  checked={showAuthor}
+                  onCheckedChange={(v) => setShowAuthor(v === true)}
+                  aria-label="Show me as the author alongside the org"
+                />
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="text-sm leading-none font-medium">
+                    Show me as the author
+                  </span>
+                  <span className="text-muted-foreground text-xs leading-snug">
+                    {showAuthor ? (
+                      <>
+                        Build will be credited to{" "}
+                        <span className="text-foreground">{ownerHandle}</span>{" "}
+                        alongside the org.
+                      </>
+                    ) : (
+                      <>
+                        Only the org will be shown. Your handle won't appear on
+                        this build.
+                      </>
+                    )}
+                  </span>
+                </div>
+              </label>
+            ) : null}
           </Section>
         </div>
 
@@ -155,7 +191,18 @@ export function PublishDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={() => onConfirm({ visibility, organizationId })}>
+          <Button
+            onClick={() =>
+              onConfirm({
+                visibility,
+                organizationId,
+                // hideAuthor only persists meaningfully on org builds; flatten
+                // to false when no org is selected so we don't carry stale
+                // state through the save.
+                hideAuthor: organizationId !== null && !showAuthor,
+              })
+            }
+          >
             {confirmLabel}
           </Button>
         </DialogFooter>
@@ -191,7 +238,7 @@ function OptionCard({
   subtitle: string
 }) {
   const className = cn(
-    "flex items-start gap-3 rounded-md border p-3 text-left transition-colors",
+    "flex items-center gap-3 rounded-md border p-3 text-left transition-colors",
     disabled
       ? "border-dashed opacity-60"
       : "hover:bg-muted/40 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",

--- a/apps/web/src/components/build-editor/publish-dialog.tsx
+++ b/apps/web/src/components/build-editor/publish-dialog.tsx
@@ -1,5 +1,5 @@
 import { Check, Globe, Link2, Lock, Users, type LucideIcon } from "lucide-react"
-import { useState, type ReactNode } from "react"
+import { useEffect, useState, type ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -86,6 +86,17 @@ export function PublishDialog({
   // reads "Show me as the author" so it stays an opt-in affirmation.
   const [showAuthor, setShowAuthor] = useState(!initialHideAuthor)
 
+  // When the user picks a different org than the build's current one inside
+  // an open dialog, treat it as a fresh attribution: default to showing the
+  // author. Without this, an opt-out chosen for the previous org would bleed
+  // into the new org silently. Restoring the initial org restores the
+  // initial preference.
+  useEffect(() => {
+    setShowAuthor(
+      organizationId === initialOrganizationId ? !initialHideAuthor : true,
+    )
+  }, [organizationId, initialOrganizationId, initialHideAuthor])
+
   const handleOpenChange = (o: boolean) => {
     if (o) {
       setVisibility(initialVisibility)
@@ -114,7 +125,13 @@ export function PublishDialog({
                 key={value}
                 selected={visibility === value}
                 onSelect={() => setVisibility(value)}
-                leading={<Icon className="size-4 shrink-0" />}
+                leading={
+                  // Anchor the icon to the title's baseline so it stays
+                  // aligned when the subtitle wraps to two lines on narrow
+                  // viewports. The OptionCard wrapper centers single-line
+                  // entries (avatars in "Publish as") via items-center.
+                  <Icon className="mt-0.5 size-4 shrink-0 self-start" />
+                }
                 title={label}
                 subtitle={description}
               />
@@ -161,6 +178,7 @@ export function PublishDialog({
                 <Checkbox
                   checked={showAuthor}
                   onCheckedChange={(v) => setShowAuthor(v === true)}
+                  className="mt-0.5 self-start"
                   aria-label="Show me as the author alongside the org"
                 />
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/apps/web/src/components/builds/build-card.tsx
+++ b/apps/web/src/components/builds/build-card.tsx
@@ -43,6 +43,16 @@ export function BuildCard({ build }: { build: BuildListItem }) {
             <>by {author}</>
           )}
         </p>
+        <p
+          className="text-muted-foreground line-clamp-1 text-xs"
+          aria-hidden={!build.organization || build.hideAuthor}
+        >
+          {build.organization && !build.hideAuthor ? (
+            <>by {author}</>
+          ) : (
+            <>&nbsp;</>
+          )}
+        </p>
         <div className="text-muted-foreground flex items-center justify-between text-xs">
           <span className="flex items-center gap-2">
             <span className="flex items-center gap-1">
@@ -91,9 +101,17 @@ export function BuildRow({ build }: { build: BuildListItem }) {
           <span className="line-clamp-1">{build.item.name}</span>
           <span aria-hidden>·</span>
           {build.organization ? (
-            <span className="line-clamp-1 text-[#a78bfa]">
-              {build.organization.name}
-            </span>
+            <>
+              <span className="line-clamp-1 text-[#a78bfa]">
+                {build.organization.name}
+              </span>
+              {!build.hideAuthor && (
+                <>
+                  <span aria-hidden>·</span>
+                  <span className="line-clamp-1">by {author}</span>
+                </>
+              )}
+            </>
           ) : (
             <span className="line-clamp-1">by {author}</span>
           )}
@@ -150,6 +168,7 @@ export function BuildCardSkeleton() {
         <Skeleton className="h-[1.125rem] w-3/4" />
         <Skeleton className="h-[0.875rem] w-1/2" />
         <Skeleton className="h-[0.875rem] w-2/5" />
+        <Skeleton className="h-[0.875rem] w-1/3" />
         <div className="flex items-center justify-between pt-0.5">
           <Skeleton className="h-3 w-16" />
           <Skeleton className="h-3 w-10" />

--- a/apps/web/src/lib/build-query.ts
+++ b/apps/web/src/lib/build-query.ts
@@ -71,6 +71,7 @@ export type BuildDetail = {
   buildData: unknown
   hasShards: boolean
   hasGuide: boolean
+  hideAuthor: boolean
   likeCount: number
   bookmarkCount: number
   viewCount: number

--- a/apps/web/src/lib/builds-list-query.ts
+++ b/apps/web/src/lib/builds-list-query.ts
@@ -34,6 +34,7 @@ export type BuildListItem = {
   viewCount: number
   hasGuide: boolean
   hasShards: boolean
+  hideAuthor: boolean
   createdAt: string
   updatedAt: string
   item: {

--- a/apps/web/src/routes/builds.$slug.tsx
+++ b/apps/web/src/routes/builds.$slug.tsx
@@ -817,27 +817,32 @@ function ViewerHeader({
               </RouterLink>
               {" · "}
               {build.organization ? (
-                <RouterLink
-                  to="/org/$slug"
-                  params={{ slug: build.organization.slug }}
-                  className="text-[#a78bfa] hover:underline"
-                >
-                  {build.organization.name}
-                </RouterLink>
-              ) : build.user.username ? (
                 <>
-                  by{" "}
                   <RouterLink
-                    to="/profile/$username"
-                    params={{ username: build.user.username }}
-                    className="hover:text-foreground hover:underline"
+                    to="/org/$slug"
+                    params={{ slug: build.organization.slug }}
+                    className="text-[#a78bfa] hover:underline"
                   >
-                    {author}
+                    {build.organization.name}
                   </RouterLink>
+                  {!build.hideAuthor && " · "}
                 </>
-              ) : (
-                <>by {author}</>
-              )}
+              ) : null}
+              {(!build.organization || !build.hideAuthor) &&
+                (build.user.username ? (
+                  <>
+                    by{" "}
+                    <RouterLink
+                      to="/profile/$username"
+                      params={{ username: build.user.username }}
+                      className="hover:text-foreground hover:underline"
+                    >
+                      {author}
+                    </RouterLink>
+                  </>
+                ) : (
+                  <>by {author}</>
+                ))}
             </span>
             <div className="flex flex-wrap items-center gap-2">
               <Badge

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -458,6 +458,9 @@ function EditorShell() {
   const [organizationId, setOrganizationId] = useState<string | null>(
     () => existingBuild?.organization?.id ?? null,
   )
+  const [hideAuthor, setHideAuthor] = useState<boolean>(
+    () => existingBuild?.hideAuthor ?? false,
+  )
   const [publishDialogOpen, setPublishDialogOpen] = useState(false)
 
   const { data: myOrgs } = useQuery({
@@ -743,12 +746,13 @@ function EditorShell() {
       setPublishDialogOpen(true)
       return
     }
-    void performSave(visibility, organizationId)
+    void performSave(visibility, organizationId, hideAuthor)
   }
 
   const performSave = async (
     nextVisibility: PublishVisibility,
     nextOrganizationId: string | null,
+    nextHideAuthor: boolean,
   ) => {
     if (!session?.user) {
       navigate({ to: "/auth/signin" })
@@ -771,6 +775,7 @@ function EditorShell() {
         name: buildName.trim() || item.name,
         visibility: nextVisibility,
         organizationId: nextOrganizationId,
+        hideAuthor: nextHideAuthor,
         buildData: {
           version: 1,
           slots: slots.placed,
@@ -1216,6 +1221,7 @@ function EditorShell() {
         onOpenChange={setPublishDialogOpen}
         initialVisibility={visibility}
         initialOrganizationId={organizationId}
+        initialHideAuthor={hideAuthor}
         owner={{
           name: session?.user?.name ?? "You",
           username:
@@ -1225,11 +1231,16 @@ function EditorShell() {
         }}
         organizations={organizations}
         confirmLabel={isUpdate ? "Update settings" : "Save build"}
-        onConfirm={({ visibility: next, organizationId: nextOrgId }) => {
+        onConfirm={({
+          visibility: next,
+          organizationId: nextOrgId,
+          hideAuthor: nextHideAuthor,
+        }) => {
           setVisibility(next)
           setOrganizationId(nextOrgId)
+          setHideAuthor(nextHideAuthor)
           setPublishDialogOpen(false)
-          if (!isUpdate) void performSave(next, nextOrgId)
+          if (!isUpdate) void performSave(next, nextOrgId, nextHideAuthor)
         }}
       />
 


### PR DESCRIPTION
## Summary

- Org-owned builds now display the author alongside the org instead of replacing them. Cards use a stacked two-line meta block (`org` / `by @author`); the build-page header is inline (`Item · Category · Org · by @author`). Solo cards add a reserved blank line so grid heights match across org and solo entries.
- New `Build.hideAuthor` boolean lets a publisher opt out of being credited on org builds. A "Show me as the author" checkbox appears in the publish dialog only when an org is selected, and the card / detail UI suppress the author segment when the flag is set.
- Toggling a build's organization back to `null` auto-resets `hideAuthor` server-side so the flag can't point at a now-null org.

## Migration

Schema column added on prod via Neon SQL editor:

```sql
ALTER TABLE builds
  ADD COLUMN IF NOT EXISTS "hideAuthor" boolean NOT NULL DEFAULT false;
```

SQL also checked in at `apps/api/scripts/migrations/2026-05-24_build_hide_author.sql` for reference. Local picks up the column via `bun run db:push`.

## Test plan

- [x] Local: create an org-owned build → card shows two-line org + author; detail header shows inline org + author
- [x] Local: create a solo build → card shows author + reserved blank line; grid heights line up with org cards
- [x] Publish dialog: select org → "Show me as the author" checkbox appears; default is checked
- [x] Uncheck → save → card + detail page render org only (no `by @author`)
- [x] Switch org → "Yourself" → checkbox hides; save → `hideAuthor` resets to false (verify with re-publish)
- [x] PATCH path: existing build with org → toggle off → `hideAuthor` is reset to false in DB