### PR TITLE
Show the aura slot for frames with no innate aura polarity

### DIFF
--- a/apps/web/src/components/build-editor/layout.test.ts
+++ b/apps/web/src/components/build-editor/layout.test.ts
@@ -6,6 +6,7 @@ import type { DetailItem } from "@/lib/warframe"
 import {
   getArcaneSlotConfig,
   getArcaneSlotCount,
+  getAuraSlotCount,
   resolveInitialArcanes,
 } from "./layout"
 import type { PlacedArcane } from "./use-arcane-slots"
@@ -71,6 +72,32 @@ describe("resolveInitialArcanes — kitgun re-bucketing", () => {
   it("leaves non-modular weapons' saved order untouched", () => {
     const saved = [placed(arc("Cascadia Flare", "Secondary"))]
     expect(resolveInitialArcanes(NORMAL_PISTOL, saved)).toBe(saved)
+  })
+})
+
+describe("getAuraSlotCount", () => {
+  it("gives a warframe one aura slot even when the innate polarity is null", () => {
+    // Excalibur / Nekros / Sevagoth ship with no default aura polarity but
+    // still have the slot in-game.
+    expect(getAuraSlotCount("warframes", { auraPolarity: null })).toBe(1)
+  })
+
+  it("gives a warframe one aura slot for a single innate polarity", () => {
+    expect(getAuraSlotCount("warframes", { auraPolarity: "madurai" })).toBe(1)
+  })
+
+  it("matches the slot count to a multi-aura array (Jade: 2)", () => {
+    expect(
+      getAuraSlotCount("warframes", { auraPolarity: ["naramon", "vazarin"] }),
+    ).toBe(2)
+  })
+
+  it("gives non-warframe categories no aura slot", () => {
+    expect(getAuraSlotCount("primary", { auraPolarity: null })).toBe(0)
+  })
+
+  it("gives railjack its single Plexus aura slot", () => {
+    expect(getAuraSlotCount("railjack", { auraPolarity: null })).toBe(1)
   })
 })
 

--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -190,9 +190,11 @@ export function hasStanceSlot(
 }
 
 /**
- * Number of Aura slots for an item. Warframes derive from
- * `item.auraPolarity` — an array means multiple aura slots (Jade: 2).
- * Companions and other categories have none.
+ * Number of Aura slots for an item. Every warframe has at least one aura slot;
+ * `item.auraPolarity` only carries the *innate* polarity of that slot, which
+ * can be null (a frame with no default aura polarity — the slot still exists,
+ * accepts any aura mod, and costs full drain). An array means multiple aura
+ * slots (Jade: 2). Companions and other categories have none.
  */
 export function getAuraSlotCount(
   category: BrowseCategory,
@@ -204,8 +206,13 @@ export function getAuraSlotCount(
   // capacity math reuses `auraBonusForMod` without changes.
   if (category === "railjack") return 1
   if (category !== "warframes") return 0
+  // The slot's existence must NOT depend on a known innate polarity — a few
+  // frames (Excalibur, Nekros, Sevagoth) ship with `auraPolarity: null` yet
+  // still have an aura slot in-game. Only a multi-slot array overrides the
+  // default of one slot. `getAuraPolarities` pads missing indices with
+  // `undefined`, so a null-polarity slot renders without an innate icon.
   if (Array.isArray(item.auraPolarity)) return item.auraPolarity.length
-  return item.auraPolarity ? 1 : 0
+  return 1
 }
 
 // =============================================================================


### PR DESCRIPTION
### The bug

Excalibur (and Nekros, Sevagoth, and their Primes) rendered in the editor with **no aura slot at all**. Five of 115 warframes are affected.

### Cause

`getAuraSlotCount` tied the slot's *existence* to `item.auraPolarity`:

```ts
return item.auraPolarity ? 1 : 0
```

Those five frames ship with `auraPolarity: null` in the generated data, so they got zero aura slots. But `auraPolarity` only describes the slot's *innate* polarity, which can legitimately be null — the slot still exists in-game, accepts any aura mod, and costs full drain.

### Fix

Decouple the count from the polarity. A warframe always gets one aura slot; an array still drives multi-aura frames (Jade: 2). `getAuraPolarities` already pads missing indices with `undefined`, so a null-polarity slot renders without an innate icon and behaves normally.

### Verification

In the browser:

- **Excalibur** (`auraPolarity: null`) now shows the aura slot (no innate icon). Selecting it floats aura mods; placing Aerodynamic raised max capacity 60 → 67 with no NaN.
- **Rhino** (`auraPolarity: "madurai"`) — non-regression: still one aura slot, still shows the madurai innate icon.

Added five `getAuraSlotCount` unit tests (null / single / multi-aura array / non-warframe / railjack). `bun run typecheck`, `just check`, and the layout tests all pass.

### Follow-up (separate)

The underlying data is also worth a look: these five frames coming back `auraPolarity: null` from the wiki merge (`scripts/build/merge-frames.ts`) may be a name-match or source gap, since at least some of them have an innate aura polarity in-game. This PR makes the editor tolerant either way; correcting the data is a separate pipeline change.