### PR TITLE
Gate Exodia arcanes off non-Zaw melees + exalted-stance editor follow-ups

### DIFF
--- a/apps/web/src/components/build-editor/layout.test.ts
+++ b/apps/web/src/components/build-editor/layout.test.ts
@@ -24,7 +24,20 @@ const ARCANES: Arcane[] = [
   arc("Pax Bolt", "Kitgun"),
   arc("Residual Boils", "Kitgun", "Offensive"),
   arc("Shotgun Vendetta", "Shotgun", "Offensive"),
+  arc("Melee Influence", "Melee", "Offensive"),
+  arc("Exodia Force", "Zaw", "Offensive"),
 ]
+
+const ZAW_STRIKE: Pick<DetailItem, "name" | "displayClass" | "uniqueName"> = {
+  name: "Plague Keewar",
+  displayClass: "Zaw Polearm / Hammer",
+  uniqueName: "/Lotus/Weapons/Ostron/Melee/LordMelee/Tips/PlagueTip",
+}
+const GLAIVE: Pick<DetailItem, "name" | "displayClass" | "uniqueName"> = {
+  name: "Falcor",
+  displayClass: "Thrown",
+  uniqueName: "/Lotus/Weapons/Tenno/Melee/Thrown/Falcor/Falcor",
+}
 
 const KITGUN_SECONDARY: Pick<
   DetailItem,
@@ -254,6 +267,29 @@ describe("hasLockedStance / getLockedStance", () => {
     // A regular melee carrying the same fields wouldn't be a locked exalted.
     expect(hasLockedStance(DESERT_WIND, "melee")).toBe(false)
     expect(getLockedStance(DESERT_WIND, "melee")).toBeUndefined()
+  })
+})
+
+describe("getArcaneSlotConfig — melee Exodia gating", () => {
+  it("gives a Zaw a dedicated Exodia slot alongside the melee slot", () => {
+    const cfg = getArcaneSlotConfig(ARCANES, "melee", 2, ZAW_STRIKE)
+    expect(cfg.labels).toEqual(["Melee Arcane", "Exodia"])
+    expect(cfg.options[0]!.map((a) => a.name)).toEqual(["Melee Influence"])
+    expect(cfg.options[1]!.map((a) => a.name)).toEqual(["Exodia Force"])
+  })
+
+  it("keeps Exodia (Zaw-only) arcanes off an ordinary melee (glaive)", () => {
+    const cfg = getArcaneSlotConfig(ARCANES, "melee", 1, GLAIVE)
+    expect(cfg.options).toHaveLength(1)
+    expect(cfg.options[0]!.map((a) => a.name)).toEqual(["Melee Influence"])
+  })
+
+  it("keeps Exodia off an exalted melee weapon (Exalted Blade)", () => {
+    const cfg = getArcaneSlotConfig(ARCANES, "exalted-weapons", 1, {
+      ...EXALTED_BLADE,
+      name: "Exalted Blade",
+    })
+    expect(cfg.options[0]!.map((a) => a.name)).toEqual(["Melee Influence"])
   })
 })
 

--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -125,15 +125,26 @@ export function getArcaneSlotConfig(
   }
   if (category === "exalted-weapons" && item) {
     const slot = getExaltedArcaneSlot(item)
-    return { options: [getArcanesForSlot(allArcanes, slot)] }
-  }
-  if (category === "melee" && item && isZawComponent(item.displayClass)) {
-    const regular: Arcane[] = []
-    const exodia: Arcane[] = []
-    for (const a of getArcanesForSlot(allArcanes, "melee")) {
-      ;(isZawArcane(a) ? exodia : regular).push(a)
+    const pool = getArcanesForSlot(allArcanes, slot)
+    // Exalted weapons are never Zaws, so Exodia (Zaw-only) arcanes never apply
+    // to an exalted-melee weapon's pool — strip them out.
+    return {
+      options: [slot === "melee" ? pool.filter((a) => !isZawArcane(a)) : pool],
     }
-    return { options: [regular, exodia], labels: ["Melee Arcane", "Exodia"] }
+  }
+  if (category === "melee" && item) {
+    const pool = getArcanesForSlot(allArcanes, "melee")
+    if (isZawComponent(item.displayClass)) {
+      const regular: Arcane[] = []
+      const exodia: Arcane[] = []
+      for (const a of pool) {
+        ;(isZawArcane(a) ? exodia : regular).push(a)
+      }
+      return { options: [regular, exodia], labels: ["Melee Arcane", "Exodia"] }
+    }
+    // Ordinary melee (glaives, swords, etc.) can't equip Exodia (Zaw-only)
+    // arcanes — the shared melee pool lumps them in, so filter them back out.
+    return { options: [pool.filter((a) => !isZawArcane(a))] }
   }
   // Kitguns get two arcane slots: the regular weapon-arcane slot plus a
   // dedicated Pax/Residual slot. Split the weapon-eligible pool so the

--- a/apps/web/src/components/build-editor/multi-variant-auto-forma.test.ts
+++ b/apps/web/src/components/build-editor/multi-variant-auto-forma.test.ts
@@ -5,6 +5,7 @@ import { calculateCapacity } from "./calculations"
 import {
   computeMultiVariantPlan,
   computeMultiVariantStage1Plan,
+  listFormaCandidates,
 } from "./multi-variant-auto-forma"
 import type { PlacedMod, SlotId } from "./use-build-slots"
 
@@ -150,6 +151,40 @@ describe("computeMultiVariantStage1Plan", () => {
     const next = { ...inputs, formaPolarities: plan!.formaPolarities }
     const cap = calculateCapacity({ ...next, placed: placedMap })
     expect(cap.used).toBeLessThanOrEqual(cap.max)
+  })
+})
+
+describe("listFormaCandidates — locked-stance guard", () => {
+  // A build with a stance slot in play (mod placed + innate polarity) so the
+  // stance branch is reachable; buckets offer a stance polarity that differs
+  // from the (empty) current forma, so a candidate would be produced.
+  const stanceInput = {
+    ...emptyInputs(),
+    variantSlots: [
+      { stance: placed("madurai", 10) } as Partial<Record<SlotId, PlacedMod>>,
+    ],
+    stanceInnate: "madurai" as Polarity,
+  }
+  const buckets = {
+    aura: [] as Polarity[],
+    exilus: [] as Polarity[],
+    stance: ["vazarin"] as Polarity[],
+    normal: [] as Polarity[],
+  }
+
+  it("offers a stance forma candidate for an ordinary (editable) stance slot", () => {
+    const out = listFormaCandidates(stanceInput, buckets)
+    expect(out.some((c) => c.id === "stance")).toBe(true)
+  })
+
+  it("omits the stance forma candidate when an exalted stance is locked", () => {
+    // The locked stance can't be forma'd — calculateCapacity ignores
+    // formaPolarities.stance here — so a stance candidate only wastes budget.
+    const out = listFormaCandidates(
+      { ...stanceInput, lockedStance: placed("madurai", 0) },
+      buckets,
+    )
+    expect(out.some((c) => c.id === "stance")).toBe(false)
   })
 })
 

--- a/apps/web/src/components/build-editor/multi-variant-auto-forma.ts
+++ b/apps/web/src/components/build-editor/multi-variant-auto-forma.ts
@@ -623,7 +623,15 @@ function listFormaCandidates(
       out.push({ id: "exilus", polarity: p })
     }
   }
-  if (input.stanceInnate !== undefined || hasStanceSlotLike(input)) {
+  // A locked exalted stance sets `stanceInnate`, but its slot can't be
+  // forma'd — `calculateCapacity` ignores `formaPolarities.stance` when
+  // `lockedStance` is set — so a stance-forma candidate can never change
+  // feasibility. Skip it: leaving it in only wastes search budget (and could
+  // surface a non-applicable "forma the stance slot" / Omni step).
+  if (
+    !input.lockedStance &&
+    (input.stanceInnate !== undefined || hasStanceSlotLike(input))
+  ) {
     for (const p of buckets.stance) {
       if (input.formaPolarities.stance === p) continue
       out.push({ id: "stance", polarity: p })

--- a/apps/web/src/components/build-editor/multi-variant-auto-forma.ts
+++ b/apps/web/src/components/build-editor/multi-variant-auto-forma.ts
@@ -600,7 +600,11 @@ interface FormaSlotChoice {
   polarity: Polarity
 }
 
-function listFormaCandidates(
+// Exported for unit testing: the locked-stance guard below changes the
+// candidate list, not the planner's final output (calculateCapacity ignores
+// `formaPolarities.stance` under `lockedStance`), so it can't be asserted
+// through the public plan API — pin it directly.
+export function listFormaCandidates(
   input: MultiVariantInput,
   buckets: KindCandidates,
 ): FormaSlotChoice[] {

--- a/apps/web/src/components/build-editor/use-keyboard-nav.ts
+++ b/apps/web/src/components/build-editor/use-keyboard-nav.ts
@@ -20,18 +20,14 @@ const COLS = 4
 
 function buildGrid(layout: SlotLayout): (SlotId | null)[][] {
   const grid: (SlotId | null)[][] = []
-  const { auraSlotCount, showExilus, showStance, stanceLocked } = layout
-  // A locked exalted stance renders but isn't selectable — keep it off the grid.
-  const navStance = showStance && !stanceLocked
-  if (auraSlotCount > 0 || showExilus || navStance) {
-    // Reading order: aura-0, stance?, exilus?, aura-1..N-1
-    const topOrder: SlotId[] = []
-    if (auraSlotCount > 0) topOrder.push("aura-0" as SlotId)
-    if (navStance) topOrder.push("stance")
-    if (showExilus) topOrder.push("exilus")
-    for (let i = 1; i < auraSlotCount; i++) {
-      topOrder.push(`aura-${i}` as SlotId)
-    }
+  // Top row = the visible non-normal slots in reading order
+  // (aura-0, stance?, exilus?, aura-1..N-1). Derive it from getVisibleSlots so
+  // the slot ordering and the locked-stance exclusion live in one place rather
+  // than being re-encoded here (a locked stance is already absent from it).
+  const topOrder = getVisibleSlots(layout).filter(
+    (id) => !id.startsWith("normal-"),
+  )
+  if (topOrder.length > 0) {
     const top: (SlotId | null)[] = new Array(
       Math.max(COLS, topOrder.length),
     ).fill(null)

--- a/scripts/build-items-index.ts
+++ b/scripts/build-items-index.ts
@@ -26,24 +26,25 @@
  * isPrime, vaulted, releaseDate.
  */
 
-import { mkdir, rm, writeFile } from "node:fs/promises"
 import { readdirSync } from "node:fs"
+import { mkdir, rm, writeFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
-import { slugify } from "@arsenyx/shared/warframe/slugs"
 import { INCARNON_EVOLUTIONS } from "@arsenyx/shared/warframe/incarnon-evolutions"
+import {
+  isKitgunChamber,
+  KITGUN_GRIPS,
+  KITGUN_LOADERS,
+} from "@arsenyx/shared/warframe/kitgun-data"
+import { slugify } from "@arsenyx/shared/warframe/slugs"
 import type { BrowseItem } from "@arsenyx/shared/warframe/types"
 import {
   ZAW_GRIPS,
   ZAW_LINKS,
   ZAW_STRIKES,
 } from "@arsenyx/shared/warframe/zaw-data"
-import {
-  isKitgunChamber,
-  KITGUN_GRIPS,
-  KITGUN_LOADERS,
-} from "@arsenyx/shared/warframe/kitgun-data"
 
+import { PVE_USABLE_CONCLAVE_MODS } from "../data/curated/pve-usable-conclave-mods"
 import {
   buildExaltedSet,
   categorizeCompanion,
@@ -62,17 +63,21 @@ import {
 } from "./build/images"
 import { mergeArcanes, type MergedArcane } from "./build/merge-arcanes"
 import { mergeCompanions, type MergedCompanion } from "./build/merge-companions"
-import { mergeFrame, operatorsFromWiki, type MergedFrame } from "./build/merge-frames"
+import {
+  mergeFrame,
+  operatorsFromWiki,
+  type MergedFrame,
+} from "./build/merge-frames"
 import { deriveHelminthAbilities } from "./build/merge-helminth"
-import { mergeModular } from "./build/merge-modular"
 import { mergeMods, type MergedMod } from "./build/merge-mods"
-import { readPePlusUpgrades, readPePlusWeaponTags } from "./build/read-pe-plus"
+import { mergeModular } from "./build/merge-modular"
 import {
   mergeWeapon,
   mergeWikiOnlyWeapon,
   validateCuratedAgainstKnown,
   type MergedWeapon,
 } from "./build/merge-weapons"
+import { readCurated } from "./build/read-curated"
 import {
   readDeArcanes,
   readDeFrames,
@@ -82,9 +87,8 @@ import {
   readDeWeapons,
   type DeSentinel,
 } from "./build/read-de"
-import { readCurated } from "./build/read-curated"
+import { readPePlusUpgrades, readPePlusWeaponTags } from "./build/read-pe-plus"
 import { readWikiModule } from "./build/read-wiki"
-import { PVE_USABLE_CONCLAVE_MODS } from "../data/curated/pve-usable-conclave-mods"
 
 const REPO_ROOT = resolve(import.meta.dirname, "..")
 const WIKI_DIR = resolve(REPO_ROOT, "data/raw/wiki")
@@ -133,7 +137,9 @@ async function main() {
   const deSentinelsBlob = readDeSentinels()
   const deManifest = readDeManifest()
   const deUpgrades = readDeUpgrades()
-  console.log(`DE: ${deWeapons.length} weapons, ${deFramesBlob.ExportWarframes.length} frames, ${deSentinelsBlob.ExportSentinels.length} sentinel-blob rows, ${deUpgrades.ExportUpgrades?.length ?? 0} upgrades`)
+  console.log(
+    `DE: ${deWeapons.length} weapons, ${deFramesBlob.ExportWarframes.length} frames, ${deSentinelsBlob.ExportSentinels.length} sentinel-blob rows, ${deUpgrades.ExportUpgrades?.length ?? 0} upgrades`,
+  )
 
   // Wiki weapon subpages — flat name → entry map.
   const wikiWeaponsByName = new Map<string, Record<string, unknown>>()
@@ -147,9 +153,13 @@ async function main() {
       }
     }
   }
-  console.log(`Wiki weapons (across subpages): ${wikiWeaponsByName.size} unique names`)
+  console.log(
+    `Wiki weapons (across subpages): ${wikiWeaponsByName.size} unique names`,
+  )
 
-  const wikiFramesBlob = readWikiModule(resolve(WIKI_DIR, "Warframes_data.lua")) as {
+  const wikiFramesBlob = readWikiModule(
+    resolve(WIKI_DIR, "Warframes_data.lua"),
+  ) as {
     Warframes?: Record<string, Record<string, unknown>>
     Archwings?: Record<string, Record<string, unknown>>
     Necramechs?: Record<string, Record<string, unknown>>
@@ -160,7 +170,9 @@ async function main() {
     resolve(WIKI_DIR, "Companions_data.lua"),
   ) as { Companions?: Record<string, Record<string, unknown>> }
   const wikiCompanions = wikiCompanionsBlob.Companions ?? {}
-  console.log(`Wiki: ${Object.keys(wikiFramesBlob.Warframes ?? {}).length} warframes, ${Object.keys(wikiCompanions).length} companions`)
+  console.log(
+    `Wiki: ${Object.keys(wikiFramesBlob.Warframes ?? {}).length} warframes, ${Object.keys(wikiCompanions).length} companions`,
+  )
 
   // Modular (Kitgun/Zaw) stat tables. Module:Modular/data is the only
   // verifiable source for the per-combination stats DE zeroes out; pass the
@@ -230,7 +242,9 @@ async function main() {
   const frameUnmatched = new Set<string>()
   const mergedFrames: MergedFrame[] = []
   for (const de of deFramesBlob.ExportWarframes) {
-    mergedFrames.push(mergeFrame(de, { wiki: wikiFramesBlob, unmatched: frameUnmatched }))
+    mergedFrames.push(
+      mergeFrame(de, { wiki: wikiFramesBlob, unmatched: frameUnmatched }),
+    )
   }
   const operators = operatorsFromWiki(wikiFramesBlob)
   stats.frames.de = deFramesBlob.ExportWarframes.length
@@ -240,7 +254,10 @@ async function main() {
   // ---------- 4. Merge companions ----------
   const deCompanionByName = new Map<string, DeSentinel>()
   for (const ent of deSentinelsBlob.ExportSentinels) {
-    if (ent.productCategory === "Sentinels" || ent.productCategory === "KubrowPets") {
+    if (
+      ent.productCategory === "Sentinels" ||
+      ent.productCategory === "KubrowPets"
+    ) {
       deCompanionByName.set(ent.name, ent)
     }
   }
@@ -334,7 +351,9 @@ async function main() {
     if (!wikiCache.urls[fn]) neededFilenames.add(fn)
   }
   if (neededFilenames.size > 0) {
-    console.log(`Resolving ${neededFilenames.size} wiki image URLs via MediaWiki API...`)
+    console.log(
+      `Resolving ${neededFilenames.size} wiki image URLs via MediaWiki API...`,
+    )
     const resolved = await resolveWikiImageUrls(neededFilenames)
     for (const [fn, url] of resolved) wikiCache.urls[fn] = url
     writeWikiImageCache(WIKI_IMAGE_CACHE, wikiCache)
@@ -371,6 +390,11 @@ async function main() {
   // (155 mods). The description "in Conclave" substring covers only ~14%
   // of them, so we route via this instead.
   const wikiConclaveMods = new Set<string>()
+  // PVE_USABLE_CONCLAVE_MODS entries we actually saw as Conclave-flagged
+  // records. Used to warn on drift: an entry that never matches (typo, or a
+  // wiki InternalName rename) silently stops excluding its mod and the mod
+  // vanishes from the PvE picker again — surface that at build time.
+  const pveUsableSeen = new Set<string>()
   // Mod display Name → wiki InternalName (= DE uniqueName). Resolves the
   // name-keyed `Incompatible` lists into uniqueNames below.
   const wikiModUniqueNameByName = new Map<string, string>()
@@ -394,8 +418,12 @@ async function main() {
     // handful of ability augments + zoom mods are usable in PvE too (and one,
     // Vexing Retaliation, is mis-flagged outright) — keep those out of the PvP
     // set so the picker's PvE view shows them. See pve-usable-conclave-mods.ts.
-    if (record["Conclave"] === true && !PVE_USABLE_CONCLAVE_MODS.has(internalName)) {
-      wikiConclaveMods.add(internalName)
+    if (record["Conclave"] === true) {
+      if (PVE_USABLE_CONCLAVE_MODS.has(internalName)) {
+        pveUsableSeen.add(internalName)
+      } else {
+        wikiConclaveMods.add(internalName)
+      }
     }
     const incompat = record["Incompatible"]
     if (Array.isArray(incompat)) {
@@ -407,6 +435,19 @@ async function main() {
       )
     }
   }
+  const unmatchedPveUsable = [...PVE_USABLE_CONCLAVE_MODS].filter(
+    (name) => !pveUsableSeen.has(name),
+  )
+  if (unmatchedPveUsable.length > 0) {
+    console.warn(
+      `  WARN pve-usable-conclave-mods.ts: ${unmatchedPveUsable.length} allowlist entr${
+        unmatchedPveUsable.length === 1 ? "y" : "ies"
+      } matched no Conclave-flagged wiki record (typo or wiki rename — these mods are no longer being un-hidden from the PvE picker):\n${unmatchedPveUsable
+        .map((n) => `         - ${n}`)
+        .join("\n")}`,
+    )
+  }
+
   const { mods: rawMergedMods, counts: modCounts } = mergeMods(
     deUpgrades.ExportUpgrades ?? [],
     deUpgrades.ExportModSet ?? [],
@@ -678,7 +719,9 @@ async function main() {
 
   const indexJson = JSON.stringify(byCategory)
   await writeFile(resolve(OUT_DIR, "items-index.json"), indexJson, "utf8")
-  console.log(`\n  OK  items-index.json (${(indexJson.length / 1024).toFixed(1)} KB)`)
+  console.log(
+    `\n  OK  items-index.json (${(indexJson.length / 1024).toFixed(1)} KB)`,
+  )
 
   await writeFile(
     resolve(OUT_DIR, "mods-all.json"),
@@ -844,15 +887,33 @@ async function main() {
   await mkdir(DETAIL_DIR, { recursive: true })
   let detailCount = 0
   let detailBytes = 0
-  function writeDetail(cat: string, slug: string, payload: unknown): Promise<void> {
-    return mkdir(resolve(DETAIL_DIR, cat), { recursive: true }).then(async () => {
-      const body = JSON.stringify(payload)
-      await writeFile(resolve(DETAIL_DIR, cat, `${slug}.json`), body, "utf8")
-      detailCount++
-      detailBytes += Buffer.byteLength(body, "utf8")
-    })
+  function writeDetail(
+    cat: string,
+    slug: string,
+    payload: unknown,
+  ): Promise<void> {
+    return mkdir(resolve(DETAIL_DIR, cat), { recursive: true }).then(
+      async () => {
+        const body = JSON.stringify(payload)
+        await writeFile(resolve(DETAIL_DIR, cat, `${slug}.json`), body, "utf8")
+        detailCount++
+        detailBytes += Buffer.byteLength(body, "utf8")
+      },
+    )
   }
 
+  // Exalted melees with a *free* (editable) stance rather than a locked one —
+  // the documented exception to "every exalted melee ships a locked stance".
+  // See data/curated/exalted-stances.ts.
+  const FREE_STANCE_EXALTED_MELEES = new Set([
+    "Garuda Talons",
+    "Garuda Prime Talons",
+  ])
+  // Exalted melees that render a stance slot (carry stancePolarity) but have no
+  // curated locked stance and aren't a known free-stance exception. The web
+  // editor would surface an *editable* stance slot for them, letting a user
+  // place a stance that's permanently locked in-game → an unbuildable build.
+  const exaltedMeleeMissingStance: string[] = []
   for (const [catSlug, w] of weaponDetailByCatAndSlug) {
     const [cat, slug] = catSlug.split("|")
     if (!cat || !slug) continue
@@ -864,15 +925,32 @@ async function main() {
     const innateStance = stance
       ? {
           name: stance.stanceName,
-          imageName: imageByUniqueName.get(exaltedStanceImageKey(stance.wikiImage)),
+          imageName: imageByUniqueName.get(
+            exaltedStanceImageKey(stance.wikiImage),
+          ),
         }
       : undefined
+    if (
+      cat === "exalted-weapons" &&
+      w.stancePolarity &&
+      !stance &&
+      !FREE_STANCE_EXALTED_MELEES.has(w.name)
+    ) {
+      exaltedMeleeMissingStance.push(w.name)
+    }
     await writeDetail(cat, slug, {
       ...w,
       imageName: imageByUniqueName.get(w.uniqueName),
       compatTags: pePlusWeaponTags.get(w.uniqueName),
       ...(innateStance && { innateStance }),
     })
+  }
+  if (exaltedMeleeMissingStance.length > 0) {
+    console.warn(
+      `  WARN exalted-stances.ts: ${exaltedMeleeMissingStance.length} exalted melee(s) carry a stance slot but no curated locked stance — the editor will show an EDITABLE stance slot for a locked-in-game weapon. Add to EXALTED_STANCES (or FREE_STANCE_EXALTED_MELEES if free):\n${exaltedMeleeMissingStance
+        .map((n) => `         - ${n}`)
+        .join("\n")}`,
+    )
   }
   for (const f of [...mergedFrames, ...operators]) {
     const cat = categorizeFrame(f)
@@ -942,7 +1020,9 @@ async function main() {
   )
 
   console.log("\nBy category:")
-  for (const [cat, n] of Object.entries(stats.perCategory).sort((a, b) => b[1] - a[1])) {
+  for (const [cat, n] of Object.entries(stats.perCategory).sort(
+    (a, b) => b[1] - a[1],
+  )) {
     console.log(`  ${cat.padEnd(20)} ${n}`)
   }
   console.log()


### PR DESCRIPTION
Follow-up fixes on top of #205 (exalted stances / Conclave visibility, squash-merged). Two independent groups, both editor/build correctness.

## 1. Gate Zaw-only Exodia arcanes out of non-Zaw melee pickers

Exodia arcanes carry `slotType: "Zaw"`, but the shared melee arcane pool lumps them in with ordinary melee arcanes (`slotTypeMatches` treats `"melee"` as `Melee || Zaw`). The per-weapon editor picker was therefore offering Exodia arcanes on glaives, swords, and exalted melees that can never equip them.

`getArcaneSlotConfig` now filters `isZawArcane` out of the ordinary-melee and exalted-melee pools (exalted weapons are never Zaws), while keeping the dedicated Zaw/Exodia split for actual Zaw strike components. The shared pool is left lumped on purpose for browse/catalog use.

## 2. Editor review follow-ups

Surfaced by a review of the merged exalted-stance work:

- **Auto-forma planner** (`multi-variant-auto-forma.ts`) — a locked exalted stance sets `stanceInnate`, so `listFormaCandidates` opened a stance-forma branch. But `calculateCapacity` ignores `formaPolarities.stance` when `lockedStance` is set, so that branch can never change feasibility — it only wasted the bounded search budget (risking a false "can't fit") and could surface a non-applicable "forma the stance slot" / Omni step. Guarded with `!input.lockedStance`.
- **Keyboard nav** (`use-keyboard-nav.ts`) — `buildGrid` re-encoded the top-row reading order plus the `showStance && !stanceLocked` gate that `getVisibleSlots` already owns (a third copy of the locked-stance rule). Now derives the top row from `getVisibleSlots`, so the ordering and the locked-stance exclusion live in one place.
- **Build-time drift guards** (`scripts/build-items-index.ts`) — two non-fatal `WARN`s:
  1. `PVE_USABLE_CONCLAVE_MODS` entries that match no Conclave-flagged wiki record (a typo or wiki `InternalName` rename would silently re-hide the mod from the PvE picker).
  2. Exalted melees that render a stance slot but have no curated locked stance — the editor would show an *editable* stance slot for a weapon whose stance is locked in-game, producing an unbuildable build. Catches a future DE addition/rename the curated `EXALTED_STANCES` map misses (Garuda Talons/Prime excepted as free-stance).

## Verification

- `bun run typecheck` (web + api + shared + scripts) clean
- build-editor + shared stance test suites pass (54 + 8)
- `bun run build:items` runs clean — both new warnings confirmed silent on current data
- oxlint + oxfmt applied to touched files

## Not included

The two untracked `apps/api/scripts/` diagnostics (`scope-stale-builds.ts`, `fix-stale-item-unique-names.ts`) from the stale-build prod repair are a separate concern and intentionally left out of this PR.
