### PR TITLE
Update changelog through 2026-06-02

### DIFF
--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -13,6 +13,103 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-06-02",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Build cards now show a forma count, and build lists can be sorted by forma.",
+      },
+      {
+        type: "feat",
+        description:
+          "Mods now settle into their slot with a subtle drop animation when placed.",
+      },
+    ],
+  },
+  {
+    date: "2026-06-01",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Mod validation now flags conflicting and incompatible mods directly in the editor, so you can see why a combination won't work.",
+      },
+      {
+        type: "fix",
+        description:
+          "Base and Primed versions of the same mod now conflict correctly, and Bayonet stances route to the right slot.",
+      },
+      {
+        type: "fix",
+        description:
+          "Exodia arcanes are now gated to Zaw melees instead of showing on every melee weapon.",
+      },
+      {
+        type: "fix",
+        description:
+          "Slot fixes for exalted stances, beast-claw Posture slots, and PvE / Conclave mod visibility.",
+      },
+      {
+        type: "fix",
+        description: "Corrected a critical-chance calculation.",
+      },
+      {
+        type: "refactor",
+        description:
+          "Data and assets are now cached at the edge for faster loads.",
+      },
+    ],
+  },
+  {
+    date: "2026-05-31",
+    changes: [
+      {
+        type: "feat",
+        description: "The build editor now supports undo and redo.",
+      },
+      {
+        type: "feat",
+        description:
+          "Editor drafts autosave to your browser, so you can pick up where you left off — with restore and reset controls.",
+      },
+      {
+        type: "feat",
+        description:
+          "The search grid now explains why a mod is dimmed instead of leaving you guessing.",
+      },
+      {
+        type: "refactor",
+        description:
+          "Build lists now show real empty states instead of a blank panel.",
+      },
+      {
+        type: "refactor",
+        description:
+          "UI consistency pass: link-button cursors, icon sizing, and accessibility labels, plus Sonner toasts replacing the old hand-rolled feedback.",
+      },
+      {
+        type: "fix",
+        description:
+          "Necramech exalted weapons (Arquebex, Ironbride, Mausolon) now show their Exilus and Arcane slots correctly.",
+      },
+      {
+        type: "fix",
+        description:
+          "Frames with no innate aura polarity now show their aura slot.",
+      },
+      {
+        type: "fix",
+        description:
+          "The editor re-hydrates correctly when you change a build's structure, and restored drafts re-resolve their mod images.",
+      },
+      {
+        type: "chore",
+        description: "Game data refreshed to the latest Warframe build.",
+      },
+    ],
+  },
+  {
     date: "2026-05-30",
     changes: [
       {


### PR DESCRIPTION
Brings the changelog page up to date with everything merged between May 31 and June 2.

## What changed
New dated entries on the `/changelog` route:

- **June 2** — forma count on build cards (with forma sort options) and the drop-settle animation when placing mods.
- **June 1** — mod validation (conflicts + tag compatibility) surfaced in the editor, base/Primed conflict fix, Exodia arcane gating to Zaws, exalted / beast-claw / PvE-Conclave slot fixes, a critical-chance fix, and edge caching.
- **May 31** — editor undo/redo, draft autosave, dimmed-mod explanations, real empty states, a UI consistency pass (Sonner toasts), Necramech exalted slot fixes, aura-slot fix, editor re-hydration fixes, and a game-data refresh.

## Notes for reviewers
- Data-only change to the `CHANGELOG` array in `apps/web/src/routes/changelog.tsx`; `bun run typecheck` passes.
- Purely internal commits (R2 creds wiring, admin build management) are folded into related notes or omitted, since they aren't user-facing.
- Forma-on-cards (#186) was bundled inside PR #208 whose title only mentioned the animation, so it's called out explicitly here.