### PR TITLE
UI consistency pass: link-button cursor, icon sizing, a11y labels

### DIFF
--- a/apps/web/src/components/build-editor/editor-variant-bar.tsx
+++ b/apps/web/src/components/build-editor/editor-variant-bar.tsx
@@ -139,6 +139,7 @@ function EditorVariantBarMulti({
                     <button
                       type="button"
                       title="Variant settings"
+                      aria-label="Variant settings"
                       className="border-primary bg-primary text-primary-foreground rounded-r-md border border-l-0 px-1.5 py-1 text-sm"
                     >
                       ⚙

--- a/apps/web/src/components/build-editor/incarnon-controls.tsx
+++ b/apps/web/src/components/build-editor/incarnon-controls.tsx
@@ -138,6 +138,7 @@ function IncarnonTierSlot({
                     setOpen(false)
                   }}
                   title="Clear selection"
+                  aria-label="Clear selection"
                 >
                   <X className="size-3" />
                 </Button>

--- a/apps/web/src/components/build-editor/shard-controls.tsx
+++ b/apps/web/src/components/build-editor/shard-controls.tsx
@@ -160,6 +160,7 @@ function ShardPicker({
               size="icon-sm"
               onClick={() => setColor(null)}
               title="Back"
+              aria-label="Back"
               className="-ml-1"
             >
               <ChevronLeft className="size-3.5" />
@@ -175,6 +176,7 @@ function ShardPicker({
             size="icon-sm"
             onClick={onClear}
             title="Remove shard"
+            aria-label="Remove shard"
           >
             <X className="size-3" />
           </Button>

--- a/apps/web/src/components/build-viewer/build-actions-menu.tsx
+++ b/apps/web/src/components/build-viewer/build-actions-menu.tsx
@@ -73,7 +73,7 @@ export function BuildActionsMenu({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-40">
           <DropdownMenuItem onClick={onFork} disabled={fork.isPending}>
-            <GitFork className="size-4" />
+            <GitFork />
             {fork.isPending ? "Forking…" : "Fork"}
           </DropdownMenuItem>
           {isOwner ? (
@@ -83,7 +83,7 @@ export function BuildActionsMenu({
                 variant="destructive"
                 onClick={() => setConfirmOpen(true)}
               >
-                <Trash2 className="size-4" />
+                <Trash2 />
                 Delete
               </DropdownMenuItem>
             </>

--- a/apps/web/src/components/build-viewer/share-menu.tsx
+++ b/apps/web/src/components/build-viewer/share-menu.tsx
@@ -31,11 +31,11 @@ export function ShareMenu({ slug }: { slug: string }) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-44">
         <DropdownMenuItem onClick={onCopyLink}>
-          <Link2 className="size-4" />
+          <Link2 />
           Copy link
         </DropdownMenuItem>
         <DropdownMenuItem onClick={onCopyEmbed}>
-          <Code2 className="size-4" />
+          <Code2 />
           Copy embed code
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/web/src/components/build-viewer/viewer-header.tsx
+++ b/apps/web/src/components/build-viewer/viewer-header.tsx
@@ -143,6 +143,7 @@ export function ViewerHeader({
             <Button
               size="sm"
               nativeButton={false}
+              className="cursor-default"
               render={
                 <RouterLink
                   to="/create"

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -58,7 +58,7 @@ export function Header() {
                     render={<Link href={item.href} />}
                     nativeButton={false}
                     onClick={() => setMobileNavOpen(false)}
-                    className="justify-start"
+                    className="cursor-default justify-start"
                   >
                     {item.label}
                   </Button>
@@ -81,6 +81,7 @@ export function Header() {
                 size="sm"
                 render={<Link href={item.href} />}
                 nativeButton={false}
+                className="cursor-default"
               >
                 {item.label}
               </Button>

--- a/apps/web/src/components/item-detail/content.tsx
+++ b/apps/web/src/components/item-detail/content.tsx
@@ -110,6 +110,7 @@ export function ItemDetailContent({
                 <Button
                   size="lg"
                   nativeButton={false}
+                  className="cursor-default"
                   render={
                     <RouterLink
                       to="/create"

--- a/apps/web/src/components/settings-dialog/api-keys-tab.tsx
+++ b/apps/web/src/components/settings-dialog/api-keys-tab.tsx
@@ -173,7 +173,7 @@ function CreateApiKeyForm({ disabled }: { disabled: boolean }) {
               void copyToClipboard(justCreated.token, "API key copied")
             }
           >
-            <Copy className="size-3.5" />
+            <Copy data-icon="inline-start" />
             Copy
           </Button>
         </div>

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -32,8 +32,9 @@ export function UserMenu() {
         variant="ghost"
         render={<Link href={ROUTES.signIn} />}
         nativeButton={false}
+        className="cursor-default"
       >
-        <LogIn className="size-4" />
+        <LogIn data-icon="inline-start" />
         Sign in
       </Button>
     )

--- a/apps/web/src/routes/org.$slug.tsx
+++ b/apps/web/src/routes/org.$slug.tsx
@@ -128,8 +128,9 @@ function OrgHeader({ org }: { org: OrgProfile }) {
           size="sm"
           render={<Link href={`/org/${org.slug}/settings`} />}
           nativeButton={false}
+          className="cursor-default"
         >
-          <Settings className="size-4" />
+          <Settings data-icon="inline-start" />
           Settings
         </Button>
       ) : null}


### PR DESCRIPTION
Closes #190.

A read-only audit against the shadcn rules turned up a handful of small, pre-existing inconsistencies. All low-risk; grouped by type.

### Cursor on link-rendered buttons
`<Button render={<Link/>}>` renders an `<a>`, which browsers default to `cursor: pointer`, while the real `<button>` peers use the arrow. Pinned `cursor-default` to match: header nav (mobile + desktop), Sign in, Create Build, Edit, org Settings.

### Icon sizing
Dropped hand-coded `size-4` / `size-3.5` so the component sizes icons itself:
- **Menu-item icons** (`share-menu` Link2/Code2, `build-actions-menu` GitFork/Trash2) just lose the class — `DropdownMenuItem` auto-sizes unclassed SVGs to `size-4`, so the render is identical. (`DropdownMenuItem` has no `data-icon` hook, so `data-icon` would have been a no-op here — the issue conflated the two; this is the correct fix.)
- **Text-button icons** (Sign in `LogIn`, org `Settings`, API-key `Copy`) move to `data-icon="inline-start"`, which also corrects their leading padding. The Copy button is `size="sm"`, whose auto-size is already `3.5` — identical render, verified at 14px.

### Accessible names
Icon-only buttons that had only a `title` now also carry `aria-label`: shard **Back** / **Remove shard**, incarnon **Clear selection**, variant settings **⚙**. `title` stays for the hover tooltip.

### Deliberately skipped
- The **"+ Variant"** button (issue flagged it) — it has visible text, so it already has a reliable accessible name; an `aria-label` would only shadow it.
- The items the issue itself marked likely-intentional: raw category badge colors, game-stat color dots, and the tip-bar hand-rolled ghost button.

### Note for review
The header nav links ("Browse", "Builds") now use the default arrow cursor for consistency with every other button in the app. If you'd rather nav links keep a pointer, that's a quick revert of those two lines — say the word.

### Verification
`bun run typecheck` and `just check` pass. Live-checked the signed-out Sign in button: `cursor: default`, icon `data-icon="inline-start"` with no size class, rendered 14px. Remaining changes are the same patterns plus static attribute additions.