### PR TITLE
Add drop-settle micro-interaction to mod slots (#188)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,10 @@
 # CLAUDE.md — Arsenyx
 
-Warframe build planner. Create, share, discover equipment builds. Live at [www.arsenyx.com](https://www.arsenyx.com).
-
-Game data (items, mods, arcanes) is static JSON precomputed at build time and served from the CDN under `apps/web/public/data/`. User data (builds, votes, favorites) lives in Postgres via the API.
+Game data (items, mods, arcanes) is static JSON precomputed at build time and served from the CDN under `apps/web/public/data/`. User data (builds, likes, bookmarks) lives in Postgres.
 
 ## Deployment
 
-- Web (Vite SPA) → Cloudflare Workers (Static Assets), `www.arsenyx.com` + `arsenyx.com`. SPA fallback + cache headers via [apps/web/wrangler.toml](apps/web/wrangler.toml) and [apps/web/public/_headers](apps/web/public/_headers).
+- Web (Vite SPA) → Cloudflare Workers (Static Assets), `www.arsenyx.com` + `arsenyx.com`. SPA fallback + cache headers via [apps/web/wrangler.toml](apps/web/wrangler.toml) and [apps/web/public/\_headers](apps/web/public/_headers).
 - API (Hono on Workers) → `api.arsenyx.com`, Prisma 7 + `@prisma/adapter-neon` (workerd runtime)
 - DB → Neon Postgres, EU (`eu-central-1`)
 - CI deploys both Workers on push to `main` via Workers Builds (configured in the CF dashboard). Secrets live in the CF dashboard, not in `.env`.
@@ -19,8 +17,6 @@ Bun workspaces. **Never use npm/npx.**
 - `apps/api/` — Hono + Prisma 7 + Better Auth + Postgres → see [apps/api/CLAUDE.md](apps/api/CLAUDE.md)
 - `packages/shared/` — types/codecs shared by web and api (`@arsenyx/shared/*`)
 
-Run: `just dev` (web + api), `just web`, `just api`.
-
 ## Architecture
 
 Game data is static, user data is dynamic. If something is read-heavy and rarely changes, emit it as a file under `apps/web/public/data/` — don't add an API route for it.
@@ -28,15 +24,18 @@ Game data is static, user data is dynamic. If something is read-heavy and rarely
 ## Boundaries
 
 **Always**
+
 - `bun run typecheck` (web + api + shared) before claiming done — `vite build` and dev servers don't typecheck, so web/shared type errors hide otherwise
 - `just check` (typecheck + oxlint + oxfmt) touched files before committing; `just fix` auto-applies lint + format
 - Use `uv run python` instead of `python`/`python3`
 
 **Ask first**
+
 - Adding new dependencies — don't skip this; actually discuss it with the user first
 - Schema changes that drop/rename columns or add required fields
 
 **Never**
+
 - Modify `apps/web/src/components/ui/` — override via `className` instead
 - Don't assume Warframe game-mechanic facts from memory. Mod compatibility, slot rules, ability behavior, drop sources, etc. drift between updates and the model's training data is unreliable here. Check [wiki.warframe.com](https://wiki.warframe.com) (via WebFetch) or the data files under `apps/web/public/data/` before encoding a rule into filters, validators, or hardcoded branches. If a fact can't be verified, say so instead of guessing.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,118 @@
+# Arsenyx
+
+Warframe build planner. Users create, share, and discover equipment builds. This
+glossary captures the language **specific to Arsenyx** — the app's own concepts,
+plus the handful of Warframe terms whose meaning is precise or app-specific here.
+Canonical game terms with a single accepted meaning (Mod, Arcane, Polarity, Forma,
+Riven…) are intentionally left out — the game and the wiki already define them, and
+[CLAUDE.md](./CLAUDE.md) forbids encoding game facts from memory anyway.
+
+It is a glossary, not a spec or a roadmap: every term below corresponds to a concept
+the code actually models today.
+
+## Builds
+
+**Build**:
+The shareable, addressable unit a user creates — one **Item**, plus a name, **Slug**,
+**Visibility**, optional **Guide**, and social counts. A Build is a container: the
+actual loadout lives in its **Variants**.
+_Avoid_: Loadout, Setup (those refer to a single Variant, not the whole shareable object).
+
+**Variant**:
+One concrete loadout within a Build — its mods, arcanes, shards, forma, incarnon, and
+helminth choices. A Build has 1–5 Variants; the Variant is the thing the editor edits.
+_Avoid_: Build (the container, not the loadout), Loadout. Also note: a Warframe Prime/Wraith/Prisma
+"variant" is **not** a Variant here — those are modeled as separate **Items** in the catalog.
+
+**Guide**:
+Optional authored prose on a Build: a short summary (≤160 chars) and a longer description
+(≤50k chars). Can be build-wide or per-Variant.
+_Avoid_: Description (too generic — the Guide is the summary + description pair), Notes.
+
+**Visibility**:
+Who can see a Build. Exactly three levels: **PUBLIC** (discoverable in browse),
+**UNLISTED** (reachable by direct link, not listed), **PRIVATE** (owner / org members only).
+_Avoid_: Privacy, Draft, Published (these conflate the three-state enum with a boolean).
+
+**Slug**:
+The immutable, URL-safe id of a Build (a 10-char nanoid excluding lookalike characters).
+The public key in `/builds/:slug`.
+_Avoid_: ID, Permalink.
+
+## Social actions
+
+**Like**:
+A one-click endorsement of a Build by a viewer; the count is denormalized on the Build,
+and you cannot Like your own. Modeled as `BuildLike`.
+_Avoid_: **Vote**, **Upvote**, Star, Heart.
+
+**Bookmark**:
+A viewer saving a Build to their personal list for later. Modeled as `BuildBookmark`.
+_Avoid_: **Favorite**, Save, Pin, Collection.
+
+**Fork**:
+A copy of an existing Build created under the forking user's own ownership, initialized
+PRIVATE and linked back to the original via `forkedFromId`.
+_Avoid_: Clone, Copy, Remix, Duplicate.
+
+**Partner Build**:
+A symmetric link between two Builds (e.g. complementary multiplayer loadouts) that requires
+mutual consent — both owners must confirm it. Modeled as the self-referential `BuildLink`.
+_Avoid_: Linked Build, Related Build, Combo.
+
+## People
+
+**User**:
+A registered person who owns the Builds they create and is credited for them by username
+(the byline). Owns the Build outright — edit and delete rights — regardless of any
+Organization it is published under.
+_Avoid_: Author, Owner, Account, Member (all collapse into User; "Member" specifically means an Organization membership, below).
+
+**Organization**:
+An optional team namespace a Build can be published under; its members hold an ADMIN or
+MEMBER role, and the org name appears in or replaces the User's byline on its Builds.
+_Avoid_: Team, Group, Studio. "Org" is an acceptable short form.
+
+## Items & loadout (Warframe terms, as Arsenyx models them)
+
+**Item**:
+Any single equippable the catalog knows about — a Warframe, weapon, Necramech, Companion,
+etc. A Build is always for exactly one Item. Prime/variant editions are distinct Items, not
+**Variants**.
+_Avoid_: Frame, Weapon, Gear (those name subtypes; "Item" is the umbrella the catalog uses).
+
+**Category**:
+The Item's top-level type, one of a fixed set of 10 (warframes, primary, secondary, melee,
+necramechs, companions, companion-weapons, exalted-weapons, archwing, railjack). Drives slot
+layout and arcane eligibility.
+_Avoid_: Type, Class, Kind. (Reserve "class" for an Item's mechanical `displayClass`, e.g. "Sniper Rifle".)
+
+**Slot**:
+A position in a Variant that holds one mod. Kinds: **normal**, **aura**, **exilus**, and
+**stance** — each with its own placement rules. A slot also carries its polarity (innate or
+re-stamped by Forma).
+_Avoid_: Cell, Position.
+
+**Capacity** / **Drain**:
+**Drain** is the cost a placed mod charges against the Item's mod **Capacity** (the budget,
+30 base, 60 with a Reactor/Catalyst). Arsenyx computes both live as you edit.
+_Avoid_: Cost, Points, Energy (Energy is an in-game ability resource, unrelated).
+
+## Example dialogue
+
+> **Dev:** A user opened a Build with two Variants — do Likes attach to the Variant they're viewing?
+>
+> **Domain:** No. Likes, Bookmarks, and the Slug all live on the **Build** — the shareable
+> container. **Variants** are just the 1–5 loadouts inside it; switching Variants doesn't change
+> what you Liked.
+>
+> **Dev:** And if they Fork it?
+>
+> **Domain:** They get their own PRIVATE Build, all Variants copied, linked back via `forkedFromId`.
+> Likes and Bookmarks don't carry over — those belong to the original.
+>
+> **Dev:** Right. And when it's published under their Organization with the username hidden —
+> who's the owner?
+>
+> **Domain:** Still the **User**. The Org only changes the byline; ownership and edit rights never
+> leave the User.

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -176,6 +176,17 @@ model Build {
   hasShards Boolean @default(false)
   hasGuide  Boolean @default(false)
 
+  // Forma count is a projection of buildData (slot forma polarities) + the
+  // item's innate polarities (game catalog). Computed client-side at save
+  // time and stored here so the list endpoint can show/sort it without
+  // shipping buildData. `formaCalcVersion` records which derivation produced
+  // it (0 = never computed, e.g. pre-backfill rows) so a calc fix can target
+  // only stale rows; `catalogVersion` records the game-data snapshot it was
+  // computed against. See packages/shared/warframe/forma.ts + recompute-forma.ts.
+  formaCount       Int     @default(0)
+  formaCalcVersion Int     @default(0)
+  catalogVersion   String?
+
   // Maintained by Postgres trigger, not Prisma
   searchVector Unsupported("tsvector")?
 
@@ -208,6 +219,7 @@ model Build {
   @@index([visibility])
   @@index([likeCount])
   @@index([createdAt])
+  @@index([formaCount])
   @@index([visibility, likeCount])
   @@index([visibility, createdAt])
   @@index([userId, visibility])

--- a/apps/api/src/routes/_build-list.ts
+++ b/apps/api/src/routes/_build-list.ts
@@ -18,6 +18,7 @@ export const LIST_SELECT = {
   likeCount: true,
   bookmarkCount: true,
   viewCount: true,
+  formaCount: true,
   hasGuide: true,
   hasShards: true,
   hideAuthor: true,
@@ -95,6 +96,7 @@ export function serializeBuildDetail(b: DetailRow, viewer: ViewerState | null) {
     likeCount: b.likeCount,
     bookmarkCount: b.bookmarkCount,
     viewCount: b.viewCount,
+    formaCount: b.formaCount,
     createdAt: b.createdAt,
     updatedAt: b.updatedAt,
     user: b.user,
@@ -119,6 +121,7 @@ export function serializeListRow(b: ListRow): BuildListItemResponse {
     likeCount: b.likeCount,
     bookmarkCount: b.bookmarkCount,
     viewCount: b.viewCount,
+    formaCount: b.formaCount,
     hasGuide: b.hasGuide,
     hasShards: b.hasShards,
     hideAuthor: b.hideAuthor,
@@ -183,6 +186,10 @@ function orderByForSort(sort: ListSort) {
       ]
     case "viewed":
       return [{ viewCount: "desc" as const }, { createdAt: "desc" as const }]
+    case "forma-asc":
+      return [{ formaCount: "asc" as const }, { createdAt: "desc" as const }]
+    case "forma-desc":
+      return [{ formaCount: "desc" as const }, { createdAt: "desc" as const }]
     case "newest":
     default:
       return [{ createdAt: "desc" as const }]
@@ -203,6 +210,10 @@ function tiebreakerSql(sort: ListSort) {
       return Prisma.sql`"bookmarkCount" DESC, "createdAt" DESC`
     case "viewed":
       return Prisma.sql`"viewCount" DESC, "createdAt" DESC`
+    case "forma-asc":
+      return Prisma.sql`"formaCount" ASC, "createdAt" DESC`
+    case "forma-desc":
+      return Prisma.sql`"formaCount" DESC, "createdAt" DESC`
     case "newest":
     default:
       return Prisma.sql`"createdAt" DESC`

--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -1,5 +1,10 @@
 import { MAX_VARIANTS } from "@arsenyx/shared/warframe/build-doc"
 import { isValidCategory } from "@arsenyx/shared/warframe/categories"
+import {
+  FORMA_CALC_VERSION,
+  FORMA_UNSTAMPED,
+  MAX_FORMA_COUNT,
+} from "@arsenyx/shared/warframe/forma"
 import { Hono, type Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
 import { customAlphabet, nanoid } from "nanoid"
@@ -64,6 +69,33 @@ function hasShardsInBuildData(buildData: unknown): boolean {
   return Array.isArray(shards) && shards.some((s) => s != null)
 }
 
+const MAX_CATALOG_VERSION = 64
+
+// Forma count is computed client-side (the only place with the game catalog of
+// innate polarities) and sent on save. We trust but bound it: a non-negative
+// integer ≤ MAX_FORMA_COUNT. Returns null when absent/invalid so callers can
+// decide whether that's a hard error (POST) or a no-op (PATCH without buildData).
+// The version stamp is set server-side from FORMA_CALC_VERSION — never trusted
+// from the client — so a stale client can't claim its count is current.
+function parseFormaFields(b: Record<string, unknown>): {
+  formaCount: number
+  formaCalcVersion: number
+  catalogVersion: string | null
+} | null {
+  const raw = b.formaCount
+  if (typeof raw !== "number" || !Number.isInteger(raw)) return null
+  if (raw < 0 || raw > MAX_FORMA_COUNT) return null
+  const catalogVersion =
+    typeof b.catalogVersion === "string"
+      ? b.catalogVersion.slice(0, MAX_CATALOG_VERSION)
+      : null
+  return {
+    formaCount: raw,
+    formaCalcVersion: FORMA_CALC_VERSION,
+    catalogVersion,
+  }
+}
+
 function parseGuide(input: unknown) {
   if (!input || typeof input !== "object") return null
   const g = input as Record<string, unknown>
@@ -115,6 +147,13 @@ builds.post("/", rateLimitUser("mutate"), async (c) => {
 
   const buildData = b.buildData as InputJsonValue
   const guide = parseGuide(b.guide)
+  // Lenient: a client that doesn't send a count (or sends a bad one) gets a
+  // sentinel `formaCalcVersion: 0` row, which the recompute backfill picks up.
+  const forma = parseFormaFields(b) ?? {
+    formaCount: 0,
+    formaCalcVersion: FORMA_UNSTAMPED,
+    catalogVersion: null,
+  }
 
   const orgResult = await resolveOrgAssignment(
     b.organizationId,
@@ -145,6 +184,9 @@ builds.post("/", rateLimitUser("mutate"), async (c) => {
           hideAuthor,
           buildData,
           hasShards: hasShardsInBuildData(buildData),
+          formaCount: forma.formaCount,
+          formaCalcVersion: forma.formaCalcVersion,
+          catalogVersion: forma.catalogVersion,
           hasGuide: guide?.hasGuide ?? false,
           buildGuide: guide?.hasGuide
             ? {
@@ -235,6 +277,18 @@ builds.patch("/:slug", rateLimitUser("mutate"), async (c) => {
     }
     data.buildData = b.buildData as InputJsonValue
     data.hasShards = hasShardsInBuildData(b.buildData)
+    // buildData changed → the forma count must move with it. Take the fresh
+    // count if the client sent a valid one; otherwise flag the row stale
+    // (formaCalcVersion 0) so the recompute backfill corrects it rather than
+    // leaving a silently-wrong count behind.
+    const forma = parseFormaFields(b)
+    if (forma) {
+      data.formaCount = forma.formaCount
+      data.formaCalcVersion = forma.formaCalcVersion
+      data.catalogVersion = forma.catalogVersion
+    } else {
+      data.formaCalcVersion = FORMA_UNSTAMPED
+    }
   }
   // The editor flips itemImageName when the incarnon toggle is applied;
   // accept it on PATCH so the build-overview thumbnail tracks the change.
@@ -304,6 +358,9 @@ builds.post("/:slug/fork", rateLimitUser("mutate"), async (c) => {
       name: true,
       buildData: true,
       hasShards: true,
+      formaCount: true,
+      formaCalcVersion: true,
+      catalogVersion: true,
     },
   })
   if (!source) return c.json({ error: "not_found" }, 404)
@@ -328,6 +385,9 @@ builds.post("/:slug/fork", rateLimitUser("mutate"), async (c) => {
           visibility: "PRIVATE",
           buildData: source.buildData as InputJsonValue,
           hasShards: source.hasShards,
+          formaCount: source.formaCount,
+          formaCalcVersion: source.formaCalcVersion,
+          catalogVersion: source.catalogVersion,
           forkedFromId: source.id,
         },
         select: { id: true, slug: true },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
-    "deploy": "vite build && wrangler deploy"
+    "deploy": "vite build && wrangler deploy",
+    "recompute:forma": "bun --env-file=../api/.env scripts/recompute-forma.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -27,6 +28,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@neondatabase/serverless": "^1.1.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-devtools": "^1.95.1",

--- a/apps/web/scripts/recompute-forma.ts
+++ b/apps/web/scripts/recompute-forma.ts
@@ -1,0 +1,209 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { FORMA_CALC_VERSION } from "@arsenyx/shared/warframe/forma"
+import type { Polarity } from "@arsenyx/shared/warframe/types"
+/**
+ * Recompute & backfill the denormalized `formaCount` on every build.
+ *
+ * Forma count is a projection of buildData (slot forma polarities) + the item's
+ * innate polarities (the game catalog). It's computed client-side at save time
+ * and stored on the row so the list endpoint can show / sort it without shipping
+ * buildData. This script is the re-runnable maintenance lever: after a forma
+ * calc fix (bump FORMA_CALC_VERSION) or a catalog regeneration, run it to bring
+ * stored counts back in line — touching only the rows that are stale.
+ *
+ * It reuses the EXACT `computeFormaCount` the editor uses (apps/web), so a
+ * card's number can never drift from the detail page's.
+ *
+ * Lives in apps/web (not scripts/ or apps/api) because it needs both the web
+ * calc — which only resolves under the web tsconfig's `@/` alias + DOM lib —
+ * and a DB client. The api can't import apps/web (boundary), so this is the one
+ * place the two meet. DB access mirrors apps/api/scripts/seed-admin.ts: the
+ * Prisma client is workerd-only and won't load here, so we talk to Neon
+ * directly via @neondatabase/serverless.
+ *
+ *   bun run recompute:forma              # dry run — reports diffs, writes nothing
+ *   bun run recompute:forma --apply      # write the recomputed counts
+ *   bun run recompute:forma --apply --all  # restamp every row, not just stale ones
+ *
+ * The `recompute:forma` package script wires `--env-file=../api/.env` so
+ * DATABASE_URL resolves. Point that at a dev branch before --apply.
+ */
+import { neon } from "@neondatabase/serverless"
+
+import { computeFormaCount } from "@/components/build-editor/forma-count"
+import type { SlotId } from "@/components/build-editor/use-build-slots"
+import type { BrowseCategory, DetailItem } from "@/lib/warframe"
+
+const APPLY = process.argv.includes("--apply")
+const ALL = process.argv.includes("--all")
+const DATA_DIR = resolve(import.meta.dirname, "../public/data")
+
+const DATABASE_URL = process.env.DATABASE_URL
+if (!DATABASE_URL) {
+  console.error(
+    "DATABASE_URL not set. Run via `bun run recompute:forma`, which loads ../api/.env.",
+  )
+  process.exit(1)
+}
+
+// --- catalog ---------------------------------------------------------------
+
+/** Mirrors apps/web/vite.config.ts `dataVersion()` so the `catalogVersion`
+ *  stamp this script writes matches what the client (`__DATA_VERSION__`)
+ *  writes on save. */
+function catalogVersion(): string {
+  try {
+    const meta = JSON.parse(
+      readFileSync(resolve(DATA_DIR, "meta.json"), "utf8"),
+    ) as { generatedAt?: string }
+    const ts = Date.parse(meta.generatedAt ?? "")
+    if (!Number.isNaN(ts)) return String(ts)
+  } catch {
+    // meta.json absent on a fresh checkout before build:items has run.
+  }
+  return "0"
+}
+const CATALOG_VERSION = catalogVersion()
+
+// uniqueName -> { category dir, slug } from the lightweight index, so we can
+// find each build's per-item detail JSON (which carries the innate polarities).
+type IndexItem = { uniqueName: string; slug: string }
+const index = JSON.parse(
+  readFileSync(resolve(DATA_DIR, "items-index.json"), "utf8"),
+) as Record<string, IndexItem[]>
+const locator = new Map<string, { category: string; slug: string }>()
+for (const [category, items] of Object.entries(index)) {
+  for (const it of items)
+    locator.set(it.uniqueName, { category, slug: it.slug })
+}
+
+const itemCache = new Map<string, DetailItem | null>()
+function loadItem(uniqueName: string): DetailItem | null {
+  const cached = itemCache.get(uniqueName)
+  if (cached !== undefined) return cached
+  const loc = locator.get(uniqueName)
+  let item: DetailItem | null = null
+  if (loc) {
+    try {
+      item = JSON.parse(
+        readFileSync(
+          resolve(DATA_DIR, "items", loc.category, `${loc.slug}.json`),
+          "utf8",
+        ),
+      ) as DetailItem
+    } catch {
+      item = null
+    }
+  }
+  itemCache.set(uniqueName, item)
+  return item
+}
+
+// --- buildData -------------------------------------------------------------
+
+function extractFormaPolarities(
+  buildData: unknown,
+): Partial<Record<SlotId, Polarity>> {
+  if (!buildData || typeof buildData !== "object") return {}
+  const fp = (buildData as Record<string, unknown>).formaPolarities
+  if (!fp || typeof fp !== "object") return {}
+  const out: Record<string, Polarity> = { ...(fp as Record<string, Polarity>) }
+  // Legacy single-loadout builds keyed the aura slot "aura" before the
+  // multi-aura migration renamed it "aura-0" (build-codec-adapter
+  // migrateLegacyAuraKey). Normalize so the count matches the editor.
+  if ("aura" in out && !("aura-0" in out)) {
+    out["aura-0"] = out.aura!
+    delete out.aura
+  }
+  return out as Partial<Record<SlotId, Polarity>>
+}
+
+// --- run -------------------------------------------------------------------
+
+type Row = {
+  id: string
+  itemUniqueName: string
+  itemCategory: string
+  buildData: unknown
+  formaCount: number
+  formaCalcVersion: number
+}
+
+const sql = neon(DATABASE_URL)
+const rows = (await sql`
+  SELECT id, "itemUniqueName", "itemCategory", "buildData", "formaCount", "formaCalcVersion"
+  FROM builds
+`) as Row[]
+
+let valueChanged = 0
+let restamped = 0
+let upToDate = 0
+let missingItem = 0
+let computeError = 0
+const sample: string[] = []
+
+for (const r of rows) {
+  const item = loadItem(r.itemUniqueName)
+  if (!item) {
+    missingItem++
+    continue
+  }
+  let next: number
+  try {
+    next = computeFormaCount(
+      item,
+      r.itemCategory as BrowseCategory,
+      extractFormaPolarities(r.buildData),
+    )
+  } catch {
+    computeError++
+    continue
+  }
+
+  const diff = next !== r.formaCount
+  const stale = r.formaCalcVersion !== FORMA_CALC_VERSION
+  if (!ALL && !diff && !stale) {
+    upToDate++
+    continue
+  }
+  if (diff) {
+    valueChanged++
+    if (sample.length < 25) {
+      sample.push(`  ${r.id}  ${item.name}: ${r.formaCount} → ${next}`)
+    }
+  } else {
+    restamped++
+  }
+
+  if (APPLY) {
+    await sql`
+      UPDATE builds
+      SET "formaCount" = ${next},
+          "formaCalcVersion" = ${FORMA_CALC_VERSION},
+          "catalogVersion" = ${CATALOG_VERSION}
+      WHERE id = ${r.id}
+    `
+  }
+}
+
+const verb = APPLY ? "Updated" : "Would update"
+console.log(
+  `\nForma recompute — calc v${FORMA_CALC_VERSION}, catalog ${CATALOG_VERSION}`,
+)
+console.log(`  builds scanned:   ${rows.length}`)
+console.log(`  value changed:    ${valueChanged}`)
+console.log(
+  `  restamped only:   ${restamped} (count already correct, version bumped)`,
+)
+console.log(`  already current:  ${upToDate}`)
+if (missingItem) console.log(`  item not in catalog (skipped): ${missingItem}`)
+if (computeError) console.log(`  compute errors (skipped): ${computeError}`)
+if (sample.length) {
+  console.log(`\nSample value changes:`)
+  console.log(sample.join("\n"))
+}
+console.log(`\n${verb} ${valueChanged + restamped} rows.`)
+if (!APPLY)
+  console.log("Dry run — nothing written. Re-run with --apply to write.")

--- a/apps/web/src/components/build-editor/build-derived.ts
+++ b/apps/web/src/components/build-editor/build-derived.ts
@@ -5,10 +5,16 @@ import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 
 import {
   calculateCapacity,
-  calculateFormaCount,
   calculateTotalEndoCost,
   type CapacityInput,
 } from "./calculations"
+import {
+  computeFormaCount,
+  getAuraPolarities,
+  getExilusInnatePolarity,
+  getStanceInnatePolarity,
+  toPolarity,
+} from "./forma-count"
 import {
   type ArcaneSlotConfig,
   getArcaneSlotConfig,
@@ -22,12 +28,6 @@ import {
   hasLockedStance,
   hasStanceSlot,
 } from "./layout"
-import {
-  getAuraPolarities,
-  getExilusInnatePolarity,
-  getStanceInnatePolarity,
-  toPolarity,
-} from "./mod-grid"
 import type { BuildSlotsState } from "./use-build-slots"
 
 /**
@@ -119,22 +119,12 @@ export function useBuildDerived(input: {
     () => calculateTotalEndoCost(slots.placed),
     [slots.placed],
   )
+  // Delegate to the shared pure helper so the editor, the card, and the
+  // offline recompute backfill all produce the same number. (The innate
+  // memos above stay — the capacity path still needs them.)
   const formaCount = useMemo(
-    () =>
-      calculateFormaCount({
-        auraInnates,
-        exilusInnate,
-        stanceInnate,
-        normalInnates,
-        formaPolarities: slots.formaPolarities,
-      }),
-    [
-      auraInnates,
-      exilusInnate,
-      stanceInnate,
-      normalInnates,
-      slots.formaPolarities,
-    ],
+    () => computeFormaCount(item, category, slots.formaPolarities),
+    [item, category, slots.formaPolarities],
   )
 
   const normalSlotConsumesDrain = useMemo(() => {

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -1019,6 +1019,13 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
         // image-map.json, editor via the catalog), so storing them just bloats
         // the row and rots across image-scheme changes.
         buildData: captureBuildData(),
+        // Forma count is a projection of buildData + the item's innate
+        // polarities (catalog). Compute it here — the only place with the
+        // catalog — so the list endpoint can show/sort it without shipping
+        // buildData. `catalogVersion` stamps which catalog snapshot it was
+        // computed against (server stamps the calc version).
+        formaCount,
+        catalogVersion: __DATA_VERSION__,
         guide: {
           summary: guideSummary.trim() || null,
           description: guideDescription.trim() || null,

--- a/apps/web/src/components/build-editor/forma-count.ts
+++ b/apps/web/src/components/build-editor/forma-count.ts
@@ -1,0 +1,74 @@
+import { toPolarity } from "@arsenyx/shared/warframe/polarities"
+import type { Polarity } from "@arsenyx/shared/warframe/types"
+
+import type { BrowseCategory, DetailItem } from "@/lib/warframe"
+
+import { calculateFormaCount } from "./calculations"
+import { getAuraSlotCount, getNormalSlotCount } from "./layout"
+import type { SlotId } from "./use-build-slots"
+
+// Pure (React-free) forma derivation. Kept out of mod-grid.tsx / build-derived.ts
+// so it can be reused both by the editor and by the offline recompute backfill
+// (scripts/recompute-forma.ts), which can't load React. mod-grid.tsx re-exports
+// the polarity helpers for existing importers.
+
+export { toPolarity }
+
+/**
+ * Per-slot innate polarities for an item's aura slots. `item.auraPolarity`
+ * may be a single polarity string (most frames) or an array (Jade: 2 slots).
+ * Length always matches `count` so callers can zip by index.
+ */
+export function getAuraPolarities(
+  item: Pick<DetailItem, "auraPolarity">,
+  count: number,
+): (Polarity | undefined)[] {
+  const raws = Array.isArray(item.auraPolarity)
+    ? item.auraPolarity
+    : item.auraPolarity
+      ? [item.auraPolarity]
+      : []
+  return Array.from({ length: count }, (_, i) => toPolarity(raws[i]))
+}
+
+/**
+ * Innate exilus polarity, sourced from the `exilusPolarity` field
+ * (extracted from the Warframe wiki's `Module:Weapons/data` /
+ * `Module:Warframes/data` Lua tables).
+ */
+export function getExilusInnatePolarity(
+  item: Pick<DetailItem, "exilusPolarity">,
+): Polarity | undefined {
+  return toPolarity(item.exilusPolarity)
+}
+
+export function getStanceInnatePolarity(
+  item: Pick<DetailItem, "stancePolarity">,
+): Polarity | undefined {
+  return toPolarity(item.stancePolarity)
+}
+
+/**
+ * Forma count for a build: a pure function of the item's innate polarities
+ * (game catalog) + the user's per-slot forma polarities (`formaPolarities`,
+ * stored in buildData). This is the single source of truth the editor
+ * (`useBuildDerived`) and the recompute backfill both call, so a card's count
+ * always matches the detail page and a future fix only has to change here.
+ */
+export function computeFormaCount(
+  item: DetailItem,
+  category: BrowseCategory,
+  formaPolarities: Partial<Record<SlotId, Polarity>>,
+): number {
+  const auraSlotCount = getAuraSlotCount(category, item)
+  const normalSlotCount = getNormalSlotCount(category)
+  return calculateFormaCount({
+    auraInnates: getAuraPolarities(item, auraSlotCount),
+    exilusInnate: getExilusInnatePolarity(item),
+    stanceInnate: getStanceInnatePolarity(item),
+    normalInnates: Array.from({ length: normalSlotCount }, (_, i) =>
+      toPolarity(item.polarities?.[i]),
+    ),
+    formaPolarities,
+  })
+}

--- a/apps/web/src/components/build-editor/index.ts
+++ b/apps/web/src/components/build-editor/index.ts
@@ -50,14 +50,13 @@ export {
   type PlexusGroup,
   type PlexusGroupKind,
 } from "./layout"
+export { ArcaneRow, ModGrid } from "./mod-grid"
 export {
-  ArcaneRow,
   getAuraPolarities,
   getExilusInnatePolarity,
   getStanceInnatePolarity,
-  ModGrid,
   toPolarity,
-} from "./mod-grid"
+} from "./forma-count"
 export { ModCard } from "./mod-card"
 export { ModSearchGrid } from "./mod-search-grid"
 export { RivenDialog, type RivenDialogValues } from "./riven-dialog"
@@ -67,7 +66,7 @@ export {
   type PublishVisibility,
 } from "./publish-dialog"
 export { ModSlot, type ModSlotKind } from "./mod-slot"
-export { CANONICAL_POLARITIES, PolarityIcon, PolarityPicker } from "./polarity"
+export { PolarityIcon, PolarityPicker } from "./polarity"
 export {
   useBuildSlots,
   getNextSlot,

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -5,52 +5,19 @@ import { cn } from "@/lib/util/utils"
 import type { BrowseCategory, DetailItem } from "@/lib/warframe"
 
 import { ArcaneSlot } from "./arcane"
+// Pure polarity helpers live in ./forma-count (so the offline recompute backfill
+// can reuse them without loading React); imported here for internal use only.
+// Consumers import them from ./forma-count or the build-editor barrel directly.
+import {
+  getAuraPolarities,
+  getExilusInnatePolarity,
+  getStanceInnatePolarity,
+  toPolarity,
+} from "./forma-count"
 import { getLockedStance, PLEXUS_GROUPS } from "./layout"
 import { ModSlot } from "./mod-slot"
-import { CANONICAL_POLARITIES } from "./polarity"
 import type { ArcaneSlotsState } from "./use-arcane-slots"
 import type { BuildSlotsState, SlotId } from "./use-build-slots"
-
-const CANONICAL_SET = new Set<Polarity>(CANONICAL_POLARITIES)
-
-export function toPolarity(v: string | null | undefined): Polarity | undefined {
-  if (!v) return undefined
-  return CANONICAL_SET.has(v as Polarity) ? (v as Polarity) : undefined
-}
-
-/**
- * Per-slot innate polarities for an item's aura slots. `item.auraPolarity`
- * may be a single polarity string (most frames) or an array (Jade: 2 slots).
- * Length always matches `count` so callers can zip by index.
- */
-export function getAuraPolarities(
-  item: Pick<DetailItem, "auraPolarity">,
-  count: number,
-): (Polarity | undefined)[] {
-  const raws = Array.isArray(item.auraPolarity)
-    ? item.auraPolarity
-    : item.auraPolarity
-      ? [item.auraPolarity]
-      : []
-  return Array.from({ length: count }, (_, i) => toPolarity(raws[i]))
-}
-
-/**
- * Innate exilus polarity, sourced from the `exilusPolarity` field
- * (extracted from the Warframe wiki's `Module:Weapons/data` /
- * `Module:Warframes/data` Lua tables).
- */
-export function getExilusInnatePolarity(
-  item: Pick<DetailItem, "exilusPolarity">,
-): Polarity | undefined {
-  return toPolarity(item.exilusPolarity)
-}
-
-export function getStanceInnatePolarity(
-  item: Pick<DetailItem, "stancePolarity">,
-): Polarity | undefined {
-  return toPolarity(item.stancePolarity)
-}
 
 export function ArcaneRow({
   arcanes,

--- a/apps/web/src/components/build-editor/mod-slot.tsx
+++ b/apps/web/src/components/build-editor/mod-slot.tsx
@@ -1,7 +1,13 @@
 import { isRivenMod } from "@arsenyx/shared/warframe/rivens"
 import type { Mod, Polarity } from "@arsenyx/shared/warframe/types"
 import { Pencil, Plus, X, type LucideIcon } from "lucide-react"
-import { useState, type MouseEvent, type PointerEvent } from "react"
+import {
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type PointerEvent,
+} from "react"
 
 import {
   Popover,
@@ -29,6 +35,11 @@ import type { SlotId } from "./use-build-slots"
 import { useRankHotkey } from "./use-rank-hotkey"
 
 export type ModSlotKind = "normal" | "aura" | "exilus" | "stance"
+
+// Constructed once at module load (browser-only SPA). `.matches` reads live, so
+// it still reflects an OS setting the user toggles mid-session — we just avoid
+// allocating a fresh MediaQueryList on every drop in every slot.
+const reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
 
 interface ModSlotProps {
   kind?: ModSlotKind
@@ -95,6 +106,27 @@ export function ModSlot({
   const isDragging = useIsDragSourceSlot(slotId)
   const isAnyDragging = useIsAnyDragActive()
   const canDrag = !readOnly && !!mod && !!slotId && kind !== "aura"
+  // Drop settle (issue #188), gated for prefers-reduced-motion: a one-shot
+  // scale when a mod lands. Driven by a state flag cleared on animationend —
+  // deliberately NOT a React `key`. Re-keying the wrapper would remount
+  // ModCard, which owns the hover-preview portal; remounting it out from under
+  // an open preview orphans that portal (preview stays stuck). The flag flips
+  // only when the mod identity changes to a non-empty mod, so it fires on
+  // placement/swap but never on initial load or rank-only changes.
+  const [settling, setSettling] = useState(false)
+  const prevModName = useRef<string | null>(mod?.name ?? null)
+  useEffect(() => {
+    const name = mod?.name ?? null
+    if (name !== prevModName.current) {
+      prevModName.current = name
+      // Gate the settle at the source: under prefers-reduced-motion the flash
+      // overlay's `animation: none` means its `animationend` never fires, so
+      // `settling` would latch true forever. Never flip it on instead — no
+      // overlay, no scale class, no stuck state.
+      setSettling(name != null && !reducedMotionQuery.matches)
+    }
+  }, [mod?.name])
+
   const onDragPointerDown = (e: PointerEvent) => {
     if (!canDrag || !startDrag || !mod || !slotId) return
     startDrag({ kind: "slot", slotId, mod, rank }, e)
@@ -189,18 +221,33 @@ export function ModSlot({
         >
           {mod && !isDragging ? (
             <>
-              <ModCard
-                mod={mod}
-                rank={rank}
-                disableHover={popoverOpen || isAnyDragging}
-                drainOverride={
-                  kind === "aura" || kind === "stance"
-                    ? auraBonusForMod(mod, rank, effective)
-                    : effectiveDrainForMod(mod, rank, effective)
-                }
-                matchState={getMatchState(mod.polarity, effective)}
-                hideDrain={hideDrain}
-              />
+              {/* No `key` here on purpose — see the `settling` comment above.
+                  The scale class is added while `settling` is true; ModCard
+                  underneath is never remounted. The flash overlay below owns
+                  clearing the flag (it's the longer of the two animations). */}
+              <div className={settling ? "animate-drop-settle" : undefined}>
+                <ModCard
+                  mod={mod}
+                  rank={rank}
+                  disableHover={popoverOpen || isAnyDragging}
+                  drainOverride={
+                    kind === "aura" || kind === "stance"
+                      ? auraBonusForMod(mod, rank, effective)
+                      : effectiveDrainForMod(mod, rank, effective)
+                  }
+                  matchState={getMatchState(mod.polarity, effective)}
+                  hideDrain={hideDrain}
+                />
+              </div>
+              {/* White wash confirming the drop. Isolated sibling overlay (no
+                  children), so its animationend can't be confused with a
+                  ModCard child animation. Clears `settling` when it ends. */}
+              {settling && (
+                <div
+                  className="animate-drop-flash pointer-events-none absolute inset-0 z-30 rounded-md bg-white opacity-0"
+                  onAnimationEnd={() => setSettling(false)}
+                />
+              )}
               {!readOnly && (onRemove || (isRivenMod(mod) && onEditRiven)) && (
                 // Mobile: always visible (no hover). Desktop: appear on slot
                 // hover via CSS group-hover (parent has `group`) so we don't

--- a/apps/web/src/components/build-editor/polarity.tsx
+++ b/apps/web/src/components/build-editor/polarity.tsx
@@ -1,3 +1,4 @@
+import { CANONICAL_POLARITIES } from "@arsenyx/shared/warframe/polarities"
 import type { Polarity } from "@arsenyx/shared/warframe/types"
 import { X } from "lucide-react"
 
@@ -39,17 +40,6 @@ export function PolarityIcon({
     />
   )
 }
-
-/** The 7 canonical in-game polarities (no "any"/"universal"). */
-export const CANONICAL_POLARITIES: readonly Polarity[] = [
-  "madurai",
-  "vazarin",
-  "naramon",
-  "zenurik",
-  "unairu",
-  "penjaga",
-  "umbra",
-] as const
 
 // Picker order mirrors the legacy picker: 7 canonical + "any" (Omni Forma).
 // ✕ applies "universal" forma, which explicitly clears the slot.

--- a/apps/web/src/components/builds/build-card.tsx
+++ b/apps/web/src/components/builds/build-card.tsx
@@ -79,6 +79,38 @@ function BuildByline({
   )
 }
 
+/** Forma count on a build card. Hidden at 0 (a no-forma build), matching the
+ *  viewer's EndoFormaBadges behaviour. Uses the Forma currency icon rather than
+ *  a lucide glyph so it reads as the in-game resource at a glance. `withDivider`
+ *  prepends a hairline rule (card layout sets forma apart from the social stats;
+ *  the dense row omits it) — kept here so the show-at-all rule lives in one place. */
+function FormaStat({
+  count,
+  withDivider,
+}: {
+  count: number
+  withDivider?: boolean
+}) {
+  // `!(count > 0)` (not `count <= 0`) so a missing/undefined count — e.g. a
+  // stale React Query cache entry serialized before this field shipped — hides
+  // the badge instead of rendering "undefined forma".
+  if (!(count > 0)) return null
+  return (
+    <>
+      {withDivider && <span aria-hidden className="bg-border h-3 w-px" />}
+      <span className="flex items-center gap-1" title={`${count} forma`}>
+        <img
+          src="/icons/currency/Forma.png"
+          alt=""
+          aria-hidden
+          className="size-3 object-contain"
+        />
+        <span className="tabular-nums">{count}</span>
+      </span>
+    </>
+  )
+}
+
 export function BuildCard({ build }: { build: BuildListItem }) {
   const { timeAgo, imageUrl } = useBuildCardData(build)
 
@@ -113,6 +145,9 @@ export function BuildCard({ build }: { build: BuildListItem }) {
               <Eye className="size-3" />
               {build.viewCount}
             </span>
+            {/* Divider sets forma (a build property) apart from likes/views
+                (social signals) without the noise of a thumbnail overlay. */}
+            <FormaStat count={build.formaCount} withDivider />
           </span>
           <Tooltip>
             <TooltipTrigger render={<span>{timeAgo}</span>} />
@@ -161,6 +196,7 @@ export function BuildRow({ build }: { build: BuildListItem }) {
           <Eye className="size-3" />
           <span className="tabular-nums">{build.viewCount}</span>
         </span>
+        <FormaStat count={build.formaCount} />
         <Tooltip>
           <TooltipTrigger
             render={

--- a/apps/web/src/components/builds/builds-sort-dropdown.tsx
+++ b/apps/web/src/components/builds/builds-sort-dropdown.tsx
@@ -7,6 +7,8 @@ const SORT_ITEMS = [
   { value: "top", label: "Most Liked" },
   { value: "bookmarked", label: "Most Bookmarked" },
   { value: "viewed", label: "Most Viewed" },
+  { value: "forma-asc", label: "Fewest Forma" },
+  { value: "forma-desc", label: "Most Forma" },
 ] as const
 
 export const SORT_VALUES: BuildListSort[] = SORT_ITEMS.map((i) => i.value)

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -228,8 +228,44 @@ body {
   }
 }
 
+/* Drop settle: a placed/swapped mod card eases from 96% to rest so the action
+ * reads as landing rather than snapping in. Distinct from `mod-card-expand`,
+ * which scales from 0 for a first appearance. */
+@keyframes drop-settle {
+  0% {
+    transform: scale(0.96);
+  }
+  60% {
+    transform: scale(1.02);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.animate-drop-settle {
+  animation: drop-settle 180ms ease-out;
+}
+
+/* Drop flash: a white wash over the destination slot that fades out, making a
+ * mod landing unmistakable. Paired with the subtler drop-settle scale. */
+@keyframes drop-flash {
+  0% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.animate-drop-flash {
+  animation: drop-flash 320ms ease-out;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .animate-pulse {
+  .animate-pulse,
+  .animate-drop-settle,
+  .animate-drop-flash {
     animation: none;
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
+        "@neondatabase/serverless": "^1.1.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/router-devtools": "^1.95.1",

--- a/packages/shared/src/api/build-dto.ts
+++ b/packages/shared/src/api/build-dto.ts
@@ -58,6 +58,7 @@ export type BuildDetailResponse = {
   likeCount: number
   bookmarkCount: number
   viewCount: number
+  formaCount: number
   createdAt: string
   updatedAt: string
   user: BuildUserSummary
@@ -77,6 +78,7 @@ export type BuildListItemResponse = {
   likeCount: number
   bookmarkCount: number
   viewCount: number
+  formaCount: number
   hasGuide: boolean
   hasShards: boolean
   hideAuthor: boolean

--- a/packages/shared/src/warframe/build-list.ts
+++ b/packages/shared/src/warframe/build-list.ts
@@ -10,6 +10,8 @@ export const LIST_SORTS = [
   "top",
   "bookmarked",
   "viewed",
+  "forma-asc",
+  "forma-desc",
 ] as const
 
 export type ListSort = (typeof LIST_SORTS)[number]

--- a/packages/shared/src/warframe/forma.ts
+++ b/packages/shared/src/warframe/forma.ts
@@ -1,0 +1,19 @@
+// Version of the forma-count derivation. Stored on each build row as
+// `formaCalcVersion` when the count is computed. Bump this whenever the forma
+// calculation (apps/web build-editor `computeFormaCount` / `calculateFormaCount`)
+// changes, so a targeted recompute can find stale rows with
+// `WHERE "formaCalcVersion" < FORMA_CALC_VERSION` instead of rescanning the
+// whole table. See scripts/recompute-forma.ts.
+export const FORMA_CALC_VERSION = 1
+
+// `formaCalcVersion` value for a row whose count was never computed by the
+// current calc — a pre-backfill row, or a write that didn't carry a valid
+// client count. The recompute backfill targets these via
+// `WHERE "formaCalcVersion" < FORMA_CALC_VERSION`. Must stay 0 to match the
+// `formaCount`/`formaCalcVersion` column defaults in the Prisma schema.
+export const FORMA_UNSTAMPED = 0
+
+// Defensive bound on the client-supplied forma count. No real build has more
+// forma than it has slots (aura + exilus + stance + ~12 normal). 99 leaves
+// generous headroom while rejecting absurd values from a crafted payload.
+export const MAX_FORMA_COUNT = 99

--- a/packages/shared/src/warframe/polarities.ts
+++ b/packages/shared/src/warframe/polarities.ts
@@ -1,0 +1,22 @@
+import type { Polarity } from "./types"
+
+/** The 7 canonical in-game polarities (no "any"/"universal"). */
+export const CANONICAL_POLARITIES: readonly Polarity[] = [
+  "madurai",
+  "vazarin",
+  "naramon",
+  "zenurik",
+  "unairu",
+  "penjaga",
+  "umbra",
+] as const
+
+const CANONICAL_SET = new Set<Polarity>(CANONICAL_POLARITIES)
+
+/** Narrow an arbitrary string to a canonical Polarity, or undefined. Used to
+ *  sanitize stored/wire polarity values (item innates, saved forma choices)
+ *  before they feed slot/forma/capacity math. */
+export function toPolarity(v: string | null | undefined): Polarity | undefined {
+  if (!v) return undefined
+  return CANONICAL_SET.has(v as Polarity) ? (v as Polarity) : undefined
+}


### PR DESCRIPTION
Implements the editor drop micro-interaction from #188.

## What changed

When a mod lands in a slot (placement or swap), the slot now plays a brief, one-shot **drop settle** — a subtle scale (`0.96 → 1.02 → 1`, 180ms) plus a faint white flash wash (`opacity 0.2 → 0`, 320ms) — so the action reads as *landing* rather than snapping in.

- `apps/web/src/components/build-editor/mod-slot.tsx` — a `settling` state flag (set when the slot's mod identity changes to a non-empty mod) toggles the animation classes; the flash overlay clears the flag on `animationend`.
- `apps/web/src/styles/globals.css` — `drop-settle` / `drop-flash` keyframes + utility classes, gated under `prefers-reduced-motion`.

## Why it's built this way (reviewer notes)

- **Not a React `key`.** Re-keying the card wrapper to retrigger the animation would remount `ModCard`, which owns the hover-preview portal — remounting it out from under an open preview orphans that portal (the "stuck preview" regression). The state-flag approach animates without remounting.
- **Reduced-motion gated at the source.** `window.matchMedia("(prefers-reduced-motion: reduce)")` (cached at module scope) prevents `settling` from ever flipping true under reduced motion. This matters because the flag is cleared from the flash overlay's `animationend` — with CSS `animation: none` that event never fires, so a CSS-only gate would latch `settling` true forever. The `@media` block is retained as defense-in-depth.
- **Fires on placement/swap only.** Detection keys off mod-identity change, so initial build load and rank-only changes don't animate.

## Scope

Earlier iterations explored a rank-change flash and sidebar stat flash; those were dropped per design feedback — only the drop effect ships here. No count-up animations.

## Verification

`just check` (typecheck + oxlint + oxfmt) passes clean.