### PR TITLE
Wire R2 creds into the weekly data-refresh workflow

### DIFF
--- a/.github/workflows/update-warframe-data.yml
+++ b/.github/workflows/update-warframe-data.yml
@@ -30,6 +30,17 @@ jobs:
 
       - name: Sync upstream + rebuild items
         run: bun run data:bump
+        # data:bump runs `sync:images --skip-if-no-creds` as its last step;
+        # with these present it mirrors new images into R2 and rewrites the
+        # catalog to img.arsenyx.com, so the auto-PR already passes
+        # check:images. If any secret is unset, sync:images self-skips and the
+        # PR lands hotlinked (recoverable by running sync:images on the branch).
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
 
       # No typecheck/lint/test here — this job only refreshes data and opens a
       # PR. That PR triggers ci.yml, which runs the full gauntlet (web build →
@@ -76,9 +87,8 @@ jobs:
             Any new wiki Class strings or DE compatNames not yet curated
             will fail the build — fix `data/curated/` if so.
 
-            ⚠ This catalog still points at the upstream CDNs — the cron has
-            no R2 creds, so `sync:images` was skipped and CI's `check:images`
-            guard will fail. Before merging, check out this branch locally and
-            run `bun run sync:images` (mirrors new images into R2 + rewrites
-            the catalog to img.arsenyx.com), then push.
+            Images are mirrored to R2 and the catalog rewritten to
+            img.arsenyx.com automatically (the cron has R2 creds), so CI's
+            check:images guard should pass. If it fails, an R2 secret is
+            likely missing — check out this branch and run `bun run sync:images`.
           commit-message: "chore: refresh Warframe game data"


### PR DESCRIPTION
## What

Passes the `R2_*` repository secrets into the `Sync upstream + rebuild items` step of `update-warframe-data.yml`.

## Why

The weekly refresh runs `bun run data:bump`, whose final step is `sync:images --skip-if-no-creds`. With no R2 creds in the Actions environment it silently self-skipped, so every weekly refresh committed a catalog still hotlinking `content.warframe.com` — which trips CI's `check:images` guard and leaves `main` red (as it was after #181, and as PR #200 had to fix manually by running `sync:images` locally).

With the secrets wired in, the cron mirrors new images into R2 and rewrites the catalog to `img.arsenyx.com` itself, so the auto-PR passes `check:images` with no manual step.

## Prerequisite (done)

The 5 secrets are now configured as **repository** secrets: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_PUBLIC_URL`.

## Notes

- `--skip-if-no-creds` is retained, so a missing secret degrades gracefully (skips + recoverable) rather than failing the run.
- Updated the auto-PR body text to drop the now-obsolete 'run sync:images manually' warning.
- YAML validated; no behavior change beyond the env wiring.