### PR TITLE
Allow all profit-taker.com subdomains in frame-ancestors CSP

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -2,7 +2,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: frame-ancestors 'self' https://profit-taker.com https://testing.profit-taker.com
+  Content-Security-Policy: frame-ancestors 'self' https://profit-taker.com https://*.profit-taker.com
   Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 /index.html


### PR DESCRIPTION
Widened to `https://*.profit-taker.com`.