### PR TITLE
Include mod target (compatName + type) in mod search

### DIFF
--- a/apps/web/src/components/build-editor/mod-search-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-search-grid.tsx
@@ -103,6 +103,10 @@ const STAT_ALIASES: ReadonlyArray<readonly [string, string[]]> = [
 function getSearchable(mod: Mod): string {
   const name = mod.name.toLowerCase()
   const desc = mod.description?.toLowerCase() ?? ""
+  // Mod target metadata: `compatName` is the weapon class ("Rifle",
+  // "Shotgun", "Polearm") and `type` is the slot category ("Primary Mod",
+  // "Stance"). Both are what users actually type — see issue #160.
+  const target = `${mod.compatName ?? ""} ${mod.type ?? ""}`.toLowerCase()
   const rawStats = mod.levelStats?.[mod.levelStats.length - 1]?.stats ?? []
   const combined = new Set<string>()
   for (const stat of rawStats) {
@@ -120,7 +124,7 @@ function getSearchable(mod: Mod): string {
   }
   const combinedStr = combined.size > 0 ? ` ${[...combined].join(" ")}` : ""
   const aliasStr = aliases.size > 0 ? ` ${[...aliases].join(" ")}` : ""
-  return `${name} ${desc} ${stats}${combinedStr}${aliasStr}`
+  return `${name} ${desc} ${target} ${stats}${combinedStr}${aliasStr}`
 }
 
 function cap(s: string): string {


### PR DESCRIPTION
Closes #160

Mod search now matches the weapon class (`compatName`: "Rifle", "Shotgun", "Polearm", …) and slot category (`type`: "Primary Mod", "Stance", …). Previously typing "shotgun" or "stance" returned nothing.

Verified in dev:
- `shotgun` on a Boar build → 90/101 matches (was ~0)
- `primary` on a Boar build → 11/101 matches (was ~0)
- `stance` on a Skana build → 58/194 matches (was ~0)