### PR TITLE
Forma-count pool + API security hardening pass

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -6,25 +6,98 @@ import { prisma } from "./db"
 import { webOrigins } from "./env"
 import { validateExternalUrl } from "./lib/validate"
 
-// Normalise user.image to a value validateExternalUrl accepts, or null. The
-// hook fires for OAuth sign-in (`create`), provider-driven refreshes and
-// admin-tool round-trips (`update`), AND the user-facing /update-user
-// endpoint — we can't tell them apart inside Better Auth's hook contract.
-// Throwing on rejection would lock users out of sign-in if a provider ever
-// returns an avatar URL the validator dislikes, so we always silently null
-// instead. Hard validation for human input lives in the route handlers
-// where we control the response shape (see orgs.ts `invalid_image_url`).
-function sanitizeUserImage(
+// Mirror of the BuildVisibility enum in prisma/schema.prisma. Inlined to
+// avoid pulling generated Prisma types into the auth bootstrap path.
+const VALID_BUILD_VISIBILITIES = new Set(["PUBLIC", "PRIVATE", "UNLISTED"])
+
+// Usernames we won't let a regular user claim — `admin/support/security/...`
+// in `/profile/<name>` reads as official Arsenyx staff, which is a phishing
+// surface even though none of these flags actually grant privileges
+// (isAdmin is a separate column gated on the server side). Same list feeds
+// the `usernameValidator` below; the hook also catches the OAuth path.
+const RESERVED_USERNAMES = new Set([
+  "admin",
+  "administrator",
+  "api",
+  "arsenyx",
+  "auth",
+  "billing",
+  "help",
+  "info",
+  "mod",
+  "moderator",
+  "noreply",
+  "no-reply",
+  "official",
+  "owner",
+  "root",
+  "security",
+  "staff",
+  "support",
+  "system",
+  "team",
+])
+
+function isReservedUsername(value: string): boolean {
+  return RESERVED_USERNAMES.has(value.toLowerCase())
+}
+
+// Sanitiser for user create/update payloads. Fires for OAuth sign-in
+// (`create`), provider-driven refreshes and admin-tool round-trips
+// (`update`), AND the user-facing /update-user endpoint — Better Auth's
+// hook contract doesn't tell them apart, so we rewrite invalid values to
+// safe defaults rather than throw (a throw would lock users out of sign-in
+// if a provider ever returns something we don't like).
+//
+// Hard validation for human input lives in the route handlers where we
+// control the response shape (see orgs.ts `invalid_image_url`, and the
+// `usernameValidator` on the plugin below which throws on /update-user).
+function sanitizeUserData(
   data: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (!("image" in data)) return data
-  const v = data.image
-  if (v == null || v === "") return { ...data, image: null }
-  if (typeof v === "string") {
-    const validated = validateExternalUrl(v)
-    if (validated) return { ...data, image: validated }
+  let out = data
+
+  if ("image" in out) {
+    const v = out.image
+    if (v == null || v === "") {
+      out = { ...out, image: null }
+    } else if (typeof v === "string") {
+      const validated = validateExternalUrl(v)
+      out = { ...out, image: validated ?? null }
+    } else {
+      out = { ...out, image: null }
+    }
   }
-  return { ...data, image: null }
+
+  // The field is exposed via additionalFields (so it surfaces on
+  // session.user) but Better Auth has no per-field validator there. Without
+  // this, /auth/update-user accepts any string and the write fails at the
+  // Postgres enum cast — a 500 with no useful client signal, plus the
+  // cookie-cached session can briefly hold the bogus value.
+  if ("defaultBuildVisibility" in out) {
+    const v = out.defaultBuildVisibility
+    if (typeof v !== "string" || !VALID_BUILD_VISIBILITIES.has(v)) {
+      // Strip rather than overwrite — leaves any existing DB value intact
+      // on update, defaults to "PUBLIC" on create (Prisma default).
+      const { defaultBuildVisibility: _drop, ...rest } = out
+      out = rest
+    }
+  }
+
+  // Strip reserved usernames from non-OAuth update paths. OAuth sign-in is
+  // handled in `mapProfileToUser` (suffix), and `/update-user` is bounced
+  // by `usernameValidator` (throws before we get here). This is the
+  // belt-and-braces case where neither path applies — e.g. a future
+  // provider's profile mapper that forgets to filter.
+  if ("username" in out) {
+    const v = out.username
+    if (typeof v === "string" && isReservedUsername(v)) {
+      const { username: _u, displayUsername: _du, ...rest } = out
+      out = rest
+    }
+  }
+
+  return out
 }
 
 const githubId = process.env.GITHUB_CLIENT_ID?.trim()
@@ -64,18 +137,38 @@ export const auth = betterAuth({
             // — keeps the stale stored value forever, since Better Auth
             // otherwise only writes profile fields on first sign-in.
             overrideUserInfoOnSignIn: true,
-            mapProfileToUser: (profile) => ({
-              username: profile.login.toLowerCase(),
-              displayUsername: profile.login,
-            }),
+            mapProfileToUser: (profile) => {
+              const login = profile.login
+              // GitHub usernames are unique globally, so the only way a
+              // reserved Arsenyx handle lands here is genuine coincidence.
+              // Suffix with the (stable) GitHub numeric id so re-sync on
+              // every sign-in produces the same value — overrideUserInfo
+              // would otherwise churn the username if we generated a
+              // fresh suffix each time.
+              const reserved = isReservedUsername(login)
+              const username = reserved
+                ? `${login}-gh${profile.id}`.toLowerCase().slice(0, 30)
+                : login.toLowerCase()
+              const displayUsername = reserved ? username : login
+              return { username, displayUsername }
+            },
           },
         }
       : {},
-  plugins: [username()],
+  plugins: [
+    username({
+      // Default validator is /^[a-zA-Z0-9_.]+$/ (see better-auth source).
+      // Layer our reserved-name denylist on top — fires for /sign-up/email,
+      // /update-user, /is-username-available, /sign-in/username. OAuth
+      // path is covered by mapProfileToUser + sanitizeUserData.
+      usernameValidator: (candidate) =>
+        /^[a-zA-Z0-9_.]+$/.test(candidate) && !isReservedUsername(candidate),
+    }),
+  ],
   databaseHooks: {
     user: {
-      create: { before: async (data) => ({ data: sanitizeUserImage(data) }) },
-      update: { before: async (data) => ({ data: sanitizeUserImage(data) }) },
+      create: { before: async (data) => ({ data: sanitizeUserData(data) }) },
+      update: { before: async (data) => ({ data: sanitizeUserData(data) }) },
     },
   },
   user: {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -97,6 +97,18 @@ function sanitizeUserData(
     }
   }
 
+  // displayUsername is what /profile/<slug> actually renders. better-auth's
+  // usernameValidator only fires on `username`, so a /update-user request
+  // that touches displayUsername alone bypasses the check. Block reserved
+  // values here independently.
+  if ("displayUsername" in out) {
+    const v = out.displayUsername
+    if (typeof v === "string" && isReservedUsername(v)) {
+      const { displayUsername: _du, ...rest } = out
+      out = rest
+    }
+  }
+
   return out
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,7 +32,20 @@ app.use(
 
 app.onError((err, c) => {
   if (isPrismaNotFound(err)) return c.json({ error: "not_found" }, 404)
-  console.error(err)
+  // Don't `console.error(err)` directly — for Prisma errors that drags in
+  // `meta` (column names plus the parameter-bearing context from the
+  // failing query) and dumps it into Workers logs verbatim. Keep just the
+  // structured shape we actually need for triage; stack traces stay in
+  // dev only since they can leak bundled paths / variable names.
+  const e = err as Error & { code?: string }
+  console.error("api error:", {
+    name: e?.name,
+    code: e?.code,
+    method: c.req.method,
+    path: c.req.path,
+    message: e?.message,
+    ...(process.env.NODE_ENV !== "production" ? { stack: e?.stack } : {}),
+  })
   return c.json({ error: "internal_error" }, 500)
 })
 

--- a/apps/api/src/lib/api-key-auth.ts
+++ b/apps/api/src/lib/api-key-auth.ts
@@ -32,6 +32,10 @@ export function requireApiKey(requiredScope: ApiKeyScope): MiddlewareHandler {
         rateLimit: true,
         isActive: true,
         expiresAt: true,
+        // Cookie-session routes go through banGuard in security.ts; the
+        // PAT path needs the equivalent check or banned users keep API
+        // access after their sessions are revoked.
+        user: { select: { isBanned: true } },
       },
     })
 
@@ -40,6 +44,9 @@ export function requireApiKey(requiredScope: ApiKeyScope): MiddlewareHandler {
     }
     if (apiKey.expiresAt && apiKey.expiresAt.getTime() <= Date.now()) {
       return c.json({ error: "invalid_key" }, 401)
+    }
+    if (apiKey.user.isBanned) {
+      return c.json({ error: "banned" }, 403)
     }
     if (!apiKey.scopes.includes(requiredScope)) {
       return c.json(

--- a/apps/api/src/lib/overframe/import.ts
+++ b/apps/api/src/lib/overframe/import.ts
@@ -15,18 +15,109 @@ export function isValidOverframeBuildUrl(value: string): boolean {
   }
 }
 
+// Mirror of the hardening in routes/img.ts: cap fetch wall-time, cap response
+// size, follow redirects manually so a 3xx chain can't escape overframe.gg.
+// Without these, a logged-in user (or a banned holder of an old PAT) could
+// point this scrape at a page that streams forever, redirects to a private
+// host, or returns gigabytes of HTML.
+const FETCH_TIMEOUT_MS = 8000
+const MAX_HTML_BYTES = 1024 * 1024 // 1 MB — Next.js pages are large but bounded.
+const MAX_REDIRECTS = 3
+
+async function fetchOverframeOnce(url: string): Promise<Response> {
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS)
+  try {
+    return await fetch(url, {
+      signal: ctrl.signal,
+      // Manual so we can re-validate every Location against
+      // isValidOverframeBuildUrl. A `redirect: "follow"` here would let
+      // Overframe (or anyone they 302 to) reach an arbitrary host on our
+      // behalf — same threat the image proxy guards against.
+      redirect: "manual",
+      headers: {
+        "user-agent":
+          "Mozilla/5.0 (compatible; ArsenyxBot/1.0; +https://arsenyx.com)",
+        accept: "text/html,application/xhtml+xml",
+      },
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 async function fetchOverframeHtml(url: string): Promise<string> {
-  const res = await fetch(url, {
-    headers: {
-      "user-agent":
-        "Mozilla/5.0 (compatible; ArsenyxBot/1.0; +https://arsenyx.com)",
-      accept: "text/html,application/xhtml+xml",
-    },
-  })
+  // Caller already validated `url` via isValidOverframeBuildUrl; each
+  // redirect target gets the same gate below.
+  let current = url
+  let res = await fetchOverframeOnce(current)
+
+  let hops = 0
+  while (res.status >= 300 && res.status < 400 && hops < MAX_REDIRECTS) {
+    const loc = res.headers.get("location")
+    let nextUrl: string
+    try {
+      nextUrl = new URL(loc ?? "", current).toString()
+    } catch {
+      throw new Error("Overframe fetch failed: bad redirect target")
+    }
+    if (!isValidOverframeBuildUrl(nextUrl)) {
+      throw new Error("Overframe fetch failed: redirect off-host")
+    }
+    hops += 1
+    current = nextUrl
+    res = await fetchOverframeOnce(current)
+  }
+
+  if (res.status >= 300 && res.status < 400) {
+    throw new Error("Overframe fetch failed: too many redirects")
+  }
   if (!res.ok) {
     throw new Error(`Overframe fetch failed: ${res.status} ${res.statusText}`)
   }
-  return res.text()
+
+  const declared = res.headers.get("content-length")
+  if (declared) {
+    const n = parseInt(declared, 10)
+    if (Number.isFinite(n) && n > MAX_HTML_BYTES) {
+      throw new Error("Overframe fetch failed: response too large")
+    }
+  }
+
+  const reader = res.body?.getReader()
+  if (!reader) {
+    throw new Error("Overframe fetch failed: empty body")
+  }
+
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value) continue
+      total += value.byteLength
+      if (total > MAX_HTML_BYTES) {
+        void reader.cancel()
+        throw new Error("Overframe fetch failed: response too large")
+      }
+      chunks.push(value)
+    }
+  } finally {
+    try {
+      reader.releaseLock()
+    } catch {
+      // Already released on cancel.
+    }
+  }
+
+  const merged = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder("utf-8").decode(merged)
 }
 
 type OverframeSlotLike = {

--- a/apps/api/src/lib/overframe/import.ts
+++ b/apps/api/src/lib/overframe/import.ts
@@ -22,7 +22,7 @@ export function isValidOverframeBuildUrl(value: string): boolean {
 // host, or returns gigabytes of HTML.
 const FETCH_TIMEOUT_MS = 8000
 const MAX_HTML_BYTES = 1024 * 1024 // 1 MB — Next.js pages are large but bounded.
-const MAX_REDIRECTS = 3
+const MAX_REDIRECTS = 5
 
 async function fetchOverframeOnce(url: string): Promise<Response> {
   const ctrl = new AbortController()

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono"
 import { prisma } from "../db"
 import { Prisma } from "../generated/prisma/client"
 import { parseJsonBody } from "../lib/validate"
+import { rateLimitUser } from "../middleware/rate-limit"
 import { isPrismaNotFound, requireAdmin } from "./_admin"
 import { parseListQuery, runList } from "./_build-list"
 import { parsePage, trimQ } from "./_query"
@@ -20,7 +21,17 @@ type UserFlag = (typeof USER_FLAGS)[number]
 
 const LIST_PAGE = 24
 
-admin.get("/users", async (c) => {
+// Admin destructive ops + list/search are throttled with the same per-user
+// buckets the public surface uses. The cap is well above any plausible
+// admin workflow; the goal is to bound damage if a privileged session is
+// ever exfiltrated (stolen device, browser extension exfil, etc.) before
+// the admin notices and revokes. List/search uses `includeSafeMethods`
+// because the unindexed ILIKE %q% across four columns is the expensive
+// path here, not the writes.
+const adminMutateLimit = rateLimitUser("mutate")
+const adminSearchLimit = rateLimitUser("search", { includeSafeMethods: true })
+
+admin.get("/users", adminSearchLimit, async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 
@@ -86,7 +97,7 @@ admin.get("/users", async (c) => {
   })
 })
 
-admin.patch("/users/:id", async (c) => {
+admin.patch("/users/:id", adminMutateLimit, async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 
@@ -136,9 +147,19 @@ admin.patch("/users/:id", async (c) => {
     })
     // Better Auth caches `isBanned` in the session cookie for up to 60s
     // (auth.ts), so a ban only takes effect on cookie refresh. Delete the
-    // user's sessions to force re-auth on the next request.
+    // user's sessions to force re-auth on the next request. API keys are
+    // deactivated in the same step so a banned user can't keep hitting
+    // /api/v1 with a pre-existing PAT — requireApiKey checks isBanned on
+    // each call, but flipping isActive is the explicit, durable signal a
+    // moderator can see in the user's key list.
     if (data.isBanned === true) {
-      await prisma.session.deleteMany({ where: { userId: targetId } })
+      await Promise.all([
+        prisma.session.deleteMany({ where: { userId: targetId } }),
+        prisma.apiKey.updateMany({
+          where: { userId: targetId, isActive: true },
+          data: { isActive: false },
+        }),
+      ])
     }
     return c.json(updated)
   } catch (err) {
@@ -147,7 +168,7 @@ admin.patch("/users/:id", async (c) => {
   }
 })
 
-admin.delete("/users/:id", async (c) => {
+admin.delete("/users/:id", adminMutateLimit, async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 
@@ -165,7 +186,7 @@ admin.delete("/users/:id", async (c) => {
   return c.body(null, 204)
 })
 
-admin.get("/builds", async (c) => {
+admin.get("/builds", adminSearchLimit, async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 
@@ -178,7 +199,7 @@ admin.get("/builds", async (c) => {
   return c.json(result)
 })
 
-admin.delete("/builds/:slug", async (c) => {
+admin.delete("/builds/:slug", adminMutateLimit, async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 
@@ -192,7 +213,7 @@ admin.delete("/builds/:slug", async (c) => {
   return c.body(null, 204)
 })
 
-admin.get("/orgs", async (c) => {
+admin.get("/orgs", adminSearchLimit, async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 
@@ -245,7 +266,7 @@ admin.get("/orgs", async (c) => {
   })
 })
 
-admin.delete("/orgs/:slug", async (c) => {
+admin.delete("/orgs/:slug", adminMutateLimit, async (c) => {
   const actor = await requireAdmin(c)
   if (actor instanceof Response) return actor
 

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -12,6 +12,7 @@ import {
 } from "../lib/api-keys"
 import { getSession } from "../lib/session"
 import { parseJsonBody } from "../lib/validate"
+import { rateLimitUser } from "../middleware/rate-limit"
 import { getUserRoles } from "./_admin"
 
 const KNOWN_SCOPES = new Set<string>(ALL_API_KEY_SCOPES)
@@ -93,7 +94,7 @@ me.get("/api-keys", async (c) => {
   return c.json({ apiKeys: keys.map(serializeApiKey) })
 })
 
-me.post("/api-keys", async (c) => {
+me.post("/api-keys", rateLimitUser("mutate"), async (c) => {
   const user = await requireSession(c)
   if (!user) return c.json({ error: "unauthorized" }, 401)
 
@@ -157,7 +158,7 @@ me.post("/api-keys", async (c) => {
   }
 })
 
-me.delete("/api-keys/:id", async (c) => {
+me.delete("/api-keys/:id", rateLimitUser("mutate"), async (c) => {
   const user = await requireSession(c)
   if (!user) return c.json({ error: "unauthorized" }, 401)
 

--- a/apps/web/src/components/build-editor/calculations.ts
+++ b/apps/web/src/components/build-editor/calculations.ts
@@ -243,22 +243,24 @@ export function calculateFormaCount(input: FormaCountInput): number {
     normalInnates,
     formaPolarities,
   } = input
-  let total = 0
 
-  for (let i = 0; i < auraInnates.length; i++) {
-    total += singleSlotForma(
-      auraInnates[i],
-      formaPolarities[`aura-${i}` as SlotId],
-    )
-  }
-  total += singleSlotForma(exilusInnate, formaPolarities.exilus)
-  total += singleSlotForma(stanceInnate, formaPolarities.stance)
+  // Aura, exilus, and normal slots share a single dedup pool: moving a
+  // polarity between them (e.g. exilus → normal) costs no net forma. Stance
+  // is separate — melee stance changes always cost forma.
+  const pool: NormalSlotEntry[] = [
+    ...auraInnates.map((innate, i) => ({
+      innate,
+      forma: formaPolarities[`aura-${i}` as SlotId],
+    })),
+    {
+      innate: exilusInnate,
+      forma: formaPolarities.exilus,
+    },
+    ...normalInnates.map((innate, i) => ({
+      innate,
+      forma: formaPolarities[`normal-${i}` as SlotId],
+    })),
+  ]
 
-  const normalSlots: NormalSlotEntry[] = normalInnates.map((innate, i) => ({
-    innate,
-    forma: formaPolarities[`normal-${i}` as SlotId],
-  }))
-  total += groupForma(normalSlots)
-
-  return total
+  return groupForma(pool) + singleSlotForma(stanceInnate, formaPolarities.stance)
 }

--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -234,6 +234,7 @@ export function ItemSidebar({
       arcanes: arcaneList,
       showMaxStacks,
       deploymentContext: effectiveDeploymentContext,
+      lichBonusElement,
     })
     // The Incarnon Form alt-fire is only available with the adapter installed.
     if (showIncarnon && !incarnonEnabled) {
@@ -256,6 +257,7 @@ export function ItemSidebar({
     showIncarnon,
     incarnonEnabled,
     effectiveDeploymentContext,
+    lichBonusElement,
   ])
 
   const companionStats = useMemo<CompanionStats | null>(() => {

--- a/apps/web/src/components/build-editor/mod-card.tsx
+++ b/apps/web/src/components/build-editor/mod-card.tsx
@@ -1,5 +1,11 @@
 import type { Mod } from "@arsenyx/shared/warframe/types"
-import { Fragment, useEffect, useRef, useState } from "react"
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
 import { createPortal } from "react-dom"
 
 import {
@@ -420,13 +426,53 @@ export function ModCard({
   const effectiveHover = isHovered && !disableHover
 
   // Scroll collapses the preview — otherwise the card can stay stuck open
-  // if its wrapper moves out from under the cursor silently.
+  // if its wrapper moves out from under the cursor silently. Same problem
+  // happens when the grid reflows (e.g. mod search filters): the DOM node
+  // shifts but no mouseleave fires, so we also re-check on pointermove.
   useEffect(() => {
     if (!isHovered) return
     const close = () => setIsHovered(false)
+    const checkPointer = (e: PointerEvent) => {
+      const r = compactRef.current?.getBoundingClientRect()
+      if (!r) return
+      if (
+        e.clientX < r.left ||
+        e.clientX > r.right ||
+        e.clientY < r.top ||
+        e.clientY > r.bottom + HOVER_OVERHANG
+      ) {
+        setIsHovered(false)
+      }
+    }
     window.addEventListener("scroll", close, { capture: true, passive: true })
-    return () => window.removeEventListener("scroll", close, { capture: true })
+    window.addEventListener("pointermove", checkPointer, { passive: true })
+    return () => {
+      window.removeEventListener("scroll", close, { capture: true })
+      window.removeEventListener("pointermove", checkPointer)
+    }
   }, [isHovered])
+
+  // Close when the card's layout shifts (e.g. mod search filters reorder
+  // the grid) — pointermove alone doesn't fire if the user types without
+  // moving the cursor.
+  const lastHoveredRect = useRef<DOMRect | null>(null)
+  useLayoutEffect(() => {
+    if (!isHovered) {
+      lastHoveredRect.current = null
+      return
+    }
+    const r = compactRef.current?.getBoundingClientRect()
+    if (!r) return
+    const prev = lastHoveredRect.current
+    if (
+      prev &&
+      (Math.abs(prev.left - r.left) > 4 || Math.abs(prev.top - r.top) > 4)
+    ) {
+      setIsHovered(false)
+      return
+    }
+    lastHoveredRect.current = r
+  })
 
   // alwaysExpanded skips all the hover machinery.
   if (alwaysExpanded) {

--- a/apps/web/src/components/build-editor/mod-card.tsx
+++ b/apps/web/src/components/build-editor/mod-card.tsx
@@ -464,9 +464,14 @@ export function ModCard({
     const r = compactRef.current?.getBoundingClientRect()
     if (!r) return
     const prev = lastHoveredRect.current
+    // Threshold of half a card width — only a genuine grid reorder will
+    // ever shift by this much. Smaller wobbles from scrollbar gutters,
+    // sibling state changes, or font-load reflow shouldn't dismiss hover.
+    const shiftThreshold = DISPLAY_SIZE.compact.width / 2
     if (
       prev &&
-      (Math.abs(prev.left - r.left) > 4 || Math.abs(prev.top - r.top) > 4)
+      (Math.abs(prev.left - r.left) > shiftThreshold ||
+        Math.abs(prev.top - r.top) > shiftThreshold)
     ) {
       setIsHovered(false)
       return

--- a/apps/web/src/lib/stats/weapon.ts
+++ b/apps/web/src/lib/stats/weapon.ts
@@ -3,6 +3,7 @@ import type {
   DamageTypes,
   DeploymentContext,
   Gun,
+  LichBonusElement,
   Melee,
   Weapon,
 } from "@arsenyx/shared/warframe/types"
@@ -41,6 +42,23 @@ export interface WeaponCalcInput {
    * without atmospheric overrides.
    */
   deploymentContext?: DeploymentContext
+  /**
+   * Kuva/Tenet progenitor bonus element. Adds a flat +60% of the chosen
+   * element as if it were a mod stat, so it combines with mod elements
+   * (e.g. Cold + bonus Toxin → Viral).
+   */
+  lichBonusElement?: LichBonusElement | null
+}
+
+const LICH_BONUS_PERCENT = 60
+
+function lichBonusStat(element: LichBonusElement): SourcedStat {
+  return {
+    type: element.toLowerCase() as SourcedStat["type"],
+    value: LICH_BONUS_PERCENT,
+    operation: "percent_add",
+    sourceName: "Bonus Element",
+  }
 }
 
 export function calculateWeaponStats(input: WeaponCalcInput): WeaponStats {
@@ -48,6 +66,9 @@ export function calculateWeaponStats(input: WeaponCalcInput): WeaponStats {
   const stats = collectSourcedStats(input.mods, input.arcanes, {
     showMaxStacks: input.showMaxStacks,
   })
+  if (input.lichBonusElement) {
+    stats.push(lichBonusStat(input.lichBonusElement))
+  }
 
   const multishot = calcStat("multishot", 1, stats)
   const hasAttacks = Boolean(weapon.attacks && weapon.attacks.length > 0)
@@ -387,8 +408,23 @@ function calcDamageBreakdown(
     }
   }
 
+  // Merge entries that share the same element type (e.g. innate Cold +
+  // modded Cold from Primed Cryo Rounds). Without this, combineElements
+  // emits two separate Cold rows because Cold+Cold isn't a valid pairing.
+  const mergedByType = new Map<DamageType, (typeof elementalMods)[number]>()
+  for (const entry of elementalMods) {
+    const existing = mergedByType.get(entry.type)
+    if (existing) {
+      existing.value += entry.value
+      existing.sources.push(...entry.sources)
+      if (!entry.isInnate) existing.isInnate = false
+    } else {
+      mergedByType.set(entry.type, { ...entry, sources: [...entry.sources] })
+    }
+  }
+
   const elemental = combineElements(
-    elementalMods,
+    Array.from(mergedByType.values()),
     totalModdedBase,
     baseDamageContribs,
   )

--- a/apps/web/src/lib/stats/weapon.ts
+++ b/apps/web/src/lib/stats/weapon.ts
@@ -408,26 +408,35 @@ function calcDamageBreakdown(
     }
   }
 
-  // Merge entries that share the same element type (e.g. innate Cold +
-  // modded Cold from Primed Cryo Rounds). Without this, combineElements
-  // emits two separate Cold rows because Cold+Cold isn't a valid pairing.
-  const mergedByType = new Map<DamageType, (typeof elementalMods)[number]>()
-  for (const entry of elementalMods) {
-    const existing = mergedByType.get(entry.type)
-    if (existing) {
-      existing.value += entry.value
-      existing.sources.push(...entry.sources)
-      if (!entry.isInnate) existing.isInnate = false
-    } else {
-      mergedByType.set(entry.type, { ...entry, sources: [...entry.sources] })
-    }
-  }
-
   const elemental = combineElements(
-    Array.from(mergedByType.values()),
+    elementalMods,
     totalModdedBase,
     baseDamageContribs,
   )
+
+  // Dedupe entries of the same type that survived combineElements (e.g.
+  // innate Cold + modded Cold with no other element to pair with). Done
+  // post-combination so the "innates pair last with leftovers" ordering
+  // still applies: modded Cold + Heat → Blast first, then any leftover
+  // innate Cold gets merged with other Cold entries here.
+  const dedupedByType = new Map<DamageType, DamageEntry>()
+  const deduped: DamageEntry[] = []
+  for (const entry of elemental) {
+    const existing = dedupedByType.get(entry.type)
+    if (existing) {
+      existing.value = round1(existing.value + entry.value)
+      existing.contributions.push(...entry.contributions)
+    } else {
+      const cloned: DamageEntry = {
+        ...entry,
+        contributions: [...entry.contributions],
+      }
+      dedupedByType.set(entry.type, cloned)
+      deduped.push(cloned)
+    }
+  }
+  elemental.length = 0
+  elemental.push(...deduped)
 
   // Combined-element stats from mods/rivens/arcanes (e.g. a Riven rolling
   // +Magnetic Damage). These don't combine further, so emit them directly.

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@wfcd/items": "^1.1274.29",
         "better-auth": "^1.6.9",
         "fast-xml-parser": "^5.7.2",
+        "nanoid": "^5.1.11",
         "postcss": "^8.5.12",
         "prisma": "^7.8.0",
       },
@@ -1117,7 +1118,7 @@
 
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
-    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
+    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
 
     "nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@wfcd/items": "^1.1274.29",
     "better-auth": "^1.6.9",
     "fast-xml-parser": "^5.7.2",
+    "nanoid": "^5.1.11",
     "postcss": "^8.5.12",
     "prisma": "^7.8.0"
   },


### PR DESCRIPTION
## Summary

### Forma-count slot pool
- Aura, exilus, and normal slots now share a single polarity-dedup pool in `calculateFormaCount`, so moving a polarity between them (e.g. dropping exilus polarity and adding the same polarity to a normal slot) nets zero forma.
- Stance stays on its own per-slot count — melee stance polarities can't be redistributed and still cost forma when changed.
- Bumps `nanoid` to `^5.1.11`.

### API security hardening (second commit)
Defense-in-depth follow-ups from a security pass. None of these are directly exploitable today, but each closes a gap that would matter if another layer slipped:

- **API keys now ban-aware.** `requireApiKey` selects `user.isBanned` and 403s; admin ban branch deactivates the user's PATs alongside revoking sessions. Previously a banned user kept full `/api/v1` access via any existing key.
- **Overframe scraper picks up the `/img` hardening.** Same threat model (fetch untrusted external URL on user's behalf) — now has an 8s `AbortController` timeout, `redirect: \"manual\"` with `isValidOverframeBuildUrl` re-validation per hop, and a 1 MB streamed byte cap.
- **`defaultBuildVisibility` validated in the user-update hook.** Better Auth's `additionalFields` has no per-field validator, so `/auth/update-user` accepted any string and the write failed at the Postgres enum cast. Now stripped from the payload if invalid.
- **Rate limits on `/me/api-keys` POST + DELETE.** Every other authed write goes through `rateLimitUser(\"mutate\")`; API key churn was the outlier.
- **Rate limits on admin routes.** Destructive ops get `mutate`; list/search GETs get `search` with `includeSafeMethods`. Bounds damage if a privileged session is ever exfiltrated.
- **Sanitized error logging.** `onError` no longer dumps the raw `err` object — Prisma errors can carry `meta` / parameter-bearing context. Structured `{name, code, method, path, message}` only, with stack in dev.
- **Reserved-username denylist.** `username` plugin's `usernameValidator` rejects `admin`, `support`, `security`, etc. (a phishing surface, not a privilege escalation — `isAdmin` is server-side). GitHub OAuth path suffixes reserved logins with the stable `profile.id` so re-sync on every sign-in stays idempotent.

## Test plan

### Forma-count pool
- [x] On a frame with an innate exilus polarity, clear the exilus slot — counter goes 0 → 1.
- [x] Then apply that same polarity to any normal slot — counter goes back to 0.
- [x] Same swap between aura ↔ normal works symmetrically.
- [x] On a melee, changing the stance polarity still increments the forma counter.

### Security
- [x] Sign in via GitHub, generate an API key, call `/api/v1/builds` → 200.
- [x] Get banned via admin tool, call `/api/v1/builds` with the same key → 403 `banned`. Check the user's key list in `/me/api-keys` → marked inactive.
- [x] POST a build with `defaultBuildVisibility: \"BOGUS\"` via `/auth/update-user` → field silently dropped, existing DB value untouched.
- [x] Try to set username to `admin` via `/auth/update-user` → 400 `INVALID_USERNAME`.
- [x] Hit `/me/api-keys` POST in a tight loop — 21st call within 60s returns 429.
- [x] Cause a Prisma error in a write handler, check Workers logs — payload contains `name/code/path` but not bound values.