### PR TITLE
Fix stale editor state after deleting a non-last variant

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -131,6 +131,37 @@ export function resetEditorCache() {
   cachedVariants = null
 }
 
+// ─── Variant structural epoch ───────────────────────────────────────────────
+//
+// EditorShell is re-keyed on `${build}-${v}` (see create.tsx) so the
+// per-variant hooks re-initialize from the projected variant on a switch. But
+// `?v` is an *index*, and deleting a non-last active variant slides the next
+// variant into that same index — `?v` is unchanged, no remount fires, and the
+// slot/arcane hooks keep showing the deleted variant's data.
+//
+// This monotonic counter closes that gap: structural mutations (add / delete /
+// duplicate) bump it, CreatePage subscribes via useSyncExternalStore and folds
+// it into the key, so any structural change forces a clean remount regardless
+// of whether the index moved. A module-level store (not React state) because
+// the value has to be readable by CreatePage, which is a sibling above the
+// component that mutates it.
+let variantEpoch = 0
+const variantEpochListeners = new Set<() => void>()
+
+export function subscribeVariantEpoch(onChange: () => void): () => void {
+  variantEpochListeners.add(onChange)
+  return () => variantEpochListeners.delete(onChange)
+}
+
+export function getVariantEpoch(): number {
+  return variantEpoch
+}
+
+function bumpVariantEpoch() {
+  variantEpoch += 1
+  for (const listener of variantEpochListeners) listener()
+}
+
 export interface EditorShellSearch {
   item: string
   category: BrowseCategory
@@ -1078,6 +1109,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       search: (s) => ({ ...s, v: next.length - 1 }),
       replace: true,
     })
+    bumpVariantEpoch()
   }
 
   const duplicateActive = () => {
@@ -1099,6 +1131,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       search: (s) => ({ ...s, v: insertAt === 0 ? undefined : insertAt }),
       replace: true,
     })
+    bumpVariantEpoch()
   }
 
   const deleteActive = () => {
@@ -1115,6 +1148,10 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       }),
       replace: true,
     })
+    // Deleting a non-last active variant keeps `?v` unchanged (the next
+    // variant slides into this index), so the navigate alone won't remount.
+    // Bump the epoch to force the re-hydration regardless.
+    bumpVariantEpoch()
   }
 
   const renameActive = (label: string) => {

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -9,7 +9,9 @@ export { BuildSurface, type BuildSurfaceProps } from "./build-surface"
 export { DragController } from "./drag-controller"
 export {
   EditorShell,
+  getVariantEpoch,
   resetEditorCache,
+  subscribeVariantEpoch,
   type EditorShellSearch,
 } from "./editor-shell"
 export { EditorVariantBar } from "./editor-variant-bar"

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -4,11 +4,13 @@ import {
   MAX_VARIANT_PARSE_INDEX,
 } from "@arsenyx/shared/warframe/build-doc"
 import { createFileRoute, redirect } from "@tanstack/react-router"
-import { Suspense, useEffect } from "react"
+import { Suspense, useEffect, useSyncExternalStore } from "react"
 
 import {
   EditorShell,
+  getVariantEpoch,
   resetEditorCache,
+  subscribeVariantEpoch,
   type EditorShellSearch,
 } from "@/components/build-editor"
 import { Footer } from "@/components/footer"
@@ -97,7 +99,16 @@ function CreatePage() {
   // variant's data. Cheaper than extracting + threading callbacks for
   // every per-variant setter through every subcomponent.
   const search = Route.useSearch()
-  const variantKey = `${search.build ?? "new"}-${search.v ?? 0}`
+  // `?v` is a variant *index*; deleting a non-last active variant leaves it
+  // unchanged while the variant at that index changes. The epoch advances on
+  // every structural variant mutation, so folding it into the key forces a
+  // remount + re-hydration even when the index doesn't move.
+  const variantEpoch = useSyncExternalStore(
+    subscribeVariantEpoch,
+    getVariantEpoch,
+    getVariantEpoch,
+  )
+  const variantKey = `${search.build ?? "new"}-${search.v ?? 0}-${variantEpoch}`
   // Drop the in-memory editor cache on every navigation away from
   // /create (Cancel, route change). Without this, an unsaved variant
   // added before Cancel would silently re-appear next time the user


### PR DESCRIPTION
## The bug

Repro: `/create?item=equinox&category=warframes` → place a mod in Main, add Variant 2 and place a different mod in it, add Variant 3, switch to Variant 2 and delete it. The tab bar correctly switches active to "Variant 3" (blank), but the editor surface keeps showing Variant 2's mods and capacity.

## Why

`EditorShell` is re-keyed on `${build}-${v}` (`create.tsx`) so the per-variant hooks (`useBuildSlots`/`useArcaneSlots`) and the `[]`-deps `savedData` memo re-initialize on a variant switch. But `?v` is an *index*. Deleting a non-last active variant slides the next variant into that same index, so `?v` is unchanged → no key change → no remount → the hooks keep the deleted variant's data.

(`switchVariant` early-returns on the same index, and `addVariant`/`duplicateActive` always navigate to a new index, so delete is the one that hits this. But the fix covers all structural mutations so it can't resurface.)

## The fix

A monotonic **variant epoch**, bumped on every structural mutation (add / duplicate / delete). `CreatePage` reads it via `useSyncExternalStore` and folds it into the EditorShell key, so a structural change forces a clean remount + re-hydration even when the index doesn't move. It's a module-level store rather than React state because the value has to be read by `CreatePage` — a sibling above the component that mutates it, which therefore can't observe the change through props or normal re-renders.

Chose this over (a) a transient URL epoch param (pollutes/leaks into shared links) and (b) extracting the per-variant render into a child keyed by variant id (a large, risky refactor of a 1300-line component for the same end result).

## Verified

- Repro: deleting the middle active variant now shows the now-active variant's state (`0/60` blank), not the deleted one's (`14/60`).
- Non-regression: switching variants shows correct per-variant capacities; deleting the last variant lands on the previous one and collapses the bar to single-variant.
- `bun run typecheck` + `just check` clean, no console errors.

Unblocks the deferred "delete variant → toast with Undo" idea from #184 (the toast can now restore reliably because delete re-hydrates cleanly). Independent of PR #193 (undo/redo) and PR #194 (draft images); merges in any order.