### PR TITLE
Auto-generate routeTree.gen.ts in just check

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,7 +17,8 @@ just setup              # first-run wizard — see CONTRIBUTING.md
 ```bash
 bun --cwd apps/web run build      # Vite production build — run before claiming done
 bunx --cwd apps/api tsc --noEmit  # type-check the API (no dev-server smoke)
-just check                        # oxlint + oxfmt --check across all three workspaces
+just check                        # typecheck + oxlint + oxfmt --check (also generates routeTree.gen.ts if missing)
+just gen                          # generate apps/web/src/routeTree.gen.ts only (no-op if present)
 just fix                          # oxlint --fix + oxfmt --write
 just test                         # vitest across apps/web, apps/api, packages/shared
 ```

--- a/justfile
+++ b/justfile
@@ -57,8 +57,21 @@ setup:
 update-data:
     bun run update-data
 
+# Ensure apps/web/src/routeTree.gen.ts exists. Vite's router-plugin
+# generates it during build, but `bun run typecheck` (and editors) need
+# it on a fresh checkout. No-op once present — first run takes ~8s.
+[unix]
+[working-directory('apps/web')]
+gen:
+    test -f src/routeTree.gen.ts || bun run build >/dev/null
+
+[windows]
+[working-directory('apps/web')]
+gen:
+    if (-not (Test-Path src/routeTree.gen.ts)) { bun run build | Out-Null }
+
 # Typecheck + lint + format-check across apps/web, apps/api, packages/shared.
-check:
+check: gen
     bun run typecheck
     bun run lint
     bun run fmt:check


### PR DESCRIPTION
## Summary
- Add a `just gen` recipe that runs `vite build` only if `apps/web/src/routeTree.gen.ts` is missing (first run ~8s, subsequent runs ~0).
- Wire `gen` as a prerequisite of `just check`.
- `docs/commands.md` updated.

## Why
A fresh checkout couldn't `bun run typecheck` until Vite had run once (the TanStack Router plugin emits `routeTree.gen.ts` as a build side effect). The fix was buried in a CI workflow comment — easy first-PR papercut.

## Test plan
- [x] With file present: `just gen` no-ops in <0.5s
- [x] With file deleted: `just gen` produces identical `routeTree.gen.ts` in ~9s
- [x] `just check` runs gen → typecheck → lint → fmt:check cleanly