### PR TITLE
Undo/redo in the build editor

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -96,8 +96,14 @@ import {
   type FullAutoFormaPlan,
 } from "./multi-variant-auto-forma"
 import { PublishDialog, type PublishVisibility } from "./publish-dialog"
-import { useArcaneSlots } from "./use-arcane-slots"
-import { useBuildSlots, slotKind } from "./use-build-slots"
+import { useArcaneSlots, type PlacedArcane } from "./use-arcane-slots"
+import {
+  useBuildSlots,
+  slotKind,
+  type PlacedMod,
+  type SlotId,
+} from "./use-build-slots"
+import { useEditorHistory } from "./use-editor-history"
 import { useSlotKeyboardNav } from "./use-keyboard-nav"
 
 // ─── In-memory editor cache ─────────────────────────────────────────────────
@@ -126,6 +132,36 @@ let cachedVariants: {
   data: SavedVariant[]
   shared?: SharedEditorOverrides
 } | null = null
+
+// One undo/redo step: the full mutable editor state for the active variant
+// plus the build-wide fields. Excludes the build name and guide prose (those
+// keep their native textarea undo) and the variants array / active index
+// (variant structure isn't undoable — a switch remounts and resets history).
+type EditorHistorySnapshot = {
+  placed: Partial<Record<SlotId, PlacedMod>>
+  formaPolarities: Partial<Record<SlotId, Polarity>>
+  arcanes: (PlacedArcane | null)[]
+  shards: (PlacedShard | null)[]
+  hasReactor: boolean
+  helminth: Record<number, HelminthAbility>
+  zawComponents: { grip: string; link: string } | undefined
+  kitgunComponents: KitgunComponents | undefined
+  lichBonusElement: LichBonusElement | null
+  incarnonEnabled: boolean
+  incarnonPerks: (string | null)[]
+  deploymentContext: DeploymentContext
+}
+
+// Field-wise reference equality. Sound because every snapshot field is a value
+// or an immutably-replaced reference — never mutated in place.
+function snapshotsEqual(
+  a: EditorHistorySnapshot,
+  b: EditorHistorySnapshot,
+): boolean {
+  return (Object.keys(a) as (keyof EditorHistorySnapshot)[]).every((k) =>
+    Object.is(a[k], b[k]),
+  )
+}
 
 export function resetEditorCache() {
   cachedVariants = null
@@ -574,6 +610,88 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       return { [i]: ab }
     })
   }
+
+  // ─── Undo / redo ────────────────────────────────────────────────────
+  // Reads the live editor state into a snapshot, and writes one back through
+  // every setter. The recording effect below feeds `commit`; the hotkeys and
+  // header buttons drive `undo`/`redo`.
+  const captureHistorySnapshot = (): EditorHistorySnapshot => ({
+    placed: slots.placed,
+    formaPolarities: slots.formaPolarities,
+    arcanes: arcanes.placed,
+    shards,
+    hasReactor,
+    helminth,
+    zawComponents,
+    kitgunComponents,
+    lichBonusElement,
+    incarnonEnabled,
+    incarnonPerks,
+    deploymentContext,
+  })
+
+  const applyHistorySnapshot = (s: EditorHistorySnapshot) => {
+    slots.setPlaced(s.placed)
+    slots.setFormaPolarities(s.formaPolarities)
+    arcanes.setPlaced(s.arcanes)
+    setShards(s.shards)
+    setHasReactor(s.hasReactor)
+    setHelminth(s.helminth)
+    setZawComponents(s.zawComponents)
+    setKitgunComponents(s.kitgunComponents)
+    setLichBonusElement(s.lichBonusElement)
+    setIncarnonEnabled(s.incarnonEnabled)
+    setIncarnonPerks(s.incarnonPerks)
+    setDeploymentContext(s.deploymentContext)
+  }
+
+  // Seed the baseline from the mount snapshot (lazy init runs once). Every
+  // field is an immutable value/reference owned by a setState, so a real edit
+  // always swaps at least one reference — a field-wise `Object.is` sweep tells
+  // a genuine change apart from a no-op re-record without deep-walking mods.
+  const [historyInitial] = useState(captureHistorySnapshot)
+  const history = useEditorHistory(
+    historyInitial,
+    applyHistorySnapshot,
+    snapshotsEqual,
+  )
+
+  // Record edits into history, debounced so a burst (held +/-, drag, rapid
+  // clicks) collapses to one undo step. Mirrors the autosave effect's dep list
+  // minus the text/structure fields the snapshot intentionally omits.
+  const historyInitializedRef = useRef(false)
+  useEffect(() => {
+    if (!historyInitializedRef.current) {
+      historyInitializedRef.current = true
+      return
+    }
+    const snapshot = captureHistorySnapshot()
+    // An undo/redo apply lands here too — consume it so it isn't re-recorded.
+    if (history.consumeApply(snapshot)) return
+    const handle = window.setTimeout(() => history.commit(snapshot), 500)
+    return () => window.clearTimeout(handle)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    slots.placed,
+    slots.formaPolarities,
+    arcanes.placed,
+    shards,
+    hasReactor,
+    helminth,
+    zawComponents,
+    kitgunComponents,
+    lichBonusElement,
+    incarnonEnabled,
+    incarnonPerks,
+    deploymentContext,
+  ])
+
+  // Ctrl/Cmd+Z undoes, Ctrl/Cmd+Shift+Z (or Ctrl+Y on Windows) redoes. Left to
+  // fire only outside text fields (allowInEditable defaults false), so the name
+  // and guide inputs keep their native per-keystroke undo.
+  useHotkey("mod+z", () => history.undo())
+  useHotkey("mod+shift+z", () => history.redo())
+  useHotkey("mod+y", () => history.redo())
 
   // Innates, endo/forma totals, capacity, and arcane picker config — same
   // computation for view (`/builds/$slug`) and edit (`/create`).
@@ -1143,6 +1261,12 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
         onSave={handleSaveClick}
         saveStatus={saveStatus}
         isSignedIn={!!session?.user}
+        history={{
+          canUndo: history.canUndo,
+          canRedo: history.canRedo,
+          onUndo: history.undo,
+          onRedo: history.redo,
+        }}
         draft={
           hasDraft
             ? {

--- a/apps/web/src/components/build-editor/use-arcane-slots.ts
+++ b/apps/web/src/components/build-editor/use-arcane-slots.ts
@@ -18,6 +18,8 @@ export interface ArcaneSlotsState {
   remove: (index: number) => void
   select: (index: number | null) => void
   setRank: (index: number, rank: number) => void
+  /** Replace the entire arcane array at once — used by undo/redo restore. */
+  setPlaced: (next: (PlacedArcane | null)[]) => void
 }
 
 export function useArcaneSlots(
@@ -92,6 +94,10 @@ export function useArcaneSlots(
     })
   }, [])
 
+  const setPlacedAll = useCallback((next: (PlacedArcane | null)[]) => {
+    setPlaced(next)
+  }, [])
+
   const usedNames = useMemo(
     () =>
       new Set(
@@ -109,5 +115,6 @@ export function useArcaneSlots(
     remove,
     select,
     setRank,
+    setPlaced: setPlacedAll,
   }
 }

--- a/apps/web/src/components/build-editor/use-build-slots.ts
+++ b/apps/web/src/components/build-editor/use-build-slots.ts
@@ -191,6 +191,12 @@ export interface BuildSlotsState {
    * setState queue, which made the in-between states briefly visible.
    */
   setPlaced: (next: Partial<Record<SlotId, PlacedMod>>) => void
+  /**
+   * Replace the entire forma map at once. Used by undo/redo to restore a
+   * snapshot's forma in a single commit — `setForma` is per-slot and would
+   * need N calls plus a way to clear stale keys.
+   */
+  setFormaPolarities: (next: Partial<Record<SlotId, Polarity>>) => void
 }
 
 export function useBuildSlots(
@@ -351,6 +357,13 @@ export function useBuildSlots(
     [],
   )
 
+  const setFormaPolaritiesAll = useCallback(
+    (next: Partial<Record<SlotId, Polarity>>) => {
+      setFormaPolarities(next)
+    },
+    [],
+  )
+
   return {
     placed,
     usedNames,
@@ -365,5 +378,6 @@ export function useBuildSlots(
     setForma,
     swap,
     setPlaced: setPlacedAll,
+    setFormaPolarities: setFormaPolaritiesAll,
   }
 }

--- a/apps/web/src/components/build-editor/use-editor-history.ts
+++ b/apps/web/src/components/build-editor/use-editor-history.ts
@@ -1,0 +1,110 @@
+import { useCallback, useReducer, useRef } from "react"
+
+/**
+ * Generic undo/redo stack for a single editor mount.
+ *
+ * The build editor spreads its state across the slot/arcane hooks and a dozen
+ * `useState`s, with no single source of truth — so history is modeled as full
+ * snapshots rather than a command log. The owner is responsible for two halves:
+ *
+ *   - `apply(snapshot)` — write a snapshot back into all the live setters.
+ *   - a debounced effect that calls `commit(currentSnapshot)` after edits.
+ *
+ * The effect must funnel restore-driven changes through `consumeApply` so an
+ * undo/redo doesn't get re-recorded as a brand-new edit (which would corrupt
+ * the stacks). Snapshots are scoped to one EditorShell mount — a variant switch
+ * remounts and starts fresh, which keeps cross-variant complexity out of here.
+ */
+
+const MAX_HISTORY = 100
+
+export interface EditorHistory<T> {
+  /**
+   * Record a new history point. Pushes the prior baseline onto the undo stack
+   * and clears the redo stack. The caller debounces this so a burst of edits
+   * collapses into a single undo step.
+   */
+  commit: (snapshot: T) => void
+  /**
+   * Reconcile a snapshot that arrived from `undo`/`redo`. Returns true (and
+   * swallows the change) when the snapshot is the one we just applied, so the
+   * recording effect can bail before scheduling a spurious commit.
+   */
+  consumeApply: (snapshot: T) => boolean
+  undo: () => void
+  redo: () => void
+  canUndo: boolean
+  canRedo: boolean
+}
+
+export function useEditorHistory<T>(
+  initial: T,
+  apply: (snapshot: T) => void,
+  /**
+   * Treat a commit whose snapshot equals the current baseline as a no-op and
+   * skip it. Guards against spurious entries — notably React StrictMode
+   * double-invoking the recording effect on mount, which would otherwise seed
+   * a phantom undo step before any real edit.
+   */
+  isEqual?: (a: T, b: T) => boolean,
+): EditorHistory<T> {
+  const past = useRef<T[]>([])
+  const future = useRef<T[]>([])
+  // The state the live editor currently reflects. Every commit/undo/redo keeps
+  // this in lock-step with what's on screen.
+  const baseline = useRef<T>(initial)
+  const applying = useRef(false)
+  // canUndo/canRedo derive from the ref stacks, so a render has to be forced
+  // when they change — the refs alone won't trigger one.
+  const [, bump] = useReducer((n: number) => n + 1, 0)
+
+  const isEqualRef = useRef(isEqual)
+  isEqualRef.current = isEqual
+
+  const commit = useCallback((snapshot: T) => {
+    if (isEqualRef.current?.(snapshot, baseline.current)) return
+    past.current.push(baseline.current)
+    if (past.current.length > MAX_HISTORY) past.current.shift()
+    future.current = []
+    baseline.current = snapshot
+    bump()
+  }, [])
+
+  const consumeApply = useCallback((snapshot: T) => {
+    if (!applying.current) return false
+    applying.current = false
+    baseline.current = snapshot
+    return true
+  }, [])
+
+  const undo = useCallback(() => {
+    if (past.current.length === 0) return
+    const prev = past.current.pop() as T
+    future.current.push(baseline.current)
+    baseline.current = prev
+    // Flag the restore so the recording effect skips it. Cleared synchronously
+    // by the next `consumeApply`, which the apply's re-render triggers.
+    applying.current = true
+    apply(prev)
+    bump()
+  }, [apply])
+
+  const redo = useCallback(() => {
+    if (future.current.length === 0) return
+    const next = future.current.pop() as T
+    past.current.push(baseline.current)
+    baseline.current = next
+    applying.current = true
+    apply(next)
+    bump()
+  }, [apply])
+
+  return {
+    commit,
+    consumeApply,
+    undo,
+    redo,
+    canUndo: past.current.length > 0,
+    canRedo: future.current.length > 0,
+  }
+}

--- a/apps/web/src/components/create-editor/editor-header.tsx
+++ b/apps/web/src/components/create-editor/editor-header.tsx
@@ -1,5 +1,13 @@
 import { Link as RouterLink } from "@tanstack/react-router"
-import { Pencil, Settings2, Share2, UploadCloud, X } from "lucide-react"
+import {
+  Pencil,
+  Redo2,
+  Settings2,
+  Share2,
+  Undo2,
+  UploadCloud,
+  X,
+} from "lucide-react"
 import { useRef, useState } from "react"
 
 import { type PublishVisibility } from "@/components/build-editor"
@@ -18,11 +26,12 @@ import {
 // Mac shows ⌘S; everything else shows Ctrl S. Computed once — the platform
 // doesn't change mid-session. The matching hotkey is registered in
 // editor-shell via useHotkey("mod+s").
-const SAVE_HINT =
+const IS_MAC =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad/.test(navigator.userAgent)
-    ? "⌘S"
-    : "Ctrl S"
+const SAVE_HINT = IS_MAC ? "⌘S" : "Ctrl S"
+const UNDO_HINT = IS_MAC ? "⌘Z" : "Ctrl Z"
+const REDO_HINT = IS_MAC ? "⌘⇧Z" : "Ctrl Shift Z"
 
 export function EditorHeader({
   item,
@@ -38,6 +47,7 @@ export function EditorHeader({
   onSave,
   saveStatus,
   isSignedIn,
+  history,
   draft,
   settings,
   onShare,
@@ -55,6 +65,13 @@ export function EditorHeader({
   onSave: () => void
   saveStatus: "idle" | "saving"
   isSignedIn: boolean
+  /** Undo/redo controls for the active variant's build state. */
+  history: {
+    canUndo: boolean
+    canRedo: boolean
+    onUndo: () => void
+    onRedo: () => void
+  }
   /** Present when an autosaved draft is overriding the saved build. `label`
    *  reads "Reset to saved" (existing build) or "Discard draft" (new). */
   draft?: { label: string; onReset: () => void }
@@ -152,6 +169,28 @@ export function EditorHeader({
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={history.onUndo}
+              disabled={!history.canUndo}
+              title={`Undo (${UNDO_HINT})`}
+              aria-label="Undo"
+            >
+              <Undo2 />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={history.onRedo}
+              disabled={!history.canRedo}
+              title={`Redo (${REDO_HINT})`}
+              aria-label="Redo"
+            >
+              <Redo2 />
+            </Button>
+          </div>
           {settings && (
             <Button
               variant="outline"

--- a/apps/web/src/lib/hooks/hotkeys.ts
+++ b/apps/web/src/lib/hooks/hotkeys.ts
@@ -48,6 +48,16 @@ export const HOTKEYS: readonly Hotkey[] = [
   },
   {
     scope: "Build editor",
+    keys: ["Ctrl Z", "⌘ Z"],
+    description: "Undo the last change",
+  },
+  {
+    scope: "Build editor",
+    keys: ["Ctrl Shift Z", "⌘ ⇧ Z"],
+    description: "Redo",
+  },
+  {
+    scope: "Build editor",
     keys: ["`"],
     description: "Select the first empty slot",
   },


### PR DESCRIPTION
Closes #184 (core), with one piece deferred (see below).

## What

Adds a per-variant undo/redo history to the build editor. Every mod drop, rank change, forma, and slot overwrite used to be immediate and unrecoverable — now `Ctrl/Cmd+Z` undoes and `Ctrl/Cmd+Shift+Z` (or `Ctrl+Y`) redoes, with discoverable undo/redo buttons in the header (disabled-state + shortcut tooltips) and entries in the `?` cheat sheet.

## How

- **`use-editor-history.ts`** — a generic past/future snapshot stack. The owner supplies `apply(snapshot)` (writes a snapshot back through the live setters) and feeds `commit()` from a debounced effect. An `applying` flag routes restore-driven state changes through `consumeApply` so an undo/redo doesn't get recorded as a fresh edit.
- **Snapshot scope** — the active variant's mods/arcanes/forma plus the build-wide fields (shards, reactor, helminth, zaw/kitgun, lich, incarnon, deployment context). Deliberately **excludes** the build name and guide prose (they keep native textarea undo) and the variants array / active index (variant structure isn't undoable — a switch remounts and resets history, which keeps cross-variant complexity out).
- **Bulk setters** added to the slot/arcane hooks (`setFormaPolarities`, `setPlaced`) so a snapshot restores in a single commit.
- **No-op guard** — a field-wise `Object.is` sweep skips commits that don't change anything, including React StrictMode's double-invoked mount effect (which would otherwise seed a phantom undo step at mount).
- Recording is debounced (500ms), so a burst of edits (held `+`/`-`, drag, rapid clicks) collapses into one undo step.

## Verified

In the browser preview: place mod → `11/60`, undo → `0/60` (reverted), redo → `11/60`; both buttons toggle their disabled states correctly; `Ctrl+Z` / `Ctrl+Shift+Z` drive the same path; undo is disabled at a clean mount. `bun run typecheck` + `just check` clean.

## Deferred: variant delete → toast-with-Undo

#184 also suggested replacing the variant Delete with an immediate-delete + Undo toast. I dropped that here, because while testing I confirmed a **pre-existing bug**: deleting a non-last *active* variant navigates to the same `?v`, so `EditorShell` (keyed on `${build}-${v}`) never remounts and the live hooks keep showing the deleted variant's mods under the next variant's label. A reliable Undo toast can't sit on top of a delete that already leaves stale state — that needs the remount/staleness fixed first. Flagging separately rather than shipping a fragile undo on a fragile delete.