### PR TITLE
Notify users when a new deploy is available (reload toast)

### DIFF
--- a/apps/web/src/lib/hooks/use-app-update.ts
+++ b/apps/web/src/lib/hooks/use-app-update.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from "react"
+import { toast } from "sonner"
+
+/**
+ * Notifies the user when a newer deploy is available and offers a one-click
+ * reload.
+ *
+ * We have no service worker, so detection piggybacks on `index.html`, which the
+ * CDN serves `must-revalidate` (see public/_headers). Vite injects a single
+ * content-hashed entry script (`/assets/index-<hash>.js`); any code change ships
+ * a new hash, so a fresh `index.html` references a different entry `src` than the
+ * one this tab loaded with. Mismatch ⇒ a new version is live.
+ *
+ * Polls on an interval and whenever the tab becomes visible again (the moment a
+ * returning user is most likely to be on a stale bundle). Fires at most once.
+ */
+const POLL_MS = 5 * 60 * 1000
+const TOAST_ID = "app-update"
+
+function entryHref(doc: Document): string | null {
+  const el = doc.querySelector<HTMLScriptElement>('script[type="module"][src]')
+  return el?.getAttribute("src") ?? null
+}
+
+async function fetchDeployedEntry(signal: AbortSignal): Promise<string | null> {
+  const res = await fetch(`/index.html?_=${Date.now()}`, {
+    cache: "no-store",
+    signal,
+  })
+  if (!res.ok) return null
+  const html = await res.text()
+  return entryHref(new DOMParser().parseFromString(html, "text/html"))
+}
+
+export function useAppUpdate() {
+  const loadedEntry = useRef<string | null>(null)
+  const notified = useRef(false)
+
+  useEffect(() => {
+    // Dev serves an unhashed `/src/main.tsx` entry, so there's nothing to diff.
+    if (import.meta.env.DEV) return
+    loadedEntry.current = entryHref(document)
+    if (!loadedEntry.current) return
+
+    const controller = new AbortController()
+
+    async function check() {
+      if (notified.current || document.visibilityState !== "visible") return
+      try {
+        const latest = await fetchDeployedEntry(controller.signal)
+        if (latest && latest !== loadedEntry.current) {
+          notified.current = true
+          toast("A new version of Arsenyx is available", {
+            id: TOAST_ID,
+            description: "Reload to get the latest changes.",
+            duration: Infinity,
+            action: {
+              label: "Reload",
+              onClick: () => window.location.reload(),
+            },
+          })
+        }
+      } catch {
+        // Offline or a transient blip — just try again on the next tick.
+      }
+    }
+
+    const interval = setInterval(() => void check(), POLL_MS)
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void check()
+    }
+    document.addEventListener("visibilitychange", onVisible)
+    void check()
+
+    return () => {
+      controller.abort()
+      clearInterval(interval)
+      document.removeEventListener("visibilitychange", onVisible)
+    }
+  }, [])
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { Outlet, createRootRouteWithContext } from "@tanstack/react-router"
 import { HotkeyCheatSheet } from "@/components/hotkey-cheat-sheet"
 import { Toaster } from "@/components/ui/sonner"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import { useAppUpdate } from "@/lib/hooks/use-app-update"
 
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
   {
@@ -12,6 +13,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 )
 
 function RootLayout() {
+  useAppUpdate()
   return (
     <TooltipProvider>
       <Outlet />


### PR DESCRIPTION
## What

Adds a "new version available" prompt: when a newer deploy is detected, a persistent sonner toast appears with a one-click **Reload** action.

- `apps/web/src/lib/hooks/use-app-update.ts` — the detection hook
- `apps/web/src/routes/__root.tsx` — calls `useAppUpdate()` in `RootLayout`, next to the already-mounted `<Toaster />`

## Why

Without this, users on long-lived tabs keep running a stale bundle until they happen to hard-refresh — and can hit chunk-load errors when a hashed asset they reference no longer exists on the CDN. This nudges them to reload.

## How it works

There's no service worker, so detection piggybacks on `index.html`, which the CDN serves `must-revalidate` (see `public/_headers`). Vite injects a single content-hashed entry script (`/assets/index-<hash>.js`); any code change ships a new hash. The hook:

1. Records the entry `src` the current tab loaded with.
2. Re-fetches `index.html` (`cache: "no-store"`) every 5 min and on `visibilitychange` (when a returning user refocuses — the most likely moment to be stale).
3. Fires the toast (`duration: Infinity`, stable `id`, fires once) when the deployed entry `src` differs.

## Reviewer notes

- **No build-pipeline changes** — keys off Vite's existing asset hashing, independent of `__DATA_VERSION__` (which only changes on a *data* regen, not a frontend-only rebuild).
- **No-ops in dev** (`import.meta.env.DEV`) since the dev entry is an unhashed `/src/main.tsx`. It only does anything against a built/deployed bundle, so it wasn't exercised in a dev preview.
- `bun run typecheck` + `just check` (lint/format) pass.
