### PR TITLE
Fix base/Primed mod conflicts + Bayonet stance routing; arcane cleanups

### DIFF
--- a/apps/web/src/components/build-editor/layout.ts
+++ b/apps/web/src/components/build-editor/layout.ts
@@ -3,7 +3,7 @@ import {
   getArcanesForSlot,
   getArcanesForWeapon,
   isKitgunWeapon,
-  isZawArcane,
+  isSecondSlotArcane,
   type ArcaneSlotType,
 } from "@arsenyx/shared/warframe/arcanes"
 // Category-only slot facts live in shared (the api Overframe importer needs
@@ -131,7 +131,7 @@ export function getArcaneSlotConfig(
     const regular: Arcane[] = []
     const exodia: Arcane[] = []
     for (const a of getArcanesForSlot(allArcanes, "melee")) {
-      ;(isZawArcane(a) ? exodia : regular).push(a)
+      ;(isSecondSlotArcane(a, true) ? exodia : regular).push(a)
     }
     return { options: [regular, exodia], labels: ["Melee Arcane", "Exodia"] }
   }
@@ -148,22 +148,19 @@ export function getArcaneSlotConfig(
     const weapon: Arcane[] = []
     const kitgun: Arcane[] = []
     for (const a of getArcanesForWeapon(allArcanes, category, item)) {
-      ;(a.slotType === "Kitgun" ? kitgun : weapon).push(a)
+      ;(isSecondSlotArcane(a, false) ? kitgun : weapon).push(a)
     }
     const label = category === "primary" ? "Primary Arcane" : "Secondary Arcane"
     return { options: [weapon, kitgun], labels: [label, "Pax / Residual"] }
   }
-  // Primary/secondary: gate the weapon-type sub-pools (Shotgun/Bow/Kitgun
-  // arcanes) by this weapon's own class so e.g. a rifle doesn't see shotgun
-  // or kitgun arcanes. Falls back to the broad per-category pool when we have
-  // no item to inspect.
-  if (category === "primary" || category === "secondary") {
-    const shared = item
+  // Primary/secondary with an item: gate the weapon-type sub-pools (Shotgun/
+  // Bow/Kitgun arcanes) by this weapon's own class so e.g. a rifle doesn't see
+  // shotgun or kitgun arcanes. Everything else (and primary/secondary with no
+  // item to inspect) falls back to the broad per-category pool.
+  const shared =
+    (category === "primary" || category === "secondary") && item
       ? getArcanesForWeapon(allArcanes, category, item)
       : getArcanesForCategory(allArcanes, category)
-    return { options: Array.from({ length: count }, () => shared) }
-  }
-  const shared = getArcanesForCategory(allArcanes, category)
   return { options: Array.from({ length: count }, () => shared) }
 }
 
@@ -184,9 +181,7 @@ export function resolveInitialArcanes(
   const isZaw = isZawComponent(item.displayClass)
   const isKitgun = !isZaw && isKitgunWeapon(item)
   if (!isZaw && !isKitgun) return arcanes
-  const toSecondSlot = isZaw
-    ? (a: PlacedArcane) => isZawArcane(a.arcane)
-    : (a: PlacedArcane) => a.arcane.slotType === "Kitgun"
+  const toSecondSlot = (a: PlacedArcane) => isSecondSlotArcane(a.arcane, isZaw)
   const out: (PlacedArcane | null)[] = [null, null]
   for (const a of arcanes) {
     if (!a) continue

--- a/apps/web/src/components/build-editor/use-build-slots.ts
+++ b/apps/web/src/components/build-editor/use-build-slots.ts
@@ -400,20 +400,6 @@ export function useBuildSlots(
     [placed],
   )
 
-  const setPlacedAll = useCallback(
-    (next: Partial<Record<SlotId, PlacedMod>>) => {
-      setPlaced(next)
-    },
-    [],
-  )
-
-  const setFormaPolaritiesAll = useCallback(
-    (next: Partial<Record<SlotId, Polarity>>) => {
-      setFormaPolarities(next)
-    },
-    [],
-  )
-
   return {
     placed,
     usedNames,
@@ -427,7 +413,7 @@ export function useBuildSlots(
     setRank,
     setForma,
     swap,
-    setPlaced: setPlacedAll,
-    setFormaPolarities: setFormaPolaritiesAll,
+    setPlaced,
+    setFormaPolarities,
   }
 }

--- a/data/curated/class-pools.ts
+++ b/data/curated/class-pools.ts
@@ -65,7 +65,11 @@ export const CLASS_DEFAULT_POOLS: Record<string, readonly string[]> = {
   "Blade and Whip": ["Melee", "Blade And Whip"],
   Warfan: ["Melee", "Warfans"],
   Nunchaku: ["Melee", "Nunchaku"],
-  Bayonet: ["Melee"],
+  // The Bayonet stance pool is singular ("Bayonet"), unlike the plural stance
+  // compatNames of other classes. Vinquibus is the only Bayonet-class melee and
+  // its sole stance (Harrowing Spire, compatName "Bayonet") routes via this
+  // pool — omitting it hid the stance entirely. (wiki.warframe.com/w/Harrowing_Spire)
+  Bayonet: ["Melee", "Bayonet"],
   "Sword and Shield": ["Melee", "Sword And Shield"],
   Claws: ["Melee", "Claws"],
   "Assault Saw": ["Melee", "Assault Saw"],

--- a/packages/shared/src/warframe/arcanes.ts
+++ b/packages/shared/src/warframe/arcanes.ts
@@ -41,6 +41,14 @@ export function isZawArcane(arcane: Arcane): boolean {
   return n.includes("exodia") || n.includes("zaw")
 }
 
+/** Whether an arcane belongs in a modular weapon's dedicated *second* arcane
+ *  slot — the Exodia slot for Zaws, the Pax/Residual slot for Kitguns. The
+ *  single source for the Zaw-vs-Kitgun bucketing rule the editor uses both to
+ *  build the per-slot option lists and to re-bucket saved/imported arcanes. */
+export function isSecondSlotArcane(arcane: Arcane, isZaw: boolean): boolean {
+  return isZaw ? isZawArcane(arcane) : arcane.slotType === "Kitgun"
+}
+
 /** Operator-side arcane (Operator / Amp / Tektolyst) — never on a
  *  weapon/frame slot. */
 function isOperatorOrAmpArcane(arcane: Arcane): boolean {

--- a/scripts/build-items-index.ts
+++ b/scripts/build-items-index.ts
@@ -374,10 +374,14 @@ async function main() {
   // Mod display Name → wiki InternalName (= DE uniqueName). Resolves the
   // name-keyed `Incompatible` lists into uniqueNames below.
   const wikiModUniqueNameByName = new Map<string, string>()
-  // InternalName → the mod's `Incompatible` list (display Names). Mutually
+  // Owning mod display Name → its `Incompatible` list (display Names). Mutually
   // exclusive variant mods (Serration / Amalgam Serration / Spectral
-  // Serration, …) — see the conflict-graph build after mod merge.
-  const wikiIncompatByUniqueName = new Map<string, string[]>()
+  // Serration, …) — see the conflict-graph build after mod merge. Keyed by
+  // display Name (not InternalName) because the wiki's InternalName drifts from
+  // DE's uniqueName for some recent Primed mods, which silently dropped the
+  // edge; resolving both endpoints by display Name against the emitted catalog
+  // is robust to that drift.
+  const wikiIncompatByName = new Map<string, string[]>()
   for (const { internalName, record } of iterWikiRecords(wikiModsBlob)) {
     const name = record["Name"]
     if (typeof name === "string") {
@@ -398,11 +402,11 @@ async function main() {
       wikiConclaveMods.add(internalName)
     }
     const incompat = record["Incompatible"]
-    if (Array.isArray(incompat)) {
+    if (Array.isArray(incompat) && typeof name === "string") {
       // Some wiki entries carry placeholder `""` names; drop them so they
       // never become a dead lookup key.
-      wikiIncompatByUniqueName.set(
-        internalName,
+      wikiIncompatByName.set(
+        name,
         incompat.filter((x): x is string => typeof x === "string" && x !== ""),
       )
     }
@@ -647,6 +651,24 @@ async function main() {
   // variants, unreleased mods, Flawed mods we filter) are simply dropped — a
   // dead edge can't matter at runtime since the mod can never be placed.
   const emittedUniqueNames = new Set(mergedMods.map((m) => m.uniqueName))
+  // Display Name → emitted DE uniqueName. The authoritative resolver: DE's
+  // uniqueName is stable across wiki path renames, so keying on the shipped
+  // catalog's own names avoids the wiki-InternalName drift that previously
+  // dropped base↔Primed edges (Redirection, Steady Hands, Deadly Efficiency).
+  // First-wins on the rare duplicate display name.
+  const deNameToUniqueName = new Map<string, string>()
+  for (const m of mergedMods) {
+    if (!deNameToUniqueName.has(m.name)) deNameToUniqueName.set(m.name, m.uniqueName)
+  }
+  // Resolve a wiki display Name to an emitted uniqueName: prefer the DE catalog
+  // (stable), fall back to the wiki InternalName only when no shipped mod
+  // carries that name. Returns undefined when nothing emitted matches.
+  const resolveModName = (displayName: string): string | undefined => {
+    const de = deNameToUniqueName.get(displayName)
+    if (de) return de
+    const wiki = wikiModUniqueNameByName.get(displayName)
+    return wiki && emittedUniqueNames.has(wiki) ? wiki : undefined
+  }
   const conflictGraph = new Map<string, Set<string>>()
   const addConflictEdge = (a: string, b: string): void => {
     if (a === b) return
@@ -656,10 +678,32 @@ async function main() {
     conflictGraph.get(a)!.add(b)
     conflictGraph.get(b)!.add(a)
   }
-  for (const [uniqueName, names] of wikiIncompatByUniqueName) {
+  for (const [owningName, names] of wikiIncompatByName) {
+    const a = resolveModName(owningName)
+    if (!a) continue
     for (const conflictingName of names) {
-      const target = wikiModUniqueNameByName.get(conflictingName)
-      if (target) addConflictEdge(uniqueName, target)
+      const b = resolveModName(conflictingName)
+      if (b) addConflictEdge(a, b)
+    }
+  }
+  // Structural base↔variant edges. A Primed / Umbral / Amalgam / Archon mod is
+  // always mutually exclusive with its same-named base in-game, so derive those
+  // edges straight from the catalog rather than trusting the wiki to list them.
+  // This makes the "no two variants of one mod" guarantee independent of the
+  // wiki `Incompatible` field — which lagged DE for recent Primed mods
+  // (Redirection, Steady Hands, Deadly Efficiency), silently dropping the edge —
+  // and self-heals as new Primed mods ship instead of requiring a curated list.
+  // Cross-stem families (Sacrificial Pressure ↔ Pressure Point, Galvanized ↔
+  // base) don't share a name prefix and keep relying on the wiki edges above.
+  const VARIANT_PREFIXES = ["Primed ", "Umbral ", "Amalgam ", "Archon "]
+  let derivedVariantEdges = 0
+  for (const m of mergedMods) {
+    const prefix = VARIANT_PREFIXES.find((p) => m.name.startsWith(p))
+    if (!prefix) continue
+    const base = deNameToUniqueName.get(m.name.slice(prefix.length))
+    if (base && !conflictGraph.get(m.uniqueName)?.has(base)) {
+      addConflictEdge(m.uniqueName, base)
+      derivedVariantEdges++
     }
   }
   const modConflicts: Record<string, string[]> = {}
@@ -669,7 +713,8 @@ async function main() {
     conflictEdgeCount += set.size
   }
   console.log(
-    `  conflicts: ${conflictGraph.size} mods, ${conflictEdgeCount / 2} pairs`,
+    `  conflicts: ${conflictGraph.size} mods, ${conflictEdgeCount / 2} pairs ` +
+      `(${derivedVariantEdges} base↔variant derived structurally)`,
   )
 
   // ---------- 9. Write outputs ----------

--- a/scripts/build/merge-weapons.ts
+++ b/scripts/build/merge-weapons.ts
@@ -51,7 +51,7 @@ export const KNOWN_MOD_POOLS = new Set<string>([
   "Tonfas", "Rapiers", "Glaives", "Gunblade",
   "Machetes", "Whips", "Blade And Whip",
   "Warfans", "Nunchaku", "Sword And Shield",
-  "Thrown Melee", "Claws", "Assault Saw",
+  "Thrown Melee", "Claws", "Assault Saw", "Bayonet",
   // Companion / archwing / railjack
   "Archgun", "Archmelee", "Archwing",
   "Sentinel", "BEAST", "COMPANION", "ROBOTIC", "Hound", "Moa", "Kavat", "Kubrow",


### PR DESCRIPTION
## What & why

An audit of the build-rules code against the Warframe wiki surfaced two user-facing defects in the static-data build pipeline, plus a few editor cleanups.

### Mod conflicts — no double-equip of variant mods
The conflict graph was built solely from the wiki `Incompatible` field, resolved via the wiki **InternalName**. For some recent Primed mods that InternalName drifts from DE's `uniqueName`, so the edge was silently dropped — **Redirection**, **Steady Hands**, and **Deadly Efficiency** could each be stacked with their Primed variant with no warning in the editor.

Fix:
- Resolve conflict endpoints through the **DE catalog** (display name → `uniqueName`, stable across wiki path renames).
- Additionally **derive base↔variant edges structurally** (`Primed`/`Umbral`/`Amalgam`/`Archon` → same-named base). This makes the "no two variants of one mod" guarantee independent of wiki freshness and self-healing for future Primed mods — no hardcoded list to rot, and (per review) no hard `throw` that could block the unattended data-refresh build.

### Bayonet stance routing
`CLASS_DEFAULT_POOLS["Bayonet"]` omitted the `"Bayonet"` stance pool, so **Harrowing Spire** (the only stance for Vinquibus, the only Bayonet-class melee) was filtered out of the picker entirely. Added the pool plus the matching `KNOWN_MOD_POOLS` entry.

### Cleanups (behavior-preserving)
- Extracted `isSecondSlotArcane` into shared `arcanes.ts`; reused at both Zaw/Kitgun bucketing sites in `layout.ts` (previously duplicated 3×).
- Collapsed the duplicated `getArcaneSlotConfig` return tail.
- Dropped redundant `useCallback` passthrough wrappers in `use-build-slots.ts`; return the (referentially stable) `useState` setters directly.

## Reviewer notes
- **Data is not regenerated here.** `apps/web/public/data/` is generated and owned by the data-refresh pipeline; these source changes make that pipeline emit the corrected conflict graph and weapon pools. The fixes go live on the next `data:sync` + `build:items` run.
- **Verified locally**: ran `data:sync` + `build:items` — all variant pairs (Redirection / Steady Hands / Deadly Efficiency / Serration / Continuity / Intensify / Vitality …) link bidirectionally; Vinquibus gains the `Bayonet` pool. `0` edges derived structurally on current data (the resolution fix alone covers complete live wiki data) — confirming the structural pass adds no false edges while guarding against future wiki omissions. Typecheck (web/shared/scripts) and unit tests (79) pass.
