### PR TITLE
Autosave editor drafts to localStorage with restore + reset

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -37,7 +37,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import { EditorHeader } from "@/components/create-editor/editor-header"
@@ -55,6 +55,13 @@ import {
   SYNTHETIC_VARIANT_ID,
   SYNTHETIC_VARIANT_LABEL,
 } from "@/lib/codec/build-codec-adapter"
+import {
+  clearEditorDraft,
+  loadEditorDraft,
+  saveEditorDraft,
+  serializeDraft,
+  type EditorDraftPayload,
+} from "@/lib/editor-draft"
 import { useHotkey } from "@/lib/hooks/hotkeys"
 import { consumeDraft } from "@/lib/import-draft"
 import { arcanesQuery } from "@/lib/queries/arcanes-query"
@@ -187,9 +194,28 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     }
     return null
   })
+  // Identity for the in-memory cache and the localStorage draft bucket.
+  // `buildSlug` for an existing build; item+category for a new one (the
+  // EditorShell isn't re-keyed on item change, but the lookup must still
+  // distinguish two consecutive new-build sessions on different items).
+  const storeKey = buildSlug ?? `__new_build__:${category}:${slug}`
+
+  // Autosaved draft restore. Only on a *fresh* mount — when there's no
+  // in-memory cache for this build (a variant-switch remount keeps the cache,
+  // so we must not re-restore or re-toast then) and nothing more explicit
+  // (share link, import) is already driving hydration.
+  const [localDraft] = useState<EditorDraftPayload | null>(() => {
+    if (shareEncoded || draftId) return null
+    if (cachedVariants && cachedVariants.key === storeKey) return null
+    return loadEditorDraft(storeKey)
+  })
+
   // Full normalized saved data (all variants intact); used when persisting.
   const savedDataAll: SavedBuildData = useMemo(() => {
     if (draft) return draft.data
+    // A restored draft overrides the saved build — that's the whole point.
+    // The "Draft restored" toast + reset control keep it from being haunted.
+    if (localDraft) return localDraft.buildData
     if (existingBuild)
       return normalizeBuildData(
         existingBuild.buildData,
@@ -201,6 +227,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     return {} as SavedBuildData
   }, [
     draft,
+    localDraft,
     existingBuild,
     shareHydrated,
     allMods,
@@ -211,13 +238,8 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   // Track the variants list as mutable state so add/duplicate/delete can
   // mutate it before save without round-tripping through the URL.
   // EditorShell is re-keyed on variant switch, which would normally reset
-  // useState. The module-level cache below preserves the in-progress
-  // variants array across those remounts (keyed by buildSlug, single
-  // entry — replaced when switching to a different build).
-  // Include `item` and `category` so two consecutive new-build sessions on
-  // different items don't share the same cache bucket (the EditorShell isn't
-  // re-keyed on item change, but the cache lookup must still distinguish).
-  const storeKey = buildSlug ?? `__new_build__:${category}:${slug}`
+  // useState. The module-level cache (keyed by storeKey) preserves the
+  // in-progress variants array across those remounts.
   const [variants, _setVariants] = useState<SavedVariant[]>(() => {
     if (cachedVariants && cachedVariants.key === storeKey) {
       return cachedVariants.data
@@ -348,11 +370,18 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   const [buildName, setBuildName] = useState(
     () =>
       cachedShared?.buildName ??
+      localDraft?.buildName ??
       existingBuild?.name ??
       draft?.buildName ??
       item.name,
   )
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving">("idle")
+  // Whether an autosaved draft is currently overriding the saved build. Seeded
+  // from storage (so it survives variant-switch remounts, where localDraft is
+  // intentionally null) and kept in sync by the autosave effect below.
+  const [hasDraft, setHasDraft] = useState(
+    () => localDraft !== null || loadEditorDraft(storeKey) !== null,
+  )
 
   const [visibility, setVisibility] = useState<PublishVisibility>(
     () => existingBuild?.visibility ?? "PUBLIC",
@@ -396,11 +425,18 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   }
 
   const [guideSummary, setGuideSummary] = useState(
-    () => cachedShared?.guideSummary ?? existingBuild?.guide?.summary ?? "",
+    () =>
+      cachedShared?.guideSummary ??
+      localDraft?.guideSummary ??
+      existingBuild?.guide?.summary ??
+      "",
   )
   const [guideDescription, setGuideDescription] = useState(
     () =>
-      cachedShared?.guideDescription ?? existingBuild?.guide?.description ?? "",
+      cachedShared?.guideDescription ??
+      localDraft?.guideDescription ??
+      existingBuild?.guide?.description ??
+      "",
   )
   // Scope of the GuideEditor — build-wide vs a specific variant. Resets
   // to "build" on EditorShell remount (variant switches) which keeps the
@@ -776,15 +812,6 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     setPublishDialogOpen(false)
     setSaveStatus("saving")
     try {
-      // Snapshot the active variant's current editor state, then merge
-      // back into the full variants array. Single-variant builds emit
-      // a v1-shape payload (no `variants` field) for backwards-compat;
-      // multi-variant builds emit both top-level (mirroring active for
-      // legacy clients) and the variants array.
-      const activeSnapshot = captureActiveSnapshot()
-      const nextVariants = variants.map((v, i) =>
-        i === clampedActiveIndex ? activeSnapshot : v,
-      )
       const body = {
         name: buildName.trim() || item.name,
         visibility: nextVisibility,
@@ -794,29 +821,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
         // images are re-resolved by uniqueName at render time (viewer via
         // image-map.json, editor via the catalog), so storing them just bloats
         // the row and rots across image-scheme changes.
-        buildData: stripPersistedImages({
-          version: 1,
-          slots: slots.placed,
-          formaPolarities: slots.formaPolarities,
-          arcanes: arcanes.placed,
-          shards,
-          hasReactor,
-          helminth,
-          zawComponents,
-          kitgunComponents,
-          lichBonusElement: lichBonusElement ?? undefined,
-          incarnonEnabled,
-          incarnonPerks,
-          deploymentContext,
-          // Emit `variants` whenever there's more than one OR the single
-          // remaining variant has a user-assigned label/id — otherwise the
-          // synthetic placeholder from getVariants() would silently
-          // overwrite the user's label after delete-down-to-one.
-          ...((nextVariants.length > 1 ||
-            !isSyntheticVariant(nextVariants[0])) && {
-            variants: nextVariants,
-          }),
-        }),
+        buildData: captureBuildData(),
         guide: {
           summary: guideSummary.trim() || null,
           description: guideDescription.trim() || null,
@@ -840,8 +845,10 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       })
       await queryClient.invalidateQueries({ queryKey: ["build", slug] })
       // Drop the in-memory variants cache so a follow-up edit re-hydrates
-      // from the persisted server state rather than stale local edits.
+      // from the persisted server state rather than stale local edits, and
+      // clear the autosaved draft — the saved state is now the source of truth.
       cachedVariants = null
+      clearEditorDraft(storeKey)
       toast.success(isUpdate ? "Build saved" : "Build published")
       navigate({ to: "/builds/$slug", params: { slug } })
     } catch (err) {
@@ -911,6 +918,123 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       guideDescription: existing?.guideDescription,
     }
   }
+
+  // The full persistable buildData for the current editor state, with the
+  // active variant's live edits folded back into the variants array. Shared
+  // by the save path and the autosave draft writer so the two can't drift.
+  const captureBuildData = (): SavedBuildData => {
+    const activeSnapshot = captureActiveSnapshot()
+    const nextVariants = variants.map((v, i) =>
+      i === clampedActiveIndex ? activeSnapshot : v,
+    )
+    return stripPersistedImages({
+      version: 1,
+      slots: slots.placed,
+      formaPolarities: slots.formaPolarities,
+      arcanes: arcanes.placed,
+      shards,
+      hasReactor,
+      helminth,
+      zawComponents,
+      kitgunComponents,
+      lichBonusElement: lichBonusElement ?? undefined,
+      incarnonEnabled,
+      incarnonPerks,
+      deploymentContext,
+      // Emit `variants` whenever there's more than one OR the single
+      // remaining variant has a user-assigned label/id — otherwise the
+      // synthetic placeholder from getVariants() would silently overwrite
+      // the user's label after delete-down-to-one.
+      ...((nextVariants.length > 1 || !isSyntheticVariant(nextVariants[0])) && {
+        variants: nextVariants,
+      }),
+    })
+  }
+
+  // ─── Autosave draft ─────────────────────────────────────────────────
+  // Debounce the full editor state to localStorage so a refresh doesn't wipe
+  // unsaved work. Skip the hydration render, and clear the draft when the
+  // state returns to its baseline (saved build, or pristine new build) so a
+  // reload doesn't resurrect a no-op "draft".
+  const draftBaselineRef = useRef<string | null>(null)
+  const draftInitializedRef = useRef(false)
+
+  useEffect(() => {
+    const payload: EditorDraftPayload = {
+      buildData: captureBuildData(),
+      buildName,
+      guideSummary,
+      guideDescription,
+    }
+    const snapshot = serializeDraft(payload)
+    if (!draftInitializedRef.current) {
+      draftInitializedRef.current = true
+      // A restored draft is already dirty vs the saved build — leave it in
+      // storage. Otherwise the mount state IS the baseline, so reverting back
+      // to it later should clear the draft.
+      if (localDraft === null) draftBaselineRef.current = snapshot
+      return
+    }
+    const handle = window.setTimeout(() => {
+      if (snapshot === draftBaselineRef.current) {
+        clearEditorDraft(storeKey)
+        setHasDraft(false)
+      } else {
+        saveEditorDraft(storeKey, payload)
+        setHasDraft(true)
+      }
+    }, 600)
+    return () => window.clearTimeout(handle)
+    // Re-run on any edit. captureBuildData/serializeDraft read the values
+    // below; listing them keeps the snapshot current without re-binding the
+    // helpers in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    buildName,
+    guideSummary,
+    guideDescription,
+    slots.placed,
+    slots.formaPolarities,
+    arcanes.placed,
+    shards,
+    hasReactor,
+    helminth,
+    zawComponents,
+    kitgunComponents,
+    lichBonusElement,
+    incarnonEnabled,
+    incarnonPerks,
+    deploymentContext,
+    variants,
+    clampedActiveIndex,
+  ])
+
+  // Clear the draft and reload so the editor re-hydrates from the saved build
+  // (or a blank new build). A reload is the simplest way to reset the live
+  // slot/arcane hooks, which only initialize at mount.
+  const resetToSaved = () => {
+    clearEditorDraft(storeKey)
+    resetEditorCache()
+    window.location.reload()
+  }
+
+  // Tell the user once, on the mount where we actually restored a draft, that
+  // their unsaved edits came back — with a one-click bail-out.
+  useEffect(() => {
+    if (localDraft === null) return
+    toast("Draft restored", {
+      // Stable id dedupes StrictMode's double-invoked mount effect (and any
+      // remount) into a single toast instead of stacking duplicates.
+      id: `draft-restored:${storeKey}`,
+      description: "Your unsaved edits from last time are back.",
+      action: {
+        label: isUpdate ? "Reset to saved" : "Discard",
+        onClick: resetToSaved,
+      },
+    })
+    // Fire once, for the restoring mount only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const newVariantId = () =>
     `v${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`
@@ -1018,6 +1142,14 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
         onSave={handleSaveClick}
         saveStatus={saveStatus}
         isSignedIn={!!session?.user}
+        draft={
+          hasDraft
+            ? {
+                label: isUpdate ? "Reset to saved" : "Discard draft",
+                onReset: resetToSaved,
+              }
+            : undefined
+        }
         settings={
           isUpdate
             ? { visibility, onEdit: () => setPublishDialogOpen(true) }

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -59,7 +59,6 @@ import {
   clearEditorDraft,
   loadEditorDraft,
   saveEditorDraft,
-  serializeDraft,
   type EditorDraftPayload,
 } from "@/lib/editor-draft"
 import { useHotkey } from "@/lib/hooks/hotkeys"
@@ -200,15 +199,19 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   // distinguish two consecutive new-build sessions on different items).
   const storeKey = buildSlug ?? `__new_build__:${category}:${slug}`
 
-  // Autosaved draft restore. Only on a *fresh* mount — when there's no
-  // in-memory cache for this build (a variant-switch remount keeps the cache,
-  // so we must not re-restore or re-toast then) and nothing more explicit
-  // (share link, import) is already driving hydration.
-  const [localDraft] = useState<EditorDraftPayload | null>(() => {
-    if (shareEncoded || draftId) return null
-    if (cachedVariants && cachedVariants.key === storeKey) return null
-    return loadEditorDraft(storeKey)
-  })
+  // Whether a draft exists on disk for this build, read once at mount. Null
+  // when a share link or import is driving hydration — we don't surface a
+  // stale draft as "active" in that case.
+  const [storedDraft] = useState<EditorDraftPayload | null>(() =>
+    shareEncoded || draftId ? null : loadEditorDraft(storeKey),
+  )
+  // Hydrate the editor from the draft only on a *fresh* mount. A variant-switch
+  // remount keeps the in-memory cache, so re-applying the draft (and re-firing
+  // the restore toast) would be wrong — but the draft still exists on disk, so
+  // `storedDraft` stays non-null to keep the badge visible.
+  const [localDraft] = useState<EditorDraftPayload | null>(() =>
+    cachedVariants && cachedVariants.key === storeKey ? null : storedDraft,
+  )
 
   // Full normalized saved data (all variants intact); used when persisting.
   const savedDataAll: SavedBuildData = useMemo(() => {
@@ -377,11 +380,9 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   )
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving">("idle")
   // Whether an autosaved draft is currently overriding the saved build. Seeded
-  // from storage (so it survives variant-switch remounts, where localDraft is
-  // intentionally null) and kept in sync by the autosave effect below.
-  const [hasDraft, setHasDraft] = useState(
-    () => localDraft !== null || loadEditorDraft(storeKey) !== null,
-  )
+  // from `storedDraft` (which survives variant-switch remounts, where
+  // localDraft is intentionally null) and kept in sync by the autosave effect.
+  const [hasDraft, setHasDraft] = useState(() => storedDraft !== null)
 
   const [visibility, setVisibility] = useState<PublishVisibility>(
     () => existingBuild?.visibility ?? "PUBLIC",
@@ -784,6 +785,10 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   }
 
   const handleSaveClick = () => {
+    // Guard re-entry: the Save button is disabled while saving, but the
+    // Ctrl/Cmd+S hotkey bypasses that, so a double-press could fire two
+    // concurrent saves (duplicate POST, double navigate/toast).
+    if (saveStatus === "saving") return
     if (!session?.user) {
       navigate({ to: "/auth/signin" })
       return
@@ -857,6 +862,9 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       // there's no longer a need for the inline error text in the header.
       setSaveStatus("idle")
       toast.error(apiErrorMessage(err, "Couldn't save the build"), {
+        // A failed save is important enough to stay until the user acts on it,
+        // rather than auto-dismissing after a few seconds.
+        duration: Infinity,
         action: {
           label: "Retry",
           onClick: () =>
@@ -953,41 +961,34 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
 
   // ─── Autosave draft ─────────────────────────────────────────────────
   // Debounce the full editor state to localStorage so a refresh doesn't wipe
-  // unsaved work. Skip the hydration render, and clear the draft when the
-  // state returns to its baseline (saved build, or pristine new build) so a
-  // reload doesn't resurrect a no-op "draft".
-  const draftBaselineRef = useRef<string | null>(null)
+  // unsaved work. The first run is the hydration render (no user edit yet), so
+  // skip it; after that, any change writes a draft. The draft is cleared on a
+  // successful save and by the explicit Reset/Discard control. We intentionally
+  // don't auto-clear on a manual revert-to-saved: that needed a baseline
+  // snapshot that was wrong after a variant-switch remount (it got re-seeded to
+  // the dirty state, so it could delete a live draft) — the visible badge plus
+  // Reset/Discard cover bailing out instead.
   const draftInitializedRef = useRef(false)
 
   useEffect(() => {
-    const payload: EditorDraftPayload = {
-      buildData: captureBuildData(),
-      buildName,
-      guideSummary,
-      guideDescription,
-    }
-    const snapshot = serializeDraft(payload)
     if (!draftInitializedRef.current) {
       draftInitializedRef.current = true
-      // A restored draft is already dirty vs the saved build — leave it in
-      // storage. Otherwise the mount state IS the baseline, so reverting back
-      // to it later should clear the draft.
-      if (localDraft === null) draftBaselineRef.current = snapshot
       return
     }
     const handle = window.setTimeout(() => {
-      if (snapshot === draftBaselineRef.current) {
-        clearEditorDraft(storeKey)
-        setHasDraft(false)
-      } else {
-        saveEditorDraft(storeKey, payload)
-        setHasDraft(true)
-      }
+      // Capture + serialize inside the debounce so a burst of edits costs one
+      // snapshot per idle window, not one per keystroke.
+      saveEditorDraft(storeKey, {
+        buildData: captureBuildData(),
+        buildName,
+        guideSummary,
+        guideDescription,
+      })
+      setHasDraft(true)
     }, 600)
     return () => window.clearTimeout(handle)
-    // Re-run on any edit. captureBuildData/serializeDraft read the values
-    // below; listing them keeps the snapshot current without re-binding the
-    // helpers in deps.
+    // Re-run on any edit. captureBuildData reads the values below; listing them
+    // keeps the snapshot current without re-binding the helper in deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     buildName,

--- a/apps/web/src/components/create-editor/editor-header.tsx
+++ b/apps/web/src/components/create-editor/editor-header.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react"
 
 import { type PublishVisibility } from "@/components/build-editor"
 import { EndoFormaBadges } from "@/components/endo-forma-badges"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Kbd } from "@/components/ui/kbd"
@@ -37,6 +38,7 @@ export function EditorHeader({
   onSave,
   saveStatus,
   isSignedIn,
+  draft,
   settings,
   onShare,
 }: {
@@ -53,6 +55,9 @@ export function EditorHeader({
   onSave: () => void
   saveStatus: "idle" | "saving"
   isSignedIn: boolean
+  /** Present when an autosaved draft is overriding the saved build. `label`
+   *  reads "Reset to saved" (existing build) or "Discard draft" (new). */
+  draft?: { label: string; onReset: () => void }
   settings?: { visibility: PublishVisibility; onEdit: () => void }
   onShare: () => void
 }) {
@@ -115,15 +120,38 @@ export function EditorHeader({
             <span className="text-muted-foreground text-sm">
               {item.name} · {categoryLabel}
             </span>
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
               <EndoFormaBadges
                 totalEndoCost={totalEndoCost}
                 formaCount={formaCount}
               />
+              {draft ? (
+                <span className="inline-flex items-center gap-1">
+                  <Badge
+                    variant="secondary"
+                    className="gap-1.5"
+                    title="Unsaved changes restored from a previous session"
+                  >
+                    <span
+                      className="size-1.5 rounded-full bg-amber-500"
+                      aria-hidden
+                    />
+                    Draft
+                  </Badge>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={draft.onReset}
+                    className="text-muted-foreground h-auto px-1.5 py-0.5 text-xs"
+                  >
+                    {draft.label}
+                  </Button>
+                </span>
+              ) : null}
             </div>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {settings && (
             <Button
               variant="outline"
@@ -161,6 +189,9 @@ export function EditorHeader({
             variant="outline"
             size="sm"
             nativeButton={false}
+            // Renders as an <a> (RouterLink), which browsers default to a
+            // pointer cursor — pin it to match the real <button> peers.
+            className="cursor-default"
             render={
               buildSlug ? (
                 <RouterLink to="/builds/$slug" params={{ slug: buildSlug }} />

--- a/apps/web/src/lib/editor-draft.ts
+++ b/apps/web/src/lib/editor-draft.ts
@@ -72,27 +72,3 @@ export function clearEditorDraft(storeKey: string): void {
     /* ignore */
   }
 }
-
-/**
- * Stable JSON for equality checks: sorts object keys and drops `undefined`
- * so two payloads with the same content but different key order or absent-vs-
- * undefined fields compare equal. Used to tell whether the live editor state
- * has drifted from a known baseline (the saved build / a pristine new build).
- */
-export function serializeDraft(payload: EditorDraftPayload): string {
-  return JSON.stringify(canonicalize(payload))
-}
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize)
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {}
-    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-      const v = (value as Record<string, unknown>)[k]
-      if (v === undefined) continue
-      out[k] = canonicalize(v)
-    }
-    return out
-  }
-  return value
-}

--- a/apps/web/src/lib/editor-draft.ts
+++ b/apps/web/src/lib/editor-draft.ts
@@ -1,0 +1,98 @@
+import type { SavedBuildData } from "@/lib/queries/build-query"
+
+/**
+ * Autosaved editor drafts in localStorage. Unsaved edits otherwise vanish on
+ * refresh — the only recovery was the share URL. A draft is keyed by the same
+ * `storeKey` the in-memory editor cache uses (`buildSlug` for an existing
+ * build, `__new_build__:<category>:<slug>` for a not-yet-saved one), so each
+ * build/new-build session gets its own bucket.
+ *
+ * The payload is the same `buildData` shape we persist on save, plus the
+ * build name and guide. Restoring just feeds it back through the editor's
+ * normal hydration path.
+ */
+
+const PREFIX = "arsenyx:editor-draft:"
+const VERSION = 1
+
+export type EditorDraftPayload = {
+  buildData: SavedBuildData
+  buildName: string
+  guideSummary: string
+  guideDescription: string
+}
+
+type StoredDraft = {
+  v: number
+  savedAt: number
+  payload: EditorDraftPayload
+}
+
+function keyFor(storeKey: string): string {
+  return `${PREFIX}${storeKey}`
+}
+
+export function loadEditorDraft(storeKey: string): EditorDraftPayload | null {
+  if (typeof window === "undefined") return null
+  try {
+    const raw = window.localStorage.getItem(keyFor(storeKey))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredDraft
+    if (parsed.v !== VERSION || !parsed.payload) {
+      // Stale schema — drop it rather than risk hydrating a shape the editor
+      // no longer understands.
+      window.localStorage.removeItem(keyFor(storeKey))
+      return null
+    }
+    return parsed.payload
+  } catch {
+    return null
+  }
+}
+
+export function saveEditorDraft(
+  storeKey: string,
+  payload: EditorDraftPayload,
+): void {
+  if (typeof window === "undefined") return
+  try {
+    const stored: StoredDraft = { v: VERSION, savedAt: Date.now(), payload }
+    window.localStorage.setItem(keyFor(storeKey), JSON.stringify(stored))
+  } catch {
+    // Quota or private-mode failures are non-fatal; the editor still works,
+    // it just won't survive a refresh.
+  }
+}
+
+export function clearEditorDraft(storeKey: string): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.removeItem(keyFor(storeKey))
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Stable JSON for equality checks: sorts object keys and drops `undefined`
+ * so two payloads with the same content but different key order or absent-vs-
+ * undefined fields compare equal. Used to tell whether the live editor state
+ * has drifted from a known baseline (the saved build / a pristine new build).
+ */
+export function serializeDraft(payload: EditorDraftPayload): string {
+  return JSON.stringify(canonicalize(payload))
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      const v = (value as Record<string, unknown>)[k]
+      if (v === undefined) continue
+      out[k] = canonicalize(v)
+    }
+    return out
+  }
+  return value
+}


### PR DESCRIPTION
Closes #183. (Supersedes #191, which GitHub auto-closed when the stacked base branch `feat/toast-sonner` was deleted on merge of #189 — same branch/commits, now rebased onto `main`.)

Unsaved editor edits vanished on refresh; the only recovery was the share URL. The full editor state (mods, forma, shards, helminth, multi-variant, name, guide) is now debounced to `localStorage`, keyed by build slug — or `item+category` for a not-yet-saved build.

- Open with a draft present → hydrate and show a "Draft restored" toast with a one-click bail-out (Reset to saved / Discard).
- A "Draft" badge + reset sits next to the endo/forma badges while a draft is active.
- Draft clears on a successful save and via the explicit Reset/Discard control.
- Variant-switch remounts don't re-trigger restore; share/import links take precedence.
- `captureBuildData()` is shared by the save path and the autosave writer.

Includes the code-review hardening: dropped the fragile baseline-compare (it could delete a live draft after a variant switch), moved capture+serialize inside the debounce, guarded Ctrl/Cmd+S against double-save, single gated draft read, and a persistent failed-save toast.
