### PR TITLE
Show a fallback header bar on embeds with no curated strip

### DIFF
--- a/apps/web/src/components/build-viewer/embed-strips.tsx
+++ b/apps/web/src/components/build-viewer/embed-strips.tsx
@@ -56,9 +56,33 @@ export function EmbedStrips({
   lichBonusElement: LichBonusElement | null
   slug: string
 }) {
+  // Which curated strip (if any) applies. Each flag mirrors that strip's own
+  // render gate so we can tell synchronously whether ANY strip will show — and,
+  // if not, fall back to a bare header bar (item icon + name + "View on
+  // Arsenyx") so a plain weapon/archwing embed isn't left chrome-less. The
+  // warframe flag mirrors EmbedWarframeStrip's `hasAbilities || hasShards`.
+  // The incarnon flag is optimistic: EmbedIncarnonStrip can still bail after its
+  // async query (no choosable tiers), a rare data edge where we'd rather omit
+  // the header than risk rendering it twice.
+  const showWarframeStrip =
+    category === "warframes" && (abilities.length > 0 || shards.some(Boolean))
+  const showZawStrip =
+    category === "melee" && isZawStrike(itemName) && Boolean(zawComponents)
+  const showKitgunStrip =
+    (category === "primary" || category === "secondary") &&
+    Boolean(kitgunComponents)
+  const showIncarnonStrip = incarnonEnabled && incarnonPerks.some(Boolean)
+  const showLichStrip = lichBonusElement !== null
+  const showAnyStrip =
+    showWarframeStrip ||
+    showZawStrip ||
+    showKitgunStrip ||
+    showIncarnonStrip ||
+    showLichStrip
+
   return (
     <>
-      {category === "warframes" && (
+      {showWarframeStrip && (
         <EmbedWarframeStrip
           abilities={abilities}
           helminth={helminth}
@@ -68,7 +92,7 @@ export function EmbedStrips({
           itemImageName={itemImageName}
         />
       )}
-      {category === "melee" && isZawStrike(itemName) && zawComponents && (
+      {showZawStrip && zawComponents && (
         <EmbedZawStrip
           itemName={itemName}
           itemImageName={itemImageName}
@@ -77,17 +101,16 @@ export function EmbedStrips({
           slug={slug}
         />
       )}
-      {(category === "primary" || category === "secondary") &&
-        kitgunComponents && (
-          <EmbedKitgunStrip
-            itemName={itemName}
-            itemImageName={itemImageName}
-            grip={kitgunComponents.grip}
-            loader={kitgunComponents.loader}
-            slug={slug}
-          />
-        )}
-      {incarnonEnabled && incarnonPerks.some(Boolean) && (
+      {showKitgunStrip && kitgunComponents && (
+        <EmbedKitgunStrip
+          itemName={itemName}
+          itemImageName={itemImageName}
+          grip={kitgunComponents.grip}
+          loader={kitgunComponents.loader}
+          slug={slug}
+        />
+      )}
+      {showIncarnonStrip && (
         <Suspense fallback={null}>
           <EmbedIncarnonStrip
             weaponName={itemName}
@@ -97,9 +120,16 @@ export function EmbedStrips({
           />
         </Suspense>
       )}
-      {lichBonusElement !== null && (
+      {showLichStrip && (
         <EmbedLichStrip
           element={lichBonusElement}
+          itemName={itemName}
+          itemImageName={itemImageName}
+          slug={slug}
+        />
+      )}
+      {!showAnyStrip && (
+        <EmbedStripFrame
           itemName={itemName}
           itemImageName={itemImageName}
           slug={slug}
@@ -126,7 +156,9 @@ function EmbedStripFrame({
   itemImageName?: string
   slug: string
   warframeLayout?: boolean
-  children: ReactNode
+  /** Optional middle content. Omitted for the fallback header bar (item +
+   *  "View on Arsenyx") shown when a build qualifies for no curated strip. */
+  children?: ReactNode
 }) {
   const buildUrl = `${window.location.origin}/builds/${slug}`
   const footerLink = (


### PR DESCRIPTION
## What

In `?embed=1` mode, the item icon + name + **View on Arsenyx** header was baked **inside** each category-specific strip (warframe abilities, zaw, kitgun, incarnon, lich). A build that qualifies for none of those strips rendered **no header at all** — no item name, no link back to Arsenyx.

That's why, on the profit-taker.com guide page, a **Chroma Prime** (warframe) embed shows the header but a **Kuva Ogris** (plain primary, no bonus element set) shows just the bare loadout grid. Same for archwing builds and any lich weapon without a bonus element.

## How

Keep the curated strips exactly as they are, and add a bare `EmbedStripFrame` fallback (header + "View on Arsenyx", no middle content) **only** when no strip applies.

To avoid the "did any strip render?" race, `EmbedStrips` now computes each strip's render gate synchronously and renders the fallback only if all are false:
- The warframe flag mirrors `EmbedWarframeStrip`'s own `hasAbilities || hasShards` check, so a warframe never gets both its strip *and* the fallback.
- The incarnon flag is **optimistic**: `EmbedIncarnonStrip` can still bail after its async evolutions query (no choosable tiers). In that rare data edge the header is omitted rather than risk rendering twice — documented in a comment.

`EmbedStripFrame`'s `children` prop is now optional (the fallback passes none); two flex-1 sections lay the name out left and the link right.

## Notes for the reviewer

- Independent of the embed perf work (PR #211) — this only touches `embed-strips.tsx`, which that PR doesn't modify, so it's branched off `main` and can merge in any order.
- Verified visually (plain-weapon embed now shows the header; warframe embed unchanged, no double header) plus `tsc --noEmit` / lint / format clean.
