### PR TITLE
Cap weapon stat decimals to 2 on item detail

### DIFF
--- a/apps/web/src/components/item-detail/content.tsx
+++ b/apps/web/src/components/item-detail/content.tsx
@@ -210,7 +210,7 @@ function statsFor(item: DetailItem, category: BrowseCategory): Stat[] {
         label: "Crit x",
         value:
           item.criticalMultiplier !== undefined
-            ? `${item.criticalMultiplier}x`
+            ? `${formatStat(item.criticalMultiplier)}x`
             : undefined,
       },
       { label: "Status", value: formatPct(item.procChance) },
@@ -218,7 +218,7 @@ function statsFor(item: DetailItem, category: BrowseCategory): Stat[] {
         label: "Fire Rate",
         value:
           item.fireRate !== undefined
-            ? formatStat(item.fireRate, 3)
+            ? formatStat(item.fireRate)
             : undefined,
       },
       { label: "Magazine", value: item.magazineSize },

--- a/apps/web/src/components/item-detail/content.tsx
+++ b/apps/web/src/components/item-detail/content.tsx
@@ -217,9 +217,7 @@ function statsFor(item: DetailItem, category: BrowseCategory): Stat[] {
       {
         label: "Fire Rate",
         value:
-          item.fireRate !== undefined
-            ? formatStat(item.fireRate)
-            : undefined,
+          item.fireRate !== undefined ? formatStat(item.fireRate) : undefined,
       },
       { label: "Magazine", value: item.magazineSize },
       {


### PR DESCRIPTION
Crit multiplier was rendering the raw float (e.g. `2.5999999x`) and fire rate was forced to 3 decimals (`6.061`). Both now flow through `formatStat()` with its default 2-digit precision, so the Perigale Prime header reads `Crit x 2.6x` / `Fire Rate 6.06`.

### Changes
- [apps/web/src/components/item-detail/content.tsx](apps/web/src/components/item-detail/content.tsx): wrap `criticalMultiplier` in `formatStat()`; drop the `digits=3` override on `fireRate`.

No behavior change beyond display formatting; same helper already used for reload time.