### PR TITLE
Real empty states for build lists

### DIFF
--- a/apps/web/src/components/builds/builds-empty-state.tsx
+++ b/apps/web/src/components/builds/builds-empty-state.tsx
@@ -1,0 +1,42 @@
+import type { LucideIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+
+/**
+ * Shared empty state for the build-list pages (My Builds, Bookmarks,
+ * Community). Wraps the shadcn `Empty` primitives so every list shows the
+ * same illustration-plus-CTA shape instead of a bare line of text.
+ */
+export function BuildsEmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: {
+  icon: LucideIcon
+  title: string
+  description: ReactNode
+  /** Optional CTA, e.g. a "Create your first build" button. */
+  action?: ReactNode
+}) {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Icon />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+      {action ? <EmptyContent>{action}</EmptyContent> : null}
+    </Empty>
+  )
+}

--- a/apps/web/src/components/builds/builds-list-view.tsx
+++ b/apps/web/src/components/builds/builds-list-view.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import { SearchX } from "lucide-react"
 import { useCallback, useEffect, useState, type ReactNode } from "react"
 
 import {
@@ -8,6 +9,7 @@ import {
   BuildRowSkeleton,
 } from "@/components/builds/build-card"
 import { BuildsCategoryTabs } from "@/components/builds/builds-category-tabs"
+import { BuildsEmptyState } from "@/components/builds/builds-empty-state"
 import { BuildsSortDropdown } from "@/components/builds/builds-sort-dropdown"
 import {
   BuildsLayoutToggle,
@@ -184,6 +186,10 @@ export function BuildsListView({
   }, [qLocal, q, patch])
 
   const activeFilterCount = (hasGuide ? 1 : 0) + (hasShards ? 1 : 0)
+  // A search, category tab, or toggle is narrowing the list. Zero results then
+  // means "nothing matched", not "this list is empty" — so the route's own
+  // empty state (its create-a-build CTA) shouldn't show.
+  const isFiltered = Boolean(q) || Boolean(category) || hasGuide || hasShards
 
   return (
     <div className="flex flex-col gap-6">
@@ -252,6 +258,7 @@ export function BuildsListView({
         query={query}
         page={page}
         q={q}
+        isFiltered={isFiltered}
         onPage={(p) => patch({ page: p > 1 ? p : undefined })}
         emptyState={emptyState}
       />
@@ -263,12 +270,14 @@ function Results({
   query,
   page,
   q,
+  isFiltered,
   onPage,
   emptyState,
 }: {
   query: BuildsQuery
   page: number
   q: string
+  isFiltered: boolean
   onPage: (p: number) => void
   emptyState: ReactNode
 }) {
@@ -287,7 +296,17 @@ function Results({
       </div>
 
       {data.builds.length === 0 ? (
-        <div className="py-16 text-center">{emptyState}</div>
+        <div className="py-16">
+          {isFiltered ? (
+            <BuildsEmptyState
+              icon={SearchX}
+              title="No builds match"
+              description="Try a different search, or clear your filters."
+            />
+          ) : (
+            emptyState
+          )}
+        </div>
       ) : (
         <div
           aria-busy={isFetching}

--- a/apps/web/src/components/ui/empty.tsx
+++ b/apps/web/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/util/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl border-dashed p-6 text-center text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn("flex max-w-sm flex-col items-center gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn(
+        "font-heading text-sm font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-2.5 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/apps/web/src/routes/bookmarks.tsx
+++ b/apps/web/src/routes/bookmarks.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { Bookmark } from "lucide-react"
 
+import { BuildsEmptyState } from "@/components/builds/builds-empty-state"
 import {
   BuildsListView,
   buildsListLoaderDeps,
@@ -9,6 +11,7 @@ import {
 } from "@/components/builds/builds-list-view"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
+import { Button } from "@/components/ui/button"
 import { requireUser } from "@/lib/auth-guards"
 import { bookmarkedBuildsQuery } from "@/lib/queries/builds-list-query"
 
@@ -42,18 +45,16 @@ function BookmarksPage() {
             onUpdateSearch={onUpdateSearch}
             showFilters
             emptyState={
-              <>
-                <p className="text-muted-foreground">
-                  You haven't bookmarked any builds yet.
-                </p>
-                <p className="text-muted-foreground mt-2 text-sm">
-                  Browse{" "}
-                  <Link to="/builds" className="text-primary underline">
-                    public builds
-                  </Link>{" "}
-                  and tap the bookmark icon to save them here.
-                </p>
-              </>
+              <BuildsEmptyState
+                icon={Bookmark}
+                title="No bookmarks yet"
+                description="Tap the bookmark icon on any build to save it here for later."
+                action={
+                  <Button nativeButton={false} render={<Link to="/builds" />}>
+                    Browse community builds
+                  </Button>
+                }
+              />
             }
           />
         </div>

--- a/apps/web/src/routes/builds.index.tsx
+++ b/apps/web/src/routes/builds.index.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { Compass } from "lucide-react"
 
+import { BuildsEmptyState } from "@/components/builds/builds-empty-state"
 import {
   BuildsListView,
   buildsListLoaderDeps,
@@ -9,6 +11,7 @@ import {
 } from "@/components/builds/builds-list-view"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
+import { Button } from "@/components/ui/button"
 import { publicBuildsQuery } from "@/lib/queries/builds-list-query"
 
 export const Route = createFileRoute("/builds/")({
@@ -40,20 +43,21 @@ function BuildsIndexPage() {
             onUpdateSearch={onUpdateSearch}
             showFilters
             emptyState={
-              <>
-                <p className="text-muted-foreground">No builds match.</p>
-                <p className="text-muted-foreground mt-2 text-sm">
-                  Try a different search, or head to{" "}
-                  <Link
-                    to="/browse"
-                    search={{ category: "warframes" }}
-                    className="text-primary underline"
+              <BuildsEmptyState
+                icon={Compass}
+                title="No community builds yet"
+                description="Be the first to publish one for everyone to find."
+                action={
+                  <Button
+                    nativeButton={false}
+                    render={
+                      <Link to="/browse" search={{ category: "warframes" }} />
+                    }
                   >
-                    Browse
-                  </Link>{" "}
-                  to publish one.
-                </p>
-              </>
+                    Create a build
+                  </Button>
+                }
+              />
             }
           />
         </div>

--- a/apps/web/src/routes/builds.mine.tsx
+++ b/apps/web/src/routes/builds.mine.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { Hammer } from "lucide-react"
 
+import { BuildsEmptyState } from "@/components/builds/builds-empty-state"
 import {
   BuildsListView,
   buildsListLoaderDeps,
@@ -9,6 +11,7 @@ import {
 } from "@/components/builds/builds-list-view"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
+import { Button } from "@/components/ui/button"
 import { requireUser } from "@/lib/auth-guards"
 import { myBuildsQuery } from "@/lib/queries/builds-list-query"
 
@@ -42,22 +45,21 @@ function MineBuildsPage() {
             onUpdateSearch={onUpdateSearch}
             showFilters
             emptyState={
-              <>
-                <p className="text-muted-foreground">
-                  You haven't saved any builds yet.
-                </p>
-                <p className="text-muted-foreground mt-2 text-sm">
-                  Start one from{" "}
-                  <Link
-                    to="/browse"
-                    search={{ category: "warframes" }}
-                    className="text-primary underline"
+              <BuildsEmptyState
+                icon={Hammer}
+                title="No builds yet"
+                description="Builds you create will show up here."
+                action={
+                  <Button
+                    nativeButton={false}
+                    render={
+                      <Link to="/browse" search={{ category: "warframes" }} />
+                    }
                   >
-                    Browse
-                  </Link>
-                  .
-                </p>
-              </>
+                    Create your first build
+                  </Button>
+                }
+              />
             }
           />
         </div>


### PR DESCRIPTION
Closes #187.

The build-list pages showed a bare line of text when empty. They now get a proper empty state — icon, title, description, and a CTA.

### Changes

- Added the shadcn `Empty` primitive (`ui/empty.tsx`, import path fixed to the project's `@/lib/util/utils`) and a small `BuildsEmptyState` wrapper so all three lists share one illustration-plus-CTA shape.
- **My Builds** → "No builds yet" + *Create your first build* (→ Browse).
- **Bookmarks** → "No bookmarks yet" + *Browse community builds* (→ /builds).
- **Community** → "No community builds yet" + *Create a build* (→ Browse).

### Empty vs. no-match

The old code showed the route's empty message whenever the list was empty — so searching with no results told a user with dozens of builds "you haven't saved any builds yet." The list view now knows when a search / category tab / toggle is active, and shows a dedicated **"No builds match"** state in that case, reserving the create-a-build CTA for genuinely empty lists.

### Verification

The list pages are API-backed and the headless preview has no API, so I rendered all four states on a temporary route to verify them visually (then removed it): icons, titles, and CTA hrefs (`/browse?category=warframes`, `/builds`) all resolve correctly. `bun run typecheck` and `just check` pass.

_Note: `ui/empty.tsx` is a stock shadcn component added via the CLI; the only edit was correcting the `cn` import path to match this repo._