### PR TITLE
Fix: unfurl Worker redirected /builds/* to homepage

### DIFF
--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -70,8 +70,13 @@ export default {
     const ua = request.headers.get("user-agent") ?? ""
     if (!isUnfurlBot(ua)) return env.ASSETS.fetch(request)
 
+    // Workers Static Assets redirects `/index.html` → `/` by default
+    // (html_handling), so we ask for the original path and let the SPA
+    // fallback (`not_found_handling = "single-page-application"`) serve
+    // index.html with a 200. The ASSETS binding bypasses the Worker, so
+    // there's no infinite loop here.
     const [shellRes, build] = await Promise.all([
-      env.ASSETS.fetch(new Request(new URL("/index.html", url), request)),
+      env.ASSETS.fetch(request),
       fetchBuild(slug),
     ])
 


### PR DESCRIPTION
## Summary

Follow-up to [#144](https://github.com/Reuzehagel/arsenyx/pull/144). The unfurl Worker was fetching `/index.html` literally to feed into HTMLRewriter — but Workers Static Assets redirects `/index.html → /` by default (its `html_handling` behaviour). That 307 then passed straight through HTMLRewriter (no body to transform) and clients saw `Location: /`, so Discord embedded the homepage's generic site card instead of the build.

## Fix

Fetch the original request through `env.ASSETS.fetch(request)`. The SPA fallback (`not_found_handling = "single-page-application"`) serves index.html with a 200 for any unmatched `/builds/<slug>` path, which is what HTMLRewriter needs. The ASSETS binding bypasses the Worker, so there's no loop.

## Test plan

- [ ] After deploy + cache purge: `curl -A Discordbot https://www.arsenyx.com/builds/Xu4pkhZ6RX` returns 200 with rich `og:*` tags, not a 307
- [ ] Pasting `https://arsenyx.com/builds/Xu4pkhZ6RX?v=2` (fresh URL so Discord refetches) shows the build-specific embed
- [ ] A non-bot UA on the same path still 200s with the un-rewritten shell