### PR TITLE
Let the embed fallback header use the full name width

### DIFF
--- a/apps/web/src/components/build-viewer/embed-strips.tsx
+++ b/apps/web/src/components/build-viewer/embed-strips.tsx
@@ -160,6 +160,11 @@ function EmbedStripFrame({
    *  "View on Arsenyx") shown when a build qualifies for no curated strip. */
   children?: ReactNode
 }) {
+  // The fallback header bar (no strip content) gives the name the whole row, so
+  // drop the compact 120px cap the curated strips need to leave room for their
+  // icons — it would otherwise truncate a name like "Panzer Vulpaphyla" despite
+  // ample space.
+  const headerOnly = children == null
   const buildUrl = `${window.location.origin}/builds/${slug}`
   const footerLink = (
     <a
@@ -177,7 +182,11 @@ function EmbedStripFrame({
       <div
         className={cn(
           "flex items-center gap-2",
-          warframeLayout ? "shrink-0" : "md:flex-1",
+          headerOnly
+            ? "min-w-0 md:flex-1"
+            : warframeLayout
+              ? "shrink-0"
+              : "md:flex-1",
         )}
       >
         <div className="bg-muted/10 relative flex size-8 shrink-0 overflow-hidden rounded">
@@ -187,7 +196,12 @@ function EmbedStripFrame({
             className="h-full w-full object-cover"
           />
         </div>
-        <span className="max-w-[120px] truncate text-sm font-semibold">
+        <span
+          className={cn(
+            "truncate text-sm font-semibold",
+            !headerOnly && "max-w-[120px]",
+          )}
+        >
           {itemName}
         </span>
       </div>


### PR DESCRIPTION
## What

Follow-up to #212. The fallback header bar (embeds with no curated strip) truncated long item names like **"Panzer Vulpaphyla" → "Panzer Vulpaph…"** even though the bar had plenty of empty horizontal space.

## Why

The fallback reuses `EmbedStripFrame`'s item-name `<span>`, which has a `max-w-[120px]` cap. That cap is correct for the *curated* strips — the name shares its row with ability/shard/part icons — but the fallback bar's middle is empty, so the cap just clips the name for no reason.

## Fix

In `EmbedStripFrame`, detect the header-only case (`children == null`) and:
- drop the `max-w-[120px]` cap so the name uses the available row width;
- add `min-w-0` so `truncate` still engages if the bar is genuinely too narrow (very long name / tiny iframe).

Curated strips are unchanged — they keep the compact 120px name.

Typecheck / lint / format clean.