### PR TITLE
Explain why a mod is incompatible in the search grid

### DIFF
--- a/apps/web/src/components/build-editor/mod-search-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-search-grid.tsx
@@ -28,6 +28,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { useHotkey } from "@/lib/hooks/hotkeys"
 import {
   BASE_ELEMENTS,
@@ -184,6 +189,28 @@ function slotKindPredicate(kind: ModSlotKind | undefined) {
   if (kind === "aura") return (m: Mod) => isAuraMod(m)
   if (kind === "stance") return (m: Mod) => isStanceMod(m)
   return (m: Mod) => !isAuraMod(m) && !isStanceMod(m) && isExilusCompatible(m)
+}
+
+const SLOT_KIND_REASON: Record<"aura" | "stance" | "exilus", string> = {
+  aura: "Only aura mods fit the aura slot",
+  stance: "Only stance mods fit the stance slot",
+  exilus: "Only exilus mods fit the exilus slot",
+}
+
+// Why a card is dimmed, for the hover tooltip. Returns null for a normal match
+// and — deliberately — for a card dimmed only because it doesn't match the
+// search query: that's the user's own filter, so it needs no explanation.
+// "Already equipped" wins over the slot-kind reason; it's the more actionable
+// thing to tell someone hunting for a mod they can't find.
+function incompatibilityReason(
+  mod: Mod,
+  kind: ModSlotKind | undefined,
+  isUsed: boolean,
+): string | null {
+  if (isUsed) return "Already equipped in this build"
+  if (!kind || kind === "normal") return null
+  const pred = slotKindPredicate(kind)
+  return pred && !pred(mod) ? SLOT_KIND_REASON[kind] : null
 }
 
 export function ModSearchGrid({
@@ -517,6 +544,7 @@ export function ModSearchGrid({
               isMatch={isMatch}
               isUsed={isUsed}
               isFocusable={isFocusable}
+              reason={incompatibilityReason(mod, selectedSlotKind, isUsed)}
               draggable={!!onSelect}
               registerRef={registerCardRef}
               onSelect={cellOnSelect}
@@ -534,6 +562,8 @@ interface PoolCardCellProps {
   isMatch: boolean
   isUsed: boolean
   isFocusable: boolean
+  /** When set, the card is dimmed for this reason; surfaced via a tooltip. */
+  reason: string | null
   draggable: boolean
   registerRef: (uniqueName: string, el: HTMLDivElement | null) => void
   onSelect?: (mod: Mod) => void
@@ -545,6 +575,7 @@ const PoolCardCell = memo(function PoolCardCell({
   isMatch,
   isUsed,
   isFocusable,
+  reason,
   draggable,
   registerRef,
   onSelect,
@@ -571,7 +602,7 @@ const PoolCardCell = memo(function PoolCardCell({
     },
     [startDrag, draggable, isFocusable, mod],
   )
-  return (
+  const cell = (
     <div
       ref={setRef}
       tabIndex={-1}
@@ -601,5 +632,16 @@ const PoolCardCell = memo(function PoolCardCell({
         )}
       />
     </div>
+  )
+
+  // Only dimmed-for-a-reason cards carry a tooltip. Plain matches and
+  // search-only non-matches stay tooltip-free, so the common browsing case
+  // mounts zero tooltip roots.
+  if (!reason) return cell
+  return (
+    <Tooltip>
+      <TooltipTrigger render={cell} />
+      <TooltipContent>{reason}</TooltipContent>
+    </Tooltip>
   )
 })


### PR DESCRIPTION
Closes #185.

Incompatible mods just dimmed in the pool with no reason given. Now hovering a dimmed card explains why, for the two cases that are real incompatibilities:

- **Already equipped in this build**
- **Wrong slot kind** — when an aura / stance / exilus slot is selected, mods that do not fit it say so ("Only exilus mods fit the exilus slot", etc.). The exilus case is the one that actually teaches something, since it is not obvious which mods are exilus-compatible.

`"Already equipped"` takes precedence over the slot-kind reason — it is the more useful thing to surface to someone hunting for a mod they cannot find.

### What it does not do

Cards dimmed *only* because they do not match the search query stay tooltip-free. That dimming is the user's own filter, so a "why" there would just be noise.

### Performance

Only cards that have a reason mount a tooltip. The common case — browsing with no slot selected and no query — adds zero tooltip roots, so the existing memoized-cell behavior (which keeps ~200 pool cards from re-rendering mid-drag) is untouched.

### Verification

Tested in the browser on `/create?item=excalibur&category=warframes`:

- Select the exilus slot → the ~112 dimmed non-exilus cards show "Only exilus mods fit the exilus slot" on hover.
- Place a mod, re-open the pool → its grayed card shows "Already equipped in this build", and the slot-kind reason does not leak through.
- Type a search query with no slot selected → dimmed non-matches show no tooltip.

`bun run typecheck` and `just check` are clean.