### PR TITLE
Split /docs into concepts + API reference, rewrite privacy/terms, add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Reuzehagel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Live at **[www.arsenyx.com](https://www.arsenyx.com)**.
 - **Social layer** — vote, favorite, fork, and follow other players' builds
 - **Overframe import** — paste an Overframe URL and get a first-class Arsenyx build
 - **Shareable by link** — every build encodes to a short URL, no account needed to view
-- **Bearer-token API** — publish builds from scripts, bots, or external tools — see [arsenyx.com/docs](https://www.arsenyx.com/docs)
+- **Bearer-token API** — publish builds from scripts, bots, or external tools — see [arsenyx.com/docs/api](https://www.arsenyx.com/docs/api)
 
 ## Stack
 

--- a/apps/web/src/components/settings-dialog/advanced-tab.tsx
+++ b/apps/web/src/components/settings-dialog/advanced-tab.tsx
@@ -99,7 +99,8 @@ export function AdvancedPanel() {
       <Field>
         <FieldLabel className="text-destructive">Delete account</FieldLabel>
         <FieldDescription>
-          Permanently deletes your account, builds, likes, and bookmarks. This
+          Permanently deletes your account, all sessions, your API keys, your
+          builds, guides, votes, bookmarks, and organization memberships. This
           cannot be undone.
         </FieldDescription>
         <div className="pt-1">
@@ -159,8 +160,8 @@ function DeleteAccountDialog({
       <DialogContent className="md:max-w-md">
         <DialogTitle>Delete account</DialogTitle>
         <DialogDescription>
-          This permanently deletes your account and every build, like, and
-          bookmark tied to it. Type{" "}
+          This permanently deletes your account, API keys, builds, guides,
+          votes, bookmarks, and organization memberships. Type{" "}
           <code className="font-mono">{expected}</code> to confirm.
         </DialogDescription>
         <div className="flex flex-col gap-3 pt-2">

--- a/apps/web/src/components/settings-dialog/api-keys-tab.tsx
+++ b/apps/web/src/components/settings-dialog/api-keys-tab.tsx
@@ -101,7 +101,7 @@ export function ApiKeysPanel() {
       <Field>
         <FieldLabel>API keys</FieldLabel>
         <FieldDescription>
-          Authenticate the Arsenyx public API from scripts or tools. Tokens are
+          Authenticate the Arsenyx public API from scripts or tools. Keys are
           shown once on creation — store them somewhere safe.
         </FieldDescription>
       </Field>
@@ -172,7 +172,7 @@ function CreateApiKeyForm({ disabled }: { disabled: boolean }) {
       <Field>
         <FieldLabel>New API key</FieldLabel>
         <FieldDescription>
-          Copy this token now. You won't be able to see it again.
+          Copy this key now. You won't be able to see it again.
         </FieldDescription>
         <div className="bg-muted/40 flex items-center gap-2 rounded-md border p-2">
           <code className="flex-1 truncate font-mono text-xs">
@@ -351,7 +351,7 @@ function ApiKeyRow({ apiKey }: { apiKey: ApiKeySummary }) {
         <span className="text-muted-foreground text-xs">
           Created {formatDate(apiKey.createdAt)} · Expires{" "}
           {formatDate(apiKey.expiresAt)} · Last used{" "}
-          {formatDate(apiKey.lastUsedAt)}
+          {formatDate(apiKey.lastUsedAt)} · {apiKey.rateLimit}/min
         </span>
       </div>
       {apiKey.isActive ? (

--- a/apps/web/src/routes/docs.tsx
+++ b/apps/web/src/routes/docs.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useEffect } from "react"
 
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
@@ -11,129 +12,26 @@ export const Route = createFileRoute("/docs")({
   component: DocsPage,
 })
 
-type Endpoint = {
-  method: "GET" | "POST" | "PUT"
-  path: string
-  summary: string
-  example: string
+// Anchors that used to live on /docs (API reference page) and have since moved
+// to /docs/api. Inbound bookmarks/social-card links to these hashes get
+// forwarded so they still land on the right section.
+const MOVED_HASHES: Record<string, string> = {
+  "#public-api": "#public-read-api",
+  "#public-read-api": "#public-read-api",
+  "#authenticated-write-api": "#authenticated-write-api",
+  "#game-data": "#game-data",
 }
 
-const WRITE_ENDPOINTS: Endpoint[] = [
-  {
-    method: "POST",
-    path: "/api/v1/builds",
-    summary:
-      "Create a build. Body specifies item, slots, arcanes, shards, and optional guide. Server resolves canonical refs and recomputes derived fields.",
-    example: `{
-  "name": "Rhino Tank",
-  "visibility": "PUBLIC",
-  "itemUniqueName": "/Lotus/Powersuits/Rhino/Rhino",
-  "itemCategory": "warframes",
-  "guide": { "summary": "...", "description": "..." },
-  "build": {
-    "hasReactor": true,
-    "slots": [
-      {
-        "slotId": "aura-0",
-        "mod": {
-          "uniqueName": "/Lotus/Upgrades/Mods/Aura/SteelCharge",
-          "rank": 5
-        }
-      }
-    ],
-    "arcanes": [],
-    "shards": [],
-    "helminthAbility": null
-  }
-}`,
-  },
-  {
-    method: "PUT",
-    path: "/api/v1/builds/:slug",
-    summary: "Update a build you own. Same payload shape as create.",
-    example: `{ "name": "...", "build": { ... } }`,
-  },
-  {
-    method: "POST",
-    path: "/api/v1/imports/overframe",
-    summary:
-      "Import an Overframe build by URL. If nameOverride / description / guide are omitted, Arsenyx preserves the Overframe metadata. Explicit null clears nullable fields.",
-    example: `{
-  "url": "https://overframe.gg/build/935570/",
-  "visibility": "PUBLIC",
-  "nameOverride": null,
-  "description": null,
-  "guide": null
-}`,
-  },
-]
-
-const PUBLIC_ENDPOINTS: Endpoint[] = [
-  {
-    method: "GET",
-    path: "/builds",
-    summary:
-      "List public builds. Supports ?page, ?sort, ?q, ?category, ?hasGuide, ?hasShards.",
-    example: `{
-  "builds": [ { "slug": "...", "title": "...", "category": "warframe", ... } ],
-  "total": 1234,
-  "page": 1,
-  "limit": 24
-}`,
-  },
-  {
-    method: "GET",
-    path: "/builds/:slug",
-    summary: "Fetch a single public build by slug.",
-    example: `{
-  "slug": "...",
-  "title": "...",
-  "category": "warframe",
-  "items": [...],
-  "mods": [...],
-  "arcanes": [...]
-}`,
-  },
-  {
-    method: "GET",
-    path: "/orgs/public",
-    summary:
-      "Directory of all organizations. Paginated, with ?q for name/slug search.",
-    example: `{
-  "orgs": [
-    { "slug": "...", "name": "...", "memberCount": 12, "buildCount": 34, ... }
-  ],
-  "total": 7,
-  "page": 1,
-  "limit": 20
-}`,
-  },
-  {
-    method: "GET",
-    path: "/orgs/:slug",
-    summary: "Organization profile: members, description, public build count.",
-    example: `{
-  "slug": "...",
-  "name": "...",
-  "members": [ { "role": "ADMIN" | "MEMBER", "user": {...} } ],
-  "buildCount": 34
-}`,
-  },
-  {
-    method: "GET",
-    path: "/orgs/:slug/builds",
-    summary:
-      "Public builds authored under an organization. Same filters as /builds.",
-    example: `{
-  "builds": [...],
-  "total": 34,
-  "page": 1,
-  "limit": 24
-}`,
-  },
-]
-
 function DocsPage() {
+  const navigate = useNavigate()
+  useEffect(() => {
+    const hash = window.location.hash
+    const target = MOVED_HASHES[hash]
+    if (target) {
+      void navigate({ to: "/docs/api", hash: target.slice(1), replace: true })
+    }
+  }, [navigate])
+
   return (
     <div className="relative flex min-h-screen flex-col">
       <Header />
@@ -141,8 +39,8 @@ function DocsPage() {
         <article className="prose prose-neutral dark:prose-invert max-w-none">
           <h1>Documentation</h1>
           <p className="lead">
-            How {SITE_CONFIG.name} is put together, and how to build on top of
-            it.
+            How {SITE_CONFIG.name} is put together — the concepts behind builds,
+            organizations, sharing, and the public API.
           </p>
 
           <h2>Overview</h2>
@@ -154,92 +52,109 @@ function DocsPage() {
             lives in Postgres behind a small HTTP API. The site, the API, and
             the data pipeline are all open source.
           </p>
-
-          <h2>Public API</h2>
           <p>
-            Base URL: <code>{EXTERNAL_LINKS.apiBase}</code>. Authentication is
-            cookie-based (Better Auth). The endpoints below are public and
-            read-only — no credentials required. Write endpoints, user data, and
-            admin routes require a session and aren&apos;t documented here.
+            Building on top of Arsenyx programmatically? Jump straight to the{" "}
+            <Link href="/docs/api">API reference</Link>.
           </p>
-          <ul className="not-prose flex list-none flex-col gap-4 pl-0">
-            {PUBLIC_ENDPOINTS.map((ep) => (
-              <li
-                key={`${ep.method} ${ep.path}`}
-                className="border-border bg-card flex flex-col gap-2 rounded-lg border p-4"
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="bg-muted rounded px-2 py-0.5 font-mono text-xs font-semibold">
-                    {ep.method}
-                  </span>
-                  <code className="text-sm font-medium">{ep.path}</code>
-                </div>
-                <p className="text-muted-foreground text-sm">{ep.summary}</p>
-                <pre className="bg-muted/50 overflow-x-auto rounded p-3 text-xs leading-relaxed">
-                  <code>{ep.example}</code>
-                </pre>
-              </li>
-            ))}
+
+          <h2>Builds</h2>
+          <p>
+            A build is an item (warframe, weapon, companion, etc.) plus its
+            slots — mods, arcanes, shards — and an optional written guide. When
+            you save one, the server resolves the canonical references and
+            recomputes derived fields like remaining capacity and forma count,
+            so the same build looks the same to every viewer.
+          </p>
+          <h3>Visibility</h3>
+          <ul>
+            <li>
+              <strong>Public</strong> builds appear in the{" "}
+              <Link href="/browse">browse</Link> and{" "}
+              <Link href="/builds">builds</Link> directories, are searchable,
+              and anyone can vote or bookmark them.
+            </li>
+            <li>
+              <strong>Private</strong> builds are link-only. They don&apos;t
+              appear in any listing — only the owner can edit, but anyone with
+              the URL can view.
+            </li>
           </ul>
-          <p className="text-sm opacity-75">
-            Fields abbreviated. Responses are subject to change while Arsenyx is
-            in beta — pin to the commit you tested against.
+          <p>
+            Build slugs are short, stable, and URL-safe (no ambiguous{" "}
+            <code>0/O/1/l/I</code> characters). They never change after
+            creation, so a shared link keeps working even after edits.
+          </p>
+          <h3>Importing from Overframe</h3>
+          <p>
+            Existing Overframe builds can be pulled in from the{" "}
+            <Link href="/import">import page</Link> by URL. Arsenyx preserves
+            the original name, description, and guide unless you override them
+            at import time.
           </p>
 
-          <h2>Authenticated write API</h2>
+          <h2>Organizations</h2>
           <p>
-            Arsenyx supports bearer-token build publishing, so you can push
-            builds from a script or bot instead of clicking through the editor.
-            Sign in, open the user menu, head to <strong>Settings</strong>, and
-            create a personal access token with the <code>build:write</code>{" "}
-            scope. Send it as <code>Authorization: Bearer &lt;token&gt;</code>.
+            An organization is a named group with its own profile at{" "}
+            <code>/org/&lt;slug&gt;</code>, listing members and the public
+            builds attributed to it. Useful for clans, content creators, and
+            communities that want a shared home for their builds without giving
+            up individual authorship.
           </p>
-          <ul className="not-prose flex list-none flex-col gap-4 pl-0">
-            {WRITE_ENDPOINTS.map((ep) => (
-              <li
-                key={`${ep.method} ${ep.path}`}
-                className="border-border bg-card flex flex-col gap-2 rounded-lg border p-4"
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="bg-muted rounded px-2 py-0.5 font-mono text-xs font-semibold">
-                    {ep.method}
-                  </span>
-                  <code className="text-sm font-medium">{ep.path}</code>
-                </div>
-                <p className="text-muted-foreground text-sm">{ep.summary}</p>
-                <pre className="bg-muted/50 overflow-x-auto rounded p-3 text-xs leading-relaxed">
-                  <code>{ep.example}</code>
-                </pre>
-              </li>
-            ))}
+          <h3>Roles</h3>
+          <ul>
+            <li>
+              <strong>Admin</strong> — manages members, edits org settings, and
+              publishes builds under the org. Every org has at least one admin.
+            </li>
+            <li>
+              <strong>Member</strong> — publishes builds under the org, but
+              can&apos;t change membership or settings.
+            </li>
           </ul>
-          <p className="text-sm opacity-75">
-            The server resolves canonical item / mod / arcane / shard data,
-            recomputes derived capacity and forma fields, and rejects invalid
-            writes with structured <code>4xx</code> JSON errors.
+          <p>
+            Membership is invite-only: an existing admin adds you from the org
+            settings page. Builds you publish stay tied to your user account —
+            attributing them to an org doesn&apos;t transfer ownership, it adds
+            a second badge.
+          </p>
+          <h3>Discovery</h3>
+          <p>
+            The public directory at <Link href="/orgs">/orgs</Link> lists every
+            organization with its member and build counts. Org profiles and
+            their public builds are accessible without an account.
           </p>
 
-          <h2>Game data</h2>
+          <h2>Profiles, votes, and bookmarks</h2>
           <p>
-            Items, mods, and arcanes live as static JSON under{" "}
-            <code>apps/web/public/data/</code>. The index is generated from the{" "}
-            <Link
-              href={EXTERNAL_LINKS.wfcd}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Warframe Community Developers
-            </Link>{" "}
-            dataset and committed to the repo, so loading game data is a single
-            static fetch against the CDN — no API round-trip.
+            Every signed-in user has a public profile at{" "}
+            <code>/profile/&lt;username&gt;</code> showing their public builds.
+            Votes signal which builds the community finds useful and feed into
+            sort order on the browse listings. Bookmarks are private — only you
+            see your own list, at <Link href="/bookmarks">/bookmarks</Link>.
           </p>
 
-          <h2>Contributing</h2>
+          <h2>API keys</h2>
           <p>
-            Arsenyx is open source. Bug reports, feature requests, and pull
-            requests are all welcome on GitHub.
+            For publishing builds from a script or bot, Arsenyx supports
+            bearer-token authentication. Open the user menu →{" "}
+            <strong>Settings</strong> → <strong>API keys</strong>, create one
+            with the <code>build:write</code> scope, and send it as an{" "}
+            <code>Authorization: Bearer</code> header. Keys are revocable from
+            the same page; revoking takes effect immediately.
           </p>
-          <div className="not-prose">
+          <p>
+            Endpoint shapes and example payloads live in the{" "}
+            <Link href="/docs/api">API reference</Link>.
+          </p>
+
+          <h2>Open source</h2>
+          <p>
+            Arsenyx is MIT-licensed. The web app, API, and data-extraction
+            scripts all live in one monorepo on GitHub. Bug reports, feature
+            requests, and pull requests are welcome — no telemetry, no
+            email-gated previews.
+          </p>
+          <div className="not-prose flex flex-wrap gap-3">
             <Button
               render={
                 <Link
@@ -252,6 +167,13 @@ function DocsPage() {
             >
               <Icons.github data-icon="inline-start" />
               View on GitHub
+            </Button>
+            <Button
+              render={<Link href="/docs/api" />}
+              nativeButton={false}
+              variant="outline"
+            >
+              API reference
             </Button>
           </div>
         </article>

--- a/apps/web/src/routes/docs_.api.tsx
+++ b/apps/web/src/routes/docs_.api.tsx
@@ -1,0 +1,327 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { ArrowLeft } from "lucide-react"
+
+import { Footer } from "@/components/footer"
+import { Header } from "@/components/header"
+import { Icons } from "@/components/icons"
+import { Link } from "@/components/link"
+import { Button } from "@/components/ui/button"
+import { EXTERNAL_LINKS } from "@/lib/util/constants"
+
+export const Route = createFileRoute("/docs_/api")({
+  component: DocsApiPage,
+})
+
+type Endpoint = {
+  method: "GET" | "POST" | "PUT"
+  path: string
+  summary: string
+  example: string
+}
+
+const WRITE_ENDPOINTS: Endpoint[] = [
+  {
+    method: "POST",
+    path: "/api/v1/builds",
+    summary:
+      "Create a build. Body specifies item, slots, arcanes, shards, and optional guide. Server resolves canonical refs and recomputes derived fields.",
+    example: `{
+  "name": "Rhino Tank",
+  "visibility": "PUBLIC",
+  "itemUniqueName": "/Lotus/Powersuits/Rhino/Rhino",
+  "itemCategory": "warframes",
+  "guide": { "summary": "...", "description": "..." },
+  "build": {
+    "hasReactor": true,
+    "slots": [
+      {
+        "slotId": "aura-0",
+        "mod": {
+          "uniqueName": "/Lotus/Upgrades/Mods/Aura/SteelCharge",
+          "rank": 5
+        }
+      }
+    ],
+    "arcanes": [],
+    "shards": [],
+    "helminthAbility": null
+  }
+}`,
+  },
+  {
+    method: "PUT",
+    path: "/api/v1/builds/:slug",
+    summary: "Update a build you own. Same payload shape as create.",
+    example: `{ "name": "...", "build": { ... } }`,
+  },
+  {
+    method: "POST",
+    path: "/api/v1/imports/overframe",
+    summary:
+      "Import an Overframe build by URL. If nameOverride / description / guide are omitted, Arsenyx preserves the Overframe metadata. Explicit null clears nullable fields.",
+    example: `{
+  "url": "https://overframe.gg/build/935570/",
+  "visibility": "PUBLIC",
+  "nameOverride": null,
+  "description": null,
+  "guide": null
+}`,
+  },
+]
+
+const PUBLIC_ENDPOINTS: Endpoint[] = [
+  {
+    method: "GET",
+    path: "/builds",
+    summary:
+      "List public builds. Supports ?page, ?sort, ?q, ?category, ?hasGuide, ?hasShards.",
+    example: `{
+  "builds": [ { "slug": "...", "title": "...", "category": "warframe", ... } ],
+  "total": 1234,
+  "page": 1,
+  "limit": 24
+}`,
+  },
+  {
+    method: "GET",
+    path: "/builds/:slug",
+    summary: "Fetch a single public build by slug.",
+    example: `{
+  "slug": "...",
+  "title": "...",
+  "category": "warframe",
+  "items": [...],
+  "mods": [...],
+  "arcanes": [...]
+}`,
+  },
+  {
+    method: "GET",
+    path: "/orgs/public",
+    summary:
+      "Directory of all organizations. Paginated, with ?q for name/slug search.",
+    example: `{
+  "orgs": [
+    { "slug": "...", "name": "...", "memberCount": 12, "buildCount": 34, ... }
+  ],
+  "total": 7,
+  "page": 1,
+  "limit": 20
+}`,
+  },
+  {
+    method: "GET",
+    path: "/orgs/:slug",
+    summary: "Organization profile: members, description, public build count.",
+    example: `{
+  "slug": "...",
+  "name": "...",
+  "members": [ { "role": "ADMIN" | "MEMBER", "user": {...} } ],
+  "buildCount": 34
+}`,
+  },
+  {
+    method: "GET",
+    path: "/orgs/:slug/builds",
+    summary:
+      "Public builds authored under an organization. Same filters as /builds.",
+    example: `{
+  "builds": [...],
+  "total": 34,
+  "page": 1,
+  "limit": 24
+}`,
+  },
+]
+
+function DocsApiPage() {
+  return (
+    <div className="relative flex min-h-screen flex-col">
+      <Header />
+      <main className="wrap max-w-3xl flex-1 py-12">
+        <article className="prose prose-neutral dark:prose-invert max-w-none">
+          <div className="not-prose mb-6">
+            <Button
+              render={<Link href="/docs" />}
+              nativeButton={false}
+              variant="ghost"
+              size="sm"
+            >
+              <ArrowLeft data-icon="inline-start" />
+              Back to documentation
+            </Button>
+          </div>
+          <h1>API reference</h1>
+          <p className="lead">
+            HTTP endpoints for reading public data and publishing builds from a
+            script. For concepts (orgs, visibility, API keys), see the{" "}
+            <Link href="/docs">documentation overview</Link>.
+          </p>
+
+          <h2 id="public-read-api">Public read API</h2>
+          <p>
+            Base URL: <code>{EXTERNAL_LINKS.apiBase}</code>. Authentication is
+            cookie-based (Better Auth). The endpoints below are public and
+            read-only — no credentials required.
+          </p>
+          <ul className="not-prose flex list-none flex-col gap-4 pl-0">
+            {PUBLIC_ENDPOINTS.map((ep) => (
+              <li
+                key={`${ep.method} ${ep.path}`}
+                className="border-border bg-card flex flex-col gap-2 rounded-lg border p-4"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="bg-muted rounded px-2 py-0.5 font-mono text-xs font-semibold">
+                    {ep.method}
+                  </span>
+                  <code className="text-sm font-medium">{ep.path}</code>
+                </div>
+                <p className="text-muted-foreground text-sm">{ep.summary}</p>
+                <pre className="bg-muted/50 overflow-x-auto rounded p-3 text-xs leading-relaxed">
+                  <code>{ep.example}</code>
+                </pre>
+              </li>
+            ))}
+          </ul>
+          <p className="text-sm opacity-75">
+            Fields abbreviated. Responses are subject to change while Arsenyx is
+            in beta — pin to the commit you tested against.
+          </p>
+
+          <h2 id="authenticated-write-api">Authenticated write API</h2>
+          <p>
+            Arsenyx supports bearer-token build publishing, so you can push
+            builds from a script or bot instead of clicking through the editor.
+            Sign in, open the user menu, head to <strong>Settings</strong> →{" "}
+            <strong>API keys</strong>, create one with the{" "}
+            <code>build:write</code> scope, and send it as{" "}
+            <code>Authorization: Bearer &lt;key&gt;</code>.
+          </p>
+          <ul className="not-prose flex list-none flex-col gap-4 pl-0">
+            {WRITE_ENDPOINTS.map((ep) => (
+              <li
+                key={`${ep.method} ${ep.path}`}
+                className="border-border bg-card flex flex-col gap-2 rounded-lg border p-4"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="bg-muted rounded px-2 py-0.5 font-mono text-xs font-semibold">
+                    {ep.method}
+                  </span>
+                  <code className="text-sm font-medium">{ep.path}</code>
+                </div>
+                <p className="text-muted-foreground text-sm">{ep.summary}</p>
+                <pre className="bg-muted/50 overflow-x-auto rounded p-3 text-xs leading-relaxed">
+                  <code>{ep.example}</code>
+                </pre>
+              </li>
+            ))}
+          </ul>
+          <p className="text-sm opacity-75">
+            The server resolves canonical item / mod / arcane / shard data,
+            recomputes derived capacity and forma fields, and rejects invalid
+            writes with structured <code>4xx</code> JSON errors.
+          </p>
+
+          <h2 id="rate-limits">Rate limits</h2>
+          <p>
+            Requests are rate-limited per minute. Exceeding the limit returns{" "}
+            <code>429</code> with body{" "}
+            <code>{`{ "error": "rate_limited" }`}</code>. API keys and cookie
+            sessions are throttled differently.
+          </p>
+          <h3>API keys (bearer-token)</h3>
+          <p>
+            Each API key has a single per-key cap of{" "}
+            <strong>60 requests per minute</strong> by default, shared across
+            every endpoint. The cap is configurable per key — if a legitimate
+            workflow needs more, open an issue. Every response on the
+            authenticated path includes:
+          </p>
+          <ul>
+            <li>
+              <code>X-RateLimit-Limit</code> — the per-key cap currently in
+              effect.
+            </li>
+            <li>
+              <code>X-RateLimit-Remaining</code> — requests left in the current
+              minute window.
+            </li>
+            <li>
+              <code>X-RateLimit-Reset</code> — seconds until the window resets.
+            </li>
+            <li>
+              <code>Retry-After</code> — set on <code>429</code> responses;
+              seconds to wait before retrying.
+            </li>
+          </ul>
+          <h3>Cookie sessions (web app)</h3>
+          <p>
+            Traffic from the web app is bucketed by operation type, each bucket
+            with its own per-user per-minute cap:
+          </p>
+          <ul>
+            <li>
+              <strong>mutate</strong> — 20/min. Build create, update, delete,
+              and fork.
+            </li>
+            <li>
+              <strong>social</strong> — 60/min. Likes, bookmarks, and similar
+              cheap toggles.
+            </li>
+            <li>
+              <strong>import</strong> — 10/min. Overframe imports and other
+              endpoints that fetch from external services.
+            </li>
+            <li>
+              <strong>search</strong> — 60/min. Typeahead and full-text
+              endpoints.
+            </li>
+          </ul>
+          <p className="text-sm opacity-75">
+            Limits are best-effort across Cloudflare Workers isolates: brief
+            bursts can slip slightly over the cap before any isolate observes
+            it. They&apos;re tuned for abuse throttling, not policing normal
+            use.
+          </p>
+
+          <h2 id="game-data">Game data</h2>
+          <p>
+            Items, mods, and arcanes live as static JSON under{" "}
+            <code>apps/web/public/data/</code>. The index is generated from the{" "}
+            <Link
+              href={EXTERNAL_LINKS.wfcd}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Warframe Community Developers
+            </Link>{" "}
+            dataset and committed to the repo, so loading game data is a single
+            static fetch against the CDN — no API round-trip.
+          </p>
+
+          <h2>Source</h2>
+          <p>
+            Arsenyx is open source. Bug reports, feature requests, and pull
+            requests are all welcome on GitHub.
+          </p>
+          <div className="not-prose">
+            <Button
+              render={
+                <Link
+                  href={EXTERNAL_LINKS.github}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+              nativeButton={false}
+            >
+              <Icons.github data-icon="inline-start" />
+              View on GitHub
+            </Button>
+          </div>
+        </article>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -142,8 +142,10 @@ function Home() {
               detail="Builds encode into a short URL. Drop it in chat. The reader sees the full editor without signing in."
               demo={
                 <div className="bg-background rounded-md border px-3 py-2 font-mono text-xs">
-                  <span className="text-muted-foreground">arsenyx.com/b/</span>
-                  <span className="text-foreground">v0r-prime-tank</span>
+                  <span className="text-muted-foreground">
+                    arsenyx.com/builds/
+                  </span>
+                  <span className="text-foreground">k7mQp3rTx9</span>
                 </div>
               }
             />

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -2,11 +2,14 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
-import { SITE_CONFIG } from "@/lib/util/constants"
+import { Link } from "@/components/link"
+import { EXTERNAL_LINKS, SITE_CONFIG } from "@/lib/util/constants"
 
 export const Route = createFileRoute("/privacy")({
   component: PrivacyPage,
 })
+
+const LAST_UPDATED = "2026-05-26"
 
 function PrivacyPage() {
   return (
@@ -14,52 +17,117 @@ function PrivacyPage() {
       <Header />
       <main className="wrap max-w-3xl flex-1 py-12">
         <div className="flex flex-col gap-6">
-          <h1 className="text-4xl font-bold tracking-tight">Privacy Policy</h1>
-          <p className="text-muted-foreground">
-            Last updated: {new Date().toLocaleDateString()}
-          </p>
+          <h1 className="text-4xl font-bold tracking-tight">Privacy</h1>
+          <p className="text-muted-foreground">Last updated: {LAST_UPDATED}</p>
 
           <article className="prose prose-neutral dark:prose-invert max-w-none">
-            <h2>1. Information We Collect</h2>
             <p>
-              {SITE_CONFIG.name} is designed to be privacy-friendly. We minimize
-              the data we collect.
+              {SITE_CONFIG.name} is a free, open-source Warframe build planner
+              run by one person in the Netherlands. No company, no ads, no
+              analytics, no tracking. This page tells you what data the site has
+              on you and what you can do about it.
+            </p>
+
+            <h2>What we store</h2>
+            <p>
+              You can browse the site without an account. If you sign in with
+              GitHub, we store:
             </p>
             <ul>
               <li>
-                <strong>Authentication Data:</strong> If you sign in, we store
-                your basic profile information provided by the authentication
-                provider (e.g., GitHub, Discord).
+                Your GitHub profile fields (user ID, username, display name,
+                avatar URL, and the email address attached to your GitHub
+                account). We never see your GitHub password.
               </li>
               <li>
-                <strong>Usage Data:</strong> We may collect anonymous analytics
-                data to understand how our service is used and to improve it.
+                A session record so you stay signed in. It includes the IP
+                address and user-agent string of the device that signed in.
+                Sessions expire 7 days after their last use — each visit rolls
+                that expiry forward, so a continuously active session can last
+                indefinitely until you sign out or revoke it from settings.
               </li>
               <li>
-                <strong>User Content:</strong> Builds and guides you create and
-                save are stored in our database.
+                The OAuth access and refresh tokens that GitHub issues to us, so
+                we can keep your session refreshed. They live in the database
+                row associated with your account and are not exposed via any
+                API.
+              </li>
+              <li>
+                Whatever you create: builds, guides, votes, bookmarks,
+                organizations, and any API keys you generate. API keys are
+                stored as one-way hashes — we can&apos;t read them back.
               </li>
             </ul>
-
-            <h2>2. How We Use Your Information</h2>
             <p>
-              We use the collected information solely for providing and
-              improving the service. We do not sell your personal data to third
-              parties.
+              Cloudflare (hosting) and Neon (database, hosted in Frankfurt) may
+              also keep short-lived request logs containing IP addresses for the
+              purpose of detecting abuse and diagnosing outages.
             </p>
 
-            <h2>3. Cookies and Local Storage</h2>
+            <h2>What we don&apos;t do</h2>
             <p>
-              We use cookies and local storage to maintain your session and
-              store your preferences. These are essential for the functioning of
-              the application.
+              We don&apos;t use third-party analytics, advertising trackers,
+              fingerprinting, or A/B-testing. We don&apos;t sell or share your
+              data with anyone for marketing. The only cookies the site sets are
+              the ones Better Auth needs to keep you signed in: a session token
+              and a short-lived session-cache cookie. No tracking cookies, no
+              third-party cookies.
             </p>
 
-            <h2>4. Third-Party Services</h2>
+            <h2>Deleting your account</h2>
             <p>
-              Our service may use third-party services for authentication,
-              hosting, and analytics. Please review their respective privacy
-              policies for more information.
+              You can delete your account at any time from the settings dialog.
+              That permanently removes your account, all sessions, your API
+              keys, your votes, bookmarks and organization memberships, and
+              every build and guide you authored. Shared links to your builds
+              will return 404 afterwards. You can also export all your builds as
+              JSON from the same panel before deleting.
+            </p>
+            <p>
+              Residual copies in routine database backups age out within 30
+              days.
+            </p>
+
+            <h2>Your rights</h2>
+            <p>
+              Under the GDPR you can ask to see what data we hold on you,
+              correct it, delete it, or have it exported. You can do all of this
+              yourself from the settings dialog: edit your profile, export every
+              build as JSON, or delete your account outright. For anything you
+              can&apos;t resolve from settings, open an issue on the{" "}
+              <Link
+                href={EXTERNAL_LINKS.github}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub repository
+              </Link>{" "}
+              — if the request contains personal data you&apos;d rather not post
+              publicly, mark the issue title accordingly and the operator will
+              reply with a private channel. If you think we&apos;ve mishandled
+              your data and we can&apos;t resolve it together, you can complain
+              to the data protection authority in your country.
+            </p>
+
+            <h2>Open source</h2>
+            <p>
+              The code is on{" "}
+              <Link
+                href={EXTERNAL_LINKS.github}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub
+              </Link>{" "}
+              — if you want to see exactly what&apos;s stored and how, the
+              schema and API code are right there.
+            </p>
+
+            <h2>Changes</h2>
+            <p>
+              If this policy changes materially, the &ldquo;Last updated&rdquo;
+              date above will move and the commit will be visible in the public
+              repo.
             </p>
           </article>
         </div>

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -2,11 +2,14 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
-import { SITE_CONFIG } from "@/lib/util/constants"
+import { Link } from "@/components/link"
+import { EXTERNAL_LINKS, SITE_CONFIG } from "@/lib/util/constants"
 
 export const Route = createFileRoute("/terms")({
   component: TermsPage,
 })
+
+const LAST_UPDATED = "2026-05-26"
 
 function TermsPage() {
   return (
@@ -14,46 +17,96 @@ function TermsPage() {
       <Header />
       <main className="wrap max-w-3xl flex-1 py-12">
         <div className="flex flex-col gap-6">
-          <h1 className="text-4xl font-bold tracking-tight">
-            Terms of Service
-          </h1>
-          <p className="text-muted-foreground">
-            Last updated: {new Date().toLocaleDateString()}
-          </p>
+          <h1 className="text-4xl font-bold tracking-tight">Terms</h1>
+          <p className="text-muted-foreground">Last updated: {LAST_UPDATED}</p>
 
           <article className="prose prose-neutral dark:prose-invert max-w-none">
-            <h2>1. Acceptance of Terms</h2>
             <p>
-              By accessing and using {SITE_CONFIG.name}, you agree to be bound
-              by these Terms of Service. If you do not agree to these terms,
-              please do not use our services.
+              {SITE_CONFIG.name} is a free, open-source Warframe build planner
+              run by one person in the Netherlands. By using the site, you agree
+              to the following — if you don&apos;t, please don&apos;t use it.
             </p>
 
-            <h2>2. Use of Service</h2>
+            <h2>Use of the service</h2>
             <p>
-              {SITE_CONFIG.name} is an open-source Warframe build planner
-              provided &quot;as is&quot;. You agree to use this service only for
-              lawful purposes and in accordance with these Terms.
+              Browse all you want without an account. Signing in (via GitHub)
+              lets you create builds, vote, bookmark, and join organizations.
+              Don&apos;t use the service to do anything illegal, to post content
+              that infringes other people&apos;s rights or is
+              harassing/hateful/sexually explicit, or to abuse the API beyond
+              the rate limits documented at{" "}
+              <Link href="/docs/api#rate-limits">/docs/api#rate-limits</Link>.
+              We may remove content or suspend accounts that break those rules.
             </p>
 
-            <h2>3. User Content</h2>
+            <h2>Your content</h2>
             <p>
-              Users may create and share builds. By posting content, you grant
-              us a license to use, modify, publicly perform, publicly display,
-              reproduce, and distribute such content on and through the service.
-              You retain all of your ownership rights in your content.
+              Builds and guides you create are yours. When you publish a build
+              publicly, you give {SITE_CONFIG.name} permission to host and
+              display it, and you allow other users to view and fork it. That
+              permission ends when you make the build private or delete it
+              (apart from short-lived copies in database backups, which age out
+              within 30 days).
             </p>
 
-            <h2>4. Disclaimer</h2>
+            <h2>Warframe</h2>
             <p>
-              We are not affiliated with Digital Extremes. Warframe content and
-              materials are trademarks and copyrights of Digital Extremes or its
-              licensors.
+              {SITE_CONFIG.name} is not affiliated with Digital Extremes Ltd.{" "}
+              <i>Warframe</i> and everything in it — names, marks, art, game
+              data — belongs to Digital Extremes or its licensors. Game data
+              comes from the Warframe Community Developers project and is used
+              consistent with the{" "}
+              <Link
+                href="https://www.warframe.com/eula"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Warframe EULA
+              </Link>
+              .
             </p>
+
+            <h2>Open source</h2>
             <p>
-              The service is provided without warranties of any kind, whether
-              express or implied. We do not guarantee that the service will be
-              uninterrupted or error-free.
+              The source code is on{" "}
+              <Link
+                href={EXTERNAL_LINKS.github}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub
+              </Link>{" "}
+              under the MIT licence. That covers the code only — not user
+              content and not Warframe assets.
+            </p>
+
+            <h2>No warranties</h2>
+            <p>
+              The service is provided as-is. It might break, lose data, or
+              disappear; we&apos;ll do our best to avoid that, but we can&apos;t
+              promise it. Nothing here limits rights you have under mandatory
+              consumer-protection law in your country of residence within the
+              EU/EEA.
+            </p>
+
+            <h2>Ending things</h2>
+            <p>
+              You can delete your account from settings at any time — see the{" "}
+              <Link href="/privacy">Privacy</Link> page for what that does. If
+              the service is ever shut down, we&apos;ll give at least 30
+              days&apos; notice on the site so you can export your builds first.
+            </p>
+
+            <h2>Governing law</h2>
+            <p>
+              Dutch law applies, without prejudice to mandatory consumer rules
+              in your own EU/EEA country.
+            </p>
+
+            <h2>Changes</h2>
+            <p>
+              If these terms change, the &ldquo;Last updated&rdquo; date above
+              will move. The full history is visible in the public repo.
             </p>
           </article>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "arsenyx-monorepo",
   "private": true,
+  "license": "MIT",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
## Summary

- Split `/docs` in two: concepts at `/docs`, endpoint reference at `/docs/api`. A small `useEffect` forwards old hashes (`#public-api`, `#authenticated-write-api`, `#game-data`) to the new page.
- Rewrote `/privacy` and `/terms` to be short, plain English, and accurate to what the code actually does. Killed the `new Date().toLocaleDateString()` "Last updated" line that was moving on every page load.
- `/docs/api` now documents rate limits properly: API keys have a single per-key cap (60/min default, configurable), cookie sessions use the mutate/social/import/search buckets, response headers include `X-RateLimit-*` and `Retry-After`.
- Settings → Advanced delete dialog now matches what actually gets deleted (sessions, API keys, votes, bookmarks, org memberships, guides).
- Terminology: "API keys" everywhere instead of mixing "tokens" and "keys". Each key's per-minute limit shows in the settings row.
- Landing page demo URL was `/b/<slug>` (route doesn't exist) with an invalid slug — now `/builds/<10-char-nanoid>`. Closes [#158](https://github.com/Reuzehagel/arsenyx/issues/158).
- Added an MIT [LICENSE](LICENSE) so the README and ToS claim is actually backed by a file.

## Notes

- The new API page is `docs_.api.tsx` — trailing underscore is TanStack's "non-nested route" idiom, URL is still `/docs/api`.
- ToS names Dutch law; privacy says operator resides in NL and points at the AP. Change if you'd rather not.
- Privacy contact is GitHub Issues + settings self-service. An earlier draft used a `users.noreply.github.com` address, which doesn't accept inbound mail.
- Cookie disclosure mentions both cookies Better Auth sets when `cookieCache` is on ([auth.ts:209](apps/api/src/auth.ts#L209)).

## Test plan

- [x] `just check` passes
- [x] `/docs` shows concepts, `/docs/api` shows endpoints, "Back to documentation" works
- [x] `/docs#public-api` etc. redirect to the matching `/docs/api` section
- [x] `Last updated` shows `2026-05-26` and stays put on reload
- [x] Delete-account dialog text matches what's actually deleted
- [x] Each API key row shows `· N/min`
- [x] Landing card reads `arsenyx.com/builds/k7mQp3rTx9`
- [ ] GitHub sidebar shows the MIT badge after merge