### PR TITLE
Update changelog through 2026-05-30

### DIFF
--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -13,6 +13,56 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-05-30",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Kitguns are now buildable, with a grip and loader component picker in the editor and viewer that mirrors the Zaw flow.",
+      },
+      {
+        type: "feat",
+        description:
+          "The mod picker gained a PvE / Conclave game-mode toggle and a working exilus filter, and the rarity, polarity, and game-mode filters now actually narrow the grid instead of just dimming.",
+      },
+      {
+        type: "feat",
+        description:
+          "Arch-guns now have a Space / Atmosphere toggle on item detail when both stat sets exist.",
+      },
+      {
+        type: "refactor",
+        description:
+          "Item, mod, and arcane images are now self-hosted and cached on the CDN, so they load faster and no longer break when upstream sources move.",
+      },
+      {
+        type: "refactor",
+        description:
+          "Saved builds now resolve their images from the live catalog at view time, so old builds self-heal instead of showing broken cards.",
+      },
+      {
+        type: "chore",
+        description:
+          "Game data is now sourced directly from the official Warframe export and the wiki, keeping items, mods, and arcanes more accurate and up to date.",
+      },
+      {
+        type: "fix",
+        description:
+          "Augment and modular arcane compatibility is now exact — augments only show on weapons and frames that can equip them, and Kitgun/Pax arcanes no longer appear on every primary and secondary.",
+      },
+      {
+        type: "fix",
+        description:
+          "Universal (any) polarity mods now grant their capacity bonus on every polarized slot, and trade-off auras like Power Donation report the correct stat changes.",
+      },
+      {
+        type: "fix",
+        description:
+          "The Plexus mod picker is populated again, Jade renders both of her aura slots, and the command palette no longer lists exalted weapons twice.",
+      },
+    ],
+  },
+  {
     date: "2026-05-27",
     changes: [
       {
@@ -28,6 +78,16 @@ const CHANGELOG: ChangelogEntry[] = [
         type: "fix",
         description:
           "Tome mods are restricted to the Grimoire and Noctua instead of showing up for every secondary.",
+      },
+      {
+        type: "fix",
+        description:
+          "Innate base elements now fold into the weapon's established element combinations instead of being counted separately.",
+      },
+      {
+        type: "fix",
+        description:
+          "Weapon stats on item detail pages are capped to two decimals instead of showing long fractions.",
       },
     ],
   },


### PR DESCRIPTION
## What

Adds a **2026-05-30** changelog entry for the data-pipeline-rewrite release (#176) and folds two post-changelog **2026-05-27** fixes into that day's existing entry.

### New 2026-05-30 entry
- **Kitguns are now buildable** — grip + loader component picker in the editor and viewer, mirroring the Zaw flow
- Mod picker: PvE / Conclave game-mode toggle, working exilus filter, and rarity/polarity/game-mode filters that narrow the grid instead of just dimming
- Space / Atmosphere toggle on arch-gun detail pages
- Item/mod/arcane images self-hosted and CDN-cached
- Saved builds resolve images from the live catalog at view time (old builds self-heal)
- Game data sourced directly from the official Warframe export + wiki
- Exact augment / modular-arcane compatibility; universal-polarity capacity + trade-off aura fixes; Plexus picker, Jade dual auras, and command-palette dedupe

### Folded into 2026-05-27
- Innate base elements fold into established element combinations
- Weapon stats capped to two decimals on item detail

## Why
The changelog had only been updated through 2026-05-27 (#171). These entries cover everything user-facing merged since.

## Notes for reviewers
- Content-only change to the `CHANGELOG` array in `changelog.tsx`; no rendering logic touched.
- Purely internal pieces of #176 (build-script rewrite, dead-code cleanup, CI/caching plumbing, dependency swaps) were intentionally omitted as not user-visible.
- Everything from #176 is grouped under its merge date (2026-05-30) even though the work spanned several days.
- `bun run typecheck` passes across web, api, shared, and scripts.
