### PR TITLE
Fix stale mod images after restoring an editor draft

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -218,7 +218,16 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     if (draft) return draft.data
     // A restored draft overrides the saved build — that's the whole point.
     // The "Draft restored" toast + reset control keep it from being haunted.
-    if (localDraft) return localDraft.buildData
+    // Normalize like a saved build: the draft persisted with mod/arcane
+    // `imageName` stripped (see stripPersistedImages), so re-resolve images
+    // from the catalog — otherwise restored mods render with a blank "?" tile.
+    if (localDraft)
+      return normalizeBuildData(
+        localDraft.buildData,
+        allMods,
+        allArcanes,
+        helminthAbilities,
+      )
     if (existingBuild)
       return normalizeBuildData(
         existingBuild.buildData,


### PR DESCRIPTION
## The bug

Place a mod, then refresh: the mod comes back with a blank `?` tile, even though its stats and everything else are intact. Reported with a screenshot of a restored Archon Vitality showing the placeholder image.

## Why

Autosaved drafts persist with mod/arcane `imageName` stripped (`stripPersistedImages`, the same treatment saved builds get — images are re-resolved at render time to avoid bloating storage and rotting across image-scheme changes). Saved builds run through `normalizeBuildData` on load, which re-attaches images from the catalog by `uniqueName`. The draft restore path returned `localDraft.buildData` **raw**, so the stripped images were never re-resolved.

Confirmed in the preview: the persisted draft stores the placed mod with no `imageName`, and before this fix the restored card's artwork `<img>` had no real src.

## The fix

Run the draft's `buildData` through `normalizeBuildData` (with the loaded mod/arcane/helminth catalogs) just like an existing build. It's idempotent for the non-image fields and re-resolves images by `uniqueName`.

Verified: after the fix, the restored Vitality card loads its real artwork (`HealthMaxMod-….jpg`) instead of the placeholder. `bun run typecheck` + `just check` clean, no console errors.