### PR TITLE
Disambiguate dual-form kitguns in search and item builds

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -64,17 +64,16 @@ export function CommandPalette({
 
   const allItems = useMemo<ItemEntry[]>(() => {
     if (!items) return []
-    // Exalted weapons are intentionally dual-categorized in the catalog
-    // (e.g. Garuda Prime Talons appears in both "melee" and
-    // "exalted-weapons" so they surface in the Melee browse tab too).
-    // For the palette, collapse to one row per uniqueName and prefer the
-    // "Exalted" label — it's the more specific signal for the user.
+    // Dedupe by slug, not uniqueName: modular kitgun barrels (Catchmoon,
+    // Sporelacer, Vermisplicer, …) share a single uniqueName across their
+    // Primary and Secondary forms, but those are distinct browsable items
+    // with distinct slugs. slug is unique per catalog entry, so this keeps
+    // every form as its own row while still collapsing true duplicates.
     const byKey = new Map<string, ItemEntry>()
     for (const { id, label } of CATEGORIES) {
       for (const it of items[id] ?? []) {
-        const existing = byKey.get(it.uniqueName)
-        if (!existing || id === "exalted-weapons") {
-          byKey.set(it.uniqueName, { ...it, categoryLabel: label })
+        if (!byKey.has(it.slug)) {
+          byKey.set(it.slug, { ...it, categoryLabel: label })
         }
       }
     }
@@ -94,7 +93,7 @@ export function CommandPalette({
   }, [allItems, debouncedQuery])
 
   useEffect(() => {
-    setSelected(filteredItems[0] ? `item:${filteredItems[0].uniqueName}` : "")
+    setSelected(filteredItems[0] ? `item:${filteredItems[0].slug}` : "")
   }, [filteredItems])
 
   const go = (fn: () => void) => {
@@ -171,7 +170,7 @@ export function CommandPalette({
                     <CommandGroup heading="Popular items">
                       {filteredItems.map((item) => (
                         <ItemRow
-                          key={item.uniqueName}
+                          key={item.slug}
                           item={item}
                           onSelect={() =>
                             go(() =>
@@ -196,7 +195,7 @@ export function CommandPalette({
               <CommandGroup heading="Items">
                 {filteredItems.map((item) => (
                   <ItemRow
-                    key={item.uniqueName}
+                    key={item.slug}
                     item={item}
                     onSelect={() =>
                       go(() =>
@@ -247,7 +246,7 @@ function ItemRow({
 }) {
   return (
     <CommandItem
-      value={`item:${item.uniqueName}`}
+      value={`item:${item.slug}`}
       keywords={[item.name, item.displayClass ?? "", item.categoryLabel]}
       onSelect={onSelect}
     >

--- a/apps/web/src/components/item-detail/content.tsx
+++ b/apps/web/src/components/item-detail/content.tsx
@@ -137,7 +137,7 @@ export function ItemDetailContent({
               <ArrowRight className="size-3.5" />
             </RouterLink>
           </div>
-          <TopBuildsSection item={item} />
+          <TopBuildsSection item={item} category={category} />
         </section>
       </div>
     </TooltipProvider>

--- a/apps/web/src/components/item-detail/top-builds-section.tsx
+++ b/apps/web/src/components/item-detail/top-builds-section.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/builds/build-card"
 import { useBuildLayout } from "@/lib/hooks/use-build-layout"
 import { publicBuildsQuery } from "@/lib/queries/builds-list-query"
-import type { DetailItem } from "@/lib/warframe"
+import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 
 // Cards: flex-wrap with fixed-width tiles so a small number of builds (e.g. 2)
 // don't get stretched across the full row by `1fr` grid tracks. They align
@@ -18,12 +18,22 @@ const ROWS_CLASS = "flex flex-col gap-2"
 
 const TOP_BUILDS_LIMIT = 6
 
-export function TopBuildsSection({ item }: { item: DetailItem }) {
+export function TopBuildsSection({
+  item,
+  category,
+}: {
+  item: DetailItem
+  category: BrowseCategory
+}) {
   const { data, isLoading } = useQuery(
     publicBuildsQuery({
       page: 1,
       sort: "top",
       item: item.uniqueName,
+      // Modular kitgun barrels share one uniqueName across their Primary and
+      // Secondary forms, so itemUniqueName alone matches both. Pair it with the
+      // page's category so each form only shows its own builds.
+      category,
       limit: TOP_BUILDS_LIMIT,
     }),
   )


### PR DESCRIPTION
@
## What

Fixes two symptoms with the same root cause: modular kitgun barrels (Sporelacer, Catchmoon, Gaze, Rattleguts, Tombfinger, Vermisplicer) and Vinquibus share **one `uniqueName`** across their Primary and Secondary forms, while being distinct browsable items with their own `slug` and `category`. Two spots keyed off `uniqueName` and conflated the forms.

**1. Command palette only showed one form** — `command-palette.tsx` deduped search results by `uniqueName`, collapsing the two forms into a single row, and reused the non-unique `uniqueName` as the React `key` and cmdk selection `value`. Now dedupes and keys by `slug`, which is unique per catalog entry (verified: 0 slug collisions across categories). The old `uniqueName` dedup existed for dual-categorized exalted weapons, which no longer exist in the data.

**2. Item page showed the wrong forms builds** — the "Top community builds" query on the item detail page filtered by `itemUniqueName` only, so the Sporelacer (Primary) page surfaced Sporelacer (Secondary) builds and vice versa. Now passes the page `category` into the query; the APIs `runList` already ANDs `itemCategory` with `itemUniqueName`.

## Why

Both forms are legitimately separate items (different stats, slot, displayClass) that happen to reuse the same barrel part `uniqueName`. Search and per-item build lists must treat them independently.

## Verification

- `bun run typecheck` (web + api + shared + scripts) and `just fix` clean.
- Command palette now lists both "Sporelacer (Primary)" and "Sporelacer (Secondary)".
- Live API check: `?category=primary` → 0 builds; `?category=secondary` → 1 build ("Wand of The Sorceress - Sporelacer"), correctly scoped to each page.

## Reviewer notes

No schema or API changes — purely client-side query params and dedup keys. The fix also covers the other five dual-form kitguns and Vinquibus, not just Sporelacer.
@