### PR TITLE
Add a paste/bookmarklet fallback for Overframe imports

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -209,6 +209,14 @@ export const auth = betterAuth({
     cookieCache: { enabled: true, maxAge: 60 },
   },
   advanced: {
+    // On Cloudflare Workers the trusted client IP is `cf-connecting-ip` (set
+    // at the edge, overwrites any client-supplied value). Better Auth defaults
+    // to `x-forwarded-for`, which isn't reliably populated here — so it
+    // couldn't determine the IP, silently skipped its built-in rate limiting
+    // on the /auth/* surface, and logged a warning on every request. Point it
+    // at the right header to re-enable auth rate limiting and record accurate
+    // session IPs.
+    ipAddress: { ipAddressHeaders: ["cf-connecting-ip"] },
     // Host-only cookies on api.arsenyx.com — web clients call /auth/get-session
     // cross-origin with credentials:include; no need for Domain=.arsenyx.com.
     crossSubDomainCookies: { enabled: false },

--- a/apps/api/src/lib/overframe/import.test.ts
+++ b/apps/api/src/lib/overframe/import.test.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // Mock only safeFetch; keep the real SafeFetchError so the `instanceof` checks
 // in import.ts still match. fetchOverframeHtml streams the Response body, so
@@ -9,6 +9,11 @@ vi.mock("../safe-fetch", async (importActual) => {
   return { ...actual, safeFetch: vi.fn() }
 })
 
+// The raw route handler is now sign-in-gated; stub getSession so handler tests
+// can simulate signed-in (default) and signed-out callers without Better Auth.
+vi.mock("../../lib/session", () => ({ getSession: vi.fn() }))
+
+import { getSession } from "../../lib/session"
 import { SafeFetchError, safeFetch } from "../safe-fetch"
 import {
   isValidOverframeBuildUrl,
@@ -166,6 +171,26 @@ function fakeJsonContext(body: unknown): {
 }
 
 describe("handleOverframeRawImport", () => {
+  // Default to a signed-in caller; the 401 case overrides per-test.
+  beforeEach(() => {
+    vi.mocked(getSession).mockResolvedValue({
+      user: { id: "u1" },
+    } as never)
+  })
+
+  it("401s when the caller isn't signed in", async () => {
+    vi.mocked(getSession).mockResolvedValue(null as never)
+    const handle = await importHandler()
+    const { c, captured } = fakeJsonContext({
+      source: "arsenyx-overframe",
+      url: BUILD_URL,
+      nextData: makeNextData(),
+    })
+    await handle(c)
+    expect(captured.status).toBe(401)
+    expect(captured.body).toMatchObject({ error: "unauthorized" })
+  })
+
   it("400s when nextData is missing", async () => {
     const handle = await importHandler()
     const { c, captured } = fakeJsonContext({ url: BUILD_URL })

--- a/apps/api/src/lib/overframe/import.test.ts
+++ b/apps/api/src/lib/overframe/import.test.ts
@@ -1,0 +1,188 @@
+import type { Context } from "hono"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+// Mock only safeFetch; keep the real SafeFetchError so the `instanceof` checks
+// in import.ts still match. fetchOverframeHtml streams the Response body, so
+// the mock returns a real Response built from an HTML string.
+vi.mock("../safe-fetch", async (importActual) => {
+  const actual = await importActual<typeof import("../safe-fetch")>()
+  return { ...actual, safeFetch: vi.fn() }
+})
+
+import { SafeFetchError, safeFetch } from "../safe-fetch"
+import {
+  isValidOverframeBuildUrl,
+  scrapeOverframeBuild,
+  scrapeOverframeFromNextData,
+} from "./import"
+
+const BUILD_URL = "https://overframe.gg/build/1005502/saryn-prime"
+
+// __NEXT_DATA__ shaped like a real Overframe build page.
+function makeNextData() {
+  return {
+    props: {
+      pageProps: {
+        data: {
+          title: "Test Saryn Build",
+          name: "Saryn Prime",
+          formas: 4,
+          slots: [
+            { slot_id: 1, mod: 12345, rank: 5, polarity: 1 },
+            { slot_id: 2, mod: 0, rank: 0, polarity: 0 },
+            { slot_id: 9, mod: 67890, rank: 3, polarity: 2 },
+          ],
+        },
+      },
+    },
+  }
+}
+
+function htmlWith(nextData: unknown): string {
+  return `<!doctype html><html><body><script id="__NEXT_DATA__" type="application/json">${JSON.stringify(
+    nextData,
+  )}</script></body></html>`
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe("isValidOverframeBuildUrl", () => {
+  it("accepts overframe build URLs and rejects everything else", () => {
+    expect(isValidOverframeBuildUrl(BUILD_URL)).toBe(true)
+    expect(isValidOverframeBuildUrl("https://overframe.gg/build/1")).toBe(true)
+    expect(isValidOverframeBuildUrl("https://overframe.gg/builds/1")).toBe(
+      false,
+    )
+    expect(isValidOverframeBuildUrl("https://evil.com/build/1")).toBe(false)
+    expect(isValidOverframeBuildUrl("not a url")).toBe(false)
+  })
+})
+
+describe("scrapeOverframeFromNextData", () => {
+  it("extracts item, forma, and slots from a pasted __NEXT_DATA__ object", () => {
+    const res = scrapeOverframeFromNextData(makeNextData(), BUILD_URL)
+
+    expect(res.warnings).toEqual([])
+    expect(res.itemName).toBe("Saryn Prime")
+    expect(res.formaCount).toBe(4)
+    expect(res.source.buildId).toBe("1005502")
+    expect(res.source.url).toBe(BUILD_URL)
+    expect(res.slots).toHaveLength(3)
+
+    const byId = Object.fromEntries(res.slots.map((s) => [s.slot_id, s]))
+    expect(byId[1]).toMatchObject({ overframeId: "12345", rank: 5 })
+    expect(byId[1].polarity).toBe("madurai") // code 1
+    expect(byId[2].overframeId).toBeNull() // empty slot (mod 0)
+    expect(byId[9].polarity).toBe("vazarin") // code 2
+  })
+
+  it("keeps a valid url but ignores a non-overframe one", () => {
+    expect(
+      scrapeOverframeFromNextData(makeNextData(), BUILD_URL).source.url,
+    ).toBe(BUILD_URL)
+    expect(
+      scrapeOverframeFromNextData(makeNextData(), "https://evil.com/x").source
+        .url,
+    ).toBe("")
+    expect(scrapeOverframeFromNextData(makeNextData()).source.url).toBe("")
+  })
+
+  it("warns instead of throwing on empty/garbage data", () => {
+    const res = scrapeOverframeFromNextData(null, BUILD_URL)
+    expect(res.slots).toHaveLength(0)
+    expect(res.warnings.map((w) => w.type)).toContain("next_data_missing")
+  })
+})
+
+describe("scrapeOverframeBuild (fetch path)", () => {
+  it("returns a friendly Cloudflare message on a 403", async () => {
+    vi.mocked(safeFetch).mockRejectedValueOnce(
+      new SafeFetchError("upstream_status", 403),
+    )
+
+    const res = await scrapeOverframeBuild(BUILD_URL)
+    const warning = res.warnings.find((w) => w.type === "fetch_failed")
+
+    expect(warning).toBeDefined()
+    expect(warning?.message).toMatch(/Cloudflare bot protection/i)
+    expect(warning?.message).not.toMatch(/HTTP 403/) // no raw status leak
+  })
+
+  it("still surfaces other upstream statuses verbatim", async () => {
+    vi.mocked(safeFetch).mockRejectedValueOnce(
+      new SafeFetchError("upstream_status", 500),
+    )
+
+    const res = await scrapeOverframeBuild(BUILD_URL)
+    expect(
+      res.warnings.find((w) => w.type === "fetch_failed")?.message,
+    ).toMatch(/HTTP 500/)
+  })
+
+  it("extracts a build from fetched HTML", async () => {
+    vi.mocked(safeFetch).mockResolvedValueOnce(
+      new Response(htmlWith(makeNextData())),
+    )
+
+    const res = await scrapeOverframeBuild(BUILD_URL)
+    expect(res.itemName).toBe("Saryn Prime")
+    expect(res.slots).toHaveLength(3)
+    expect(res.warnings).toEqual([])
+  })
+
+  it("rejects a non-overframe URL before fetching", async () => {
+    const res = await scrapeOverframeBuild("https://evil.com/build/1")
+    expect(res.warnings[0]?.type).toBe("invalid_url")
+    expect(safeFetch).not.toHaveBeenCalled()
+  })
+})
+
+// The raw route handler is thin glue over parseJsonBody + scrapeOverframeFromNextData.
+// Test it with a fake Context (same shim style as validate.test.ts) so we cover
+// the request validation without standing up Hono / the DB-backed rate limiter.
+async function importHandler() {
+  return (await import("../../routes/imports")).handleOverframeRawImport
+}
+
+function fakeJsonContext(body: unknown): {
+  c: Context
+  captured: { body: unknown; status: number }
+} {
+  const raw = new Request("https://test.local/", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  const captured = { body: undefined as unknown, status: 200 }
+  const c = {
+    req: { header: (n: string) => raw.headers.get(n) ?? undefined, raw },
+    json: (b: unknown, status = 200) => {
+      captured.body = b
+      captured.status = status
+      return new Response(JSON.stringify(b), { status })
+    },
+  } as unknown as Context
+  return { c, captured }
+}
+
+describe("handleOverframeRawImport", () => {
+  it("400s when nextData is missing", async () => {
+    const handle = await importHandler()
+    const { c, captured } = fakeJsonContext({ url: BUILD_URL })
+    await handle(c)
+    expect(captured.status).toBe(400)
+    expect(captured.body).toMatchObject({ error: "missing_next_data" })
+  })
+
+  it("returns a scrape response for a valid paste", async () => {
+    const handle = await importHandler()
+    const { c, captured } = fakeJsonContext({
+      source: "arsenyx-overframe",
+      url: BUILD_URL,
+      nextData: makeNextData(),
+    })
+    await handle(c)
+    expect(captured.status).toBe(200)
+    expect(captured.body).toMatchObject({ itemName: "Saryn Prime" })
+  })
+})

--- a/apps/api/src/lib/overframe/import.ts
+++ b/apps/api/src/lib/overframe/import.ts
@@ -8,7 +8,7 @@ import type {
 import { SafeFetchError, safeFetch } from "../safe-fetch"
 import { decodeOverframeBuildString } from "./decode"
 import { getOverframeItemsMap } from "./items-map"
-import { extractOverframeDataFromHtml } from "./next-data"
+import { extractOverframeData, extractOverframeDataFromHtml } from "./next-data"
 import { mapOverframePolarity } from "./polarity"
 
 export function isValidOverframeBuildUrl(value: string): boolean {
@@ -66,6 +66,16 @@ async function fetchOverframeHtml(url: string): Promise<string> {
     })
   } catch (err) {
     if (err instanceof SafeFetchError) {
+      // Overframe sits behind a Cloudflare managed challenge (Turnstile/JS
+      // interstitial) that returns 403 to every non-browser client. No UA or
+      // header tweak passes it — only a real browser can. Surface that plainly
+      // instead of a bare "HTTP 403" so users don't think it's an Arsenyx bug.
+      if (err.code === "upstream_status" && err.status === 403) {
+        throw new Error(
+          "Overframe is currently blocking automated imports (Cloudflare bot protection). This is on Overframe's side, not Arsenyx — please try again later.",
+          { cause: err },
+        )
+      }
       throw new Error(`Overframe fetch failed: ${safeFetchMessage(err)}`, {
         cause: err,
       })
@@ -144,11 +154,19 @@ function parseRawSlots(slots: unknown): OverframeRawSlot[] {
   return out
 }
 
+function buildIdFromUrl(url: string): string | undefined {
+  try {
+    const u = new URL(url)
+    const m = u.pathname.match(/^\/build\/(\d+)/)
+    return m?.[1]
+  } catch {
+    return undefined
+  }
+}
+
 export async function scrapeOverframeBuild(
   url: string,
 ): Promise<OverframeScrapeResponse> {
-  const warnings: OverframeImportWarning[] = []
-
   if (!isValidOverframeBuildUrl(url)) {
     return {
       source: { url },
@@ -183,17 +201,41 @@ export async function scrapeOverframeBuild(
     }
   }
 
-  const buildId = (() => {
-    try {
-      const u = new URL(url)
-      const m = u.pathname.match(/^\/build\/(\d+)/)
-      return m?.[1]
-    } catch {
-      return undefined
-    }
-  })()
+  const buildId = buildIdFromUrl(url)
+  return assembleScrapeResponse(
+    extractOverframeDataFromHtml(html, { url, buildId }),
+    url,
+    buildId,
+  )
+}
 
-  const extracted = extractOverframeDataFromHtml(html, { url, buildId })
+/**
+ * Fetch-less import: build the scrape response from a `__NEXT_DATA__` object
+ * the user copied off their own Overframe tab (via the bookmarklet). Their
+ * browser already cleared Cloudflare's challenge, so this sidesteps the 403
+ * that blocks the server-side {@link scrapeOverframeBuild} path. `rawUrl` is
+ * best-effort — only kept when it's a real Overframe build URL.
+ */
+export function scrapeOverframeFromNextData(
+  nextData: unknown,
+  rawUrl?: string,
+): OverframeScrapeResponse {
+  const url = rawUrl && isValidOverframeBuildUrl(rawUrl) ? rawUrl : ""
+  const buildId = url ? buildIdFromUrl(url) : undefined
+  return assembleScrapeResponse(
+    extractOverframeData(nextData, { url, buildId }),
+    url,
+    buildId,
+  )
+}
+
+function assembleScrapeResponse(
+  extracted: ReturnType<typeof extractOverframeData>,
+  url: string,
+  buildId: string | undefined,
+): OverframeScrapeResponse {
+  const warnings: OverframeImportWarning[] = []
+
   if (!extracted.nextData) {
     warnings.push({
       type: "next_data_missing",

--- a/apps/api/src/lib/overframe/import.ts
+++ b/apps/api/src/lib/overframe/import.ts
@@ -11,15 +11,25 @@ import { getOverframeItemsMap } from "./items-map"
 import { extractOverframeData, extractOverframeDataFromHtml } from "./next-data"
 import { mapOverframePolarity } from "./polarity"
 
-export function isValidOverframeBuildUrl(value: string): boolean {
+/**
+ * Parse an Overframe build URL into its numeric build id, or null if it isn't
+ * one. Single source for both the host/shape validation and the id extraction
+ * so the two can't drift (and the URL is only parsed once per call).
+ */
+export function parseOverframeBuildUrl(value: string): { id: string } | null {
   try {
     const url = new URL(value)
     if (url.hostname !== "overframe.gg" && url.hostname !== "www.overframe.gg")
-      return false
-    return /^\/build\/(\d+)(\/|$)/.test(url.pathname)
+      return null
+    const m = url.pathname.match(/^\/build\/(\d+)(\/|$)/)
+    return m ? { id: m[1] } : null
   } catch {
-    return false
+    return null
   }
+}
+
+export function isValidOverframeBuildUrl(value: string): boolean {
+  return parseOverframeBuildUrl(value) !== null
 }
 
 // Fetch wall-time / response-size / redirect caps. Without these a logged-in
@@ -154,20 +164,11 @@ function parseRawSlots(slots: unknown): OverframeRawSlot[] {
   return out
 }
 
-function buildIdFromUrl(url: string): string | undefined {
-  try {
-    const u = new URL(url)
-    const m = u.pathname.match(/^\/build\/(\d+)/)
-    return m?.[1]
-  } catch {
-    return undefined
-  }
-}
-
 export async function scrapeOverframeBuild(
   url: string,
 ): Promise<OverframeScrapeResponse> {
-  if (!isValidOverframeBuildUrl(url)) {
+  const parsed = parseOverframeBuildUrl(url)
+  if (!parsed) {
     return {
       source: { url },
       formaCount: null,
@@ -201,7 +202,7 @@ export async function scrapeOverframeBuild(
     }
   }
 
-  const buildId = buildIdFromUrl(url)
+  const buildId = parsed.id
   return assembleScrapeResponse(
     extractOverframeDataFromHtml(html, { url, buildId }),
     url,
@@ -220,8 +221,9 @@ export function scrapeOverframeFromNextData(
   nextData: unknown,
   rawUrl?: string,
 ): OverframeScrapeResponse {
-  const url = rawUrl && isValidOverframeBuildUrl(rawUrl) ? rawUrl : ""
-  const buildId = url ? buildIdFromUrl(url) : undefined
+  const parsed = rawUrl ? parseOverframeBuildUrl(rawUrl) : null
+  const url = parsed ? rawUrl! : ""
+  const buildId = parsed?.id
   return assembleScrapeResponse(
     extractOverframeData(nextData, { url, buildId }),
     url,

--- a/apps/api/src/lib/overframe/next-data.ts
+++ b/apps/api/src/lib/overframe/next-data.ts
@@ -166,7 +166,19 @@ export function extractOverframeDataFromHtml(
   html: string,
   source: OverframeBuildSource,
 ): ExtractedOverframeData {
-  const nextData = extractNextDataJson(html)
+  return extractOverframeData(extractNextDataJson(html), source)
+}
+
+/**
+ * Same extraction as {@link extractOverframeDataFromHtml} but starting from an
+ * already-parsed `__NEXT_DATA__` object. The paste/bookmarklet import path
+ * reads the JSON straight off the user's loaded Overframe tab (which has
+ * already cleared Cloudflare's challenge), so it never has HTML to regex.
+ */
+export function extractOverframeData(
+  nextData: unknown,
+  source: OverframeBuildSource,
+): ExtractedOverframeData {
   if (!nextData) {
     return {
       source,

--- a/apps/api/src/routes/imports.ts
+++ b/apps/api/src/routes/imports.ts
@@ -1,10 +1,18 @@
 import { type Context, Hono } from "hono"
 
-import { scrapeOverframeBuild } from "../lib/overframe/import"
+import {
+  scrapeOverframeBuild,
+  scrapeOverframeFromNextData,
+} from "../lib/overframe/import"
 import { parseJsonBody } from "../lib/validate"
 import { rateLimitUser } from "../middleware/rate-limit"
 
 export const imports = new Hono()
+
+// __NEXT_DATA__ for a build page is large (sibling/related builds ride along),
+// so the paste endpoint needs far more headroom than the URL endpoint. 1.5MB
+// comfortably covers it while still bounding a storage-fill / DoS attempt.
+const MAX_NEXT_DATA_BYTES = 1.5 * 1024 * 1024
 
 export async function handleOverframeImport(c: Context) {
   // Tiny cap — this endpoint only takes a URL.
@@ -26,4 +34,33 @@ export async function handleOverframeImport(c: Context) {
   }
 }
 
+// Paste/bookmarklet path: the caller hands us the __NEXT_DATA__ object lifted
+// from their own (already-challenge-cleared) Overframe tab, so there's no
+// server-side fetch and no 403. `url` is optional context for the source.
+export async function handleOverframeRawImport(c: Context) {
+  const parsed = await parseJsonBody(c, { maxBytes: MAX_NEXT_DATA_BYTES })
+  if (!parsed.ok) return parsed.response
+  const nextData = parsed.value.nextData
+  const url = parsed.value.url
+  if (!nextData || typeof nextData !== "object") {
+    return c.json({ error: "missing_next_data" }, 400)
+  }
+
+  try {
+    const result = scrapeOverframeFromNextData(
+      nextData,
+      typeof url === "string" ? url : undefined,
+    )
+    return c.json(result)
+  } catch (err) {
+    console.error("overframe raw import failed:", err)
+    return c.json({ error: "scrape_failed" }, 500)
+  }
+}
+
 imports.post("/overframe", rateLimitUser("import"), handleOverframeImport)
+imports.post(
+  "/overframe/raw",
+  rateLimitUser("import"),
+  handleOverframeRawImport,
+)

--- a/apps/api/src/routes/imports.ts
+++ b/apps/api/src/routes/imports.ts
@@ -4,6 +4,7 @@ import {
   scrapeOverframeBuild,
   scrapeOverframeFromNextData,
 } from "../lib/overframe/import"
+import { getSession } from "../lib/session"
 import { parseJsonBody } from "../lib/validate"
 import { rateLimitUser } from "../middleware/rate-limit"
 
@@ -15,6 +16,11 @@ export const imports = new Hono()
 const MAX_NEXT_DATA_BYTES = 1.5 * 1024 * 1024
 
 export async function handleOverframeImport(c: Context) {
+  // Import feeds the editor/save flow, which is sign-in-only — gate it like
+  // every other mutation so anon callers can't drive the server-side fetch.
+  const session = await getSession(c)
+  if (!session?.user) return c.json({ error: "unauthorized" }, 401)
+
   // Tiny cap — this endpoint only takes a URL.
   const parsed = await parseJsonBody(c, { maxBytes: 4 * 1024 })
   if (!parsed.ok) return parsed.response
@@ -38,6 +44,11 @@ export async function handleOverframeImport(c: Context) {
 // from their own (already-challenge-cleared) Overframe tab, so there's no
 // server-side fetch and no 403. `url` is optional context for the source.
 export async function handleOverframeRawImport(c: Context) {
+  // Sign-in-only: keeps the heavy 1.5MB parse + tree-walk off the anon surface
+  // (rateLimitUser is a no-op without a session, so this is the real gate).
+  const session = await getSession(c)
+  if (!session?.user) return c.json({ error: "unauthorized" }, 401)
+
   const parsed = await parseJsonBody(c, { maxBytes: MAX_NEXT_DATA_BYTES })
   if (!parsed.ok) return parsed.response
   const nextData = parsed.value.nextData

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -16,6 +16,7 @@ import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { requireUser } from "@/lib/auth-guards"
 import { saveDraft } from "@/lib/import-draft"
 import {
   applyOverframeScrape,
@@ -31,6 +32,9 @@ import { apiErrorMessage, apiFetch, ApiError } from "@/lib/util/api-client"
 import { copyToClipboard } from "@/lib/util/clipboard"
 
 export const Route = createFileRoute("/import")({
+  // Import feeds the sign-in-only editor/save flow, and the API endpoints are
+  // auth-gated — bounce anon users to sign-in instead of letting them hit a 401.
+  beforeLoad: () => requireUser(),
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(itemsIndexQuery),
@@ -169,19 +173,18 @@ function ImportPage() {
   }, [])
 
   // Arriving via the bookmarklet (`?paste=1`): focus the box and best-effort
-  // pull the copied payload straight off the clipboard so the user just
-  // confirms. Clipboard read can be blocked without a gesture — that's fine,
-  // they can paste manually (Ctrl/Cmd+V).
+  // pre-fill it from the clipboard so the user just clicks Import. We fill but
+  // don't auto-submit — auto-POSTing whatever happens to be on the clipboard on
+  // page load is a surprising side effect; the explicit click is the confirm.
+  // Clipboard read can be blocked without a gesture — that's fine, they can
+  // paste manually (Ctrl/Cmd+V).
   useEffect(() => {
     if (!isPasteMode) return
     pasteRef.current?.focus()
     void (async () => {
       try {
         const text = await navigator.clipboard.readText()
-        if (text.trim()) {
-          setPasteText(text)
-          submitPaste(text)
-        }
+        if (text.trim()) setPasteText(text)
       } catch {
         // No clipboard permission without a gesture — manual paste still works.
       }

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -42,6 +42,13 @@ export const Route = createFileRoute("/import")({
   component: ImportPage,
 })
 
+/** Normalise an apiFetch failure into a user-facing import error. */
+function importError(err: unknown): Error {
+  const fallback =
+    err instanceof ApiError ? `Import failed: ${err.status}` : "Import failed"
+  return new Error(apiErrorMessage(err, fallback), { cause: err })
+}
+
 async function postOverframeImport(url: string): Promise<ScrapeResponse> {
   try {
     return await apiFetch<ScrapeResponse>(`/imports/overframe`, {
@@ -49,11 +56,13 @@ async function postOverframeImport(url: string): Promise<ScrapeResponse> {
       json: { url },
     })
   } catch (err) {
-    const fallback =
-      err instanceof ApiError ? `Import failed: ${err.status}` : "Import failed"
-    throw new Error(apiErrorMessage(err, fallback), { cause: err })
+    throw importError(err)
   }
 }
+
+/** Sentinel tagging the clipboard payload — shared by the bookmarklet that
+ * writes it (buildBookmarklet) and the parser that reads it back. */
+const OVERFRAME_PASTE_SOURCE = "arsenyx-overframe"
 
 /** Payload the bookmarklet copies to the clipboard. */
 type PastedOverframe = {
@@ -72,7 +81,13 @@ function parsePastedOverframe(text: string): {
   url?: string
 } {
   const obj = JSON.parse(text.trim()) as PastedOverframe
-  if (obj && typeof obj === "object" && obj.source === "arsenyx-overframe") {
+  // A non-object (number/string/array primitive, or null) is never a valid
+  // __NEXT_DATA__ blob — reject it here so the caller surfaces the friendly
+  // "doesn't look like Overframe build data" message instead of a bare 400.
+  if (!obj || typeof obj !== "object") {
+    throw new Error("Pasted data is not an object")
+  }
+  if (obj.source === OVERFRAME_PASTE_SOURCE) {
     return {
       nextData: obj.nextData,
       url: typeof obj.url === "string" ? obj.url : undefined,
@@ -96,9 +111,7 @@ async function importPastedOverframe(text: string): Promise<ScrapeResponse> {
       json: input,
     })
   } catch (err) {
-    const fallback =
-      err instanceof ApiError ? `Import failed: ${err.status}` : "Import failed"
-    throw new Error(apiErrorMessage(err, fallback), { cause: err })
+    throw importError(err)
   }
 }
 
@@ -109,7 +122,7 @@ async function importPastedOverframe(text: string): Promise<ScrapeResponse> {
  * prod points at www.arsenyx.com.
  */
 function buildBookmarklet(origin: string): string {
-  return `javascript:(function(){try{var e=document.getElementById('__NEXT_DATA__');if(!e){alert('Arsenyx: open an Overframe build page first — no build data found here.');return;}var p=JSON.stringify({source:'arsenyx-overframe',url:location.href,nextData:JSON.parse(e.textContent)});navigator.clipboard.writeText(p).then(function(){window.open(${JSON.stringify(`${origin}/import?paste=1`)},'_blank');},function(){alert('Arsenyx: the browser blocked clipboard access. Try clicking the bookmark again.');});}catch(x){alert('Arsenyx import failed: '+(x&&x.message?x.message:x));}})();`
+  return `javascript:(function(){try{var e=document.getElementById('__NEXT_DATA__');if(!e){alert('Arsenyx: open an Overframe build page first — no build data found here.');return;}var p=JSON.stringify({source:${JSON.stringify(OVERFRAME_PASTE_SOURCE)},url:location.href,nextData:JSON.parse(e.textContent)});navigator.clipboard.writeText(p).then(function(){window.open(${JSON.stringify(`${origin}/import?paste=1`)},'_blank');},function(){alert('Arsenyx: the browser blocked clipboard access. Try clicking the bookmark again.');});}catch(x){alert('Arsenyx import failed: '+(x&&x.message?x.message:x));}})();`
 }
 
 function ImportPage() {
@@ -123,26 +136,29 @@ function ImportPage() {
   const [pasteText, setPasteText] = useState("")
   const pasteRef = useRef<HTMLTextAreaElement>(null)
   const bookmarkRef = useRef<HTMLAnchorElement>(null)
-  const isPasteMode = useMemo(
-    () =>
-      typeof window !== "undefined" &&
-      new URLSearchParams(window.location.search).get("paste") === "1",
-    [],
-  )
+  const isPasteMode =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("paste") === "1"
 
   const mutation = useMutation({ mutationFn: postOverframeImport })
   const rawMutation = useMutation({ mutationFn: importPastedOverframe })
 
-  // Newest result wins so switching between URL and paste imports isn't
-  // confusing; same for the failure surfaced to the user.
-  const result = rawMutation.data ?? mutation.data
-  const isError = mutation.isError || rawMutation.isError
-  const errorMessage = (
-    (rawMutation.error ?? mutation.error) as Error | undefined
-  )?.message
+  // Only one import path is ever live at a time — each submit handler resets
+  // the other mutation (below). So whichever isn't idle is the active one, and
+  // result/error read from it as a single source instead of three coalesces
+  // that have to stay aligned.
+  const active =
+    rawMutation.isPending || rawMutation.data || rawMutation.isError
+      ? rawMutation
+      : mutation
+  const result = active.data
+  const isError = active.isError
+  const errorMessage = (active.error as Error | null)?.message
 
   const submitPaste = (text: string) => {
-    if (text.trim()) rawMutation.mutate(text)
+    if (!text.trim()) return
+    mutation.reset()
+    rawMutation.mutate(text)
   }
 
   // Set the bookmarklet href imperatively — React strips `javascript:` hrefs.
@@ -174,7 +190,14 @@ function ImportPage() {
   }, [])
 
   const fatalWarning = result?.warnings.find(
-    (w) => w.type === "invalid_url" || w.type === "fetch_failed",
+    (w) =>
+      w.type === "invalid_url" ||
+      w.type === "fetch_failed" ||
+      // The paste/bookmarklet path can't fail to fetch, so a missing
+      // __NEXT_DATA__ blob (wrong page copied, or Overframe changed shape) is
+      // its terminal failure — surface it as one clear error, not a soft
+      // warning followed by a confusing "could not match item".
+      w.type === "next_data_missing",
   )
 
   const matchedItem = useMemo(() => {
@@ -225,6 +248,7 @@ function ImportPage() {
     e.preventDefault()
     const trimmed = url.trim()
     if (!trimmed) return
+    rawMutation.reset()
     mutation.mutate(trimmed)
   }
 

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { Copy, UploadCloud } from "lucide-react"
-import { useMemo, useState } from "react"
+import { ClipboardPaste, Copy, UploadCloud } from "lucide-react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import {
   calculateFormaCount,
@@ -55,6 +55,63 @@ async function postOverframeImport(url: string): Promise<ScrapeResponse> {
   }
 }
 
+/** Payload the bookmarklet copies to the clipboard. */
+type PastedOverframe = {
+  source?: string
+  url?: string
+  nextData?: unknown
+}
+
+/**
+ * Interpret pasted clipboard text. The bookmarklet wraps the page's
+ * __NEXT_DATA__ as `{ source: "arsenyx-overframe", url, nextData }`; we also
+ * accept a bare __NEXT_DATA__ blob in case someone copies it by hand.
+ */
+function parsePastedOverframe(text: string): {
+  nextData: unknown
+  url?: string
+} {
+  const obj = JSON.parse(text.trim()) as PastedOverframe
+  if (obj && typeof obj === "object" && obj.source === "arsenyx-overframe") {
+    return {
+      nextData: obj.nextData,
+      url: typeof obj.url === "string" ? obj.url : undefined,
+    }
+  }
+  return { nextData: obj }
+}
+
+async function importPastedOverframe(text: string): Promise<ScrapeResponse> {
+  let input: { nextData: unknown; url?: string }
+  try {
+    input = parsePastedOverframe(text)
+  } catch {
+    throw new Error(
+      "That doesn't look like Overframe build data. Use the bookmarklet on an Overframe build page, then paste here.",
+    )
+  }
+  try {
+    return await apiFetch<ScrapeResponse>(`/imports/overframe/raw`, {
+      method: "POST",
+      json: input,
+    })
+  } catch (err) {
+    const fallback =
+      err instanceof ApiError ? `Import failed: ${err.status}` : "Import failed"
+    throw new Error(apiErrorMessage(err, fallback), { cause: err })
+  }
+}
+
+/**
+ * The bookmarklet: reads __NEXT_DATA__ off the (already challenge-cleared)
+ * Overframe tab, copies it to the clipboard, and opens our import page with
+ * `?paste=1`. Built from the live origin so the dev build points at :5173 and
+ * prod points at www.arsenyx.com.
+ */
+function buildBookmarklet(origin: string): string {
+  return `javascript:(function(){try{var e=document.getElementById('__NEXT_DATA__');if(!e){alert('Arsenyx: open an Overframe build page first — no build data found here.');return;}var p=JSON.stringify({source:'arsenyx-overframe',url:location.href,nextData:JSON.parse(e.textContent)});navigator.clipboard.writeText(p).then(function(){window.open(${JSON.stringify(`${origin}/import?paste=1`)},'_blank');},function(){alert('Arsenyx: the browser blocked clipboard access. Try clicking the bookmark again.');});}catch(x){alert('Arsenyx import failed: '+(x&&x.message?x.message:x));}})();`
+}
+
 function ImportPage() {
   const [url, setUrl] = useState("")
   const navigate = useNavigate()
@@ -63,8 +120,58 @@ function ImportPage() {
   const { data: arcanes } = useQuery(arcanesQuery)
   const { data: helminthAbilities } = useQuery(helminthQuery)
 
+  const [pasteText, setPasteText] = useState("")
+  const pasteRef = useRef<HTMLTextAreaElement>(null)
+  const bookmarkRef = useRef<HTMLAnchorElement>(null)
+  const isPasteMode = useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).get("paste") === "1",
+    [],
+  )
+
   const mutation = useMutation({ mutationFn: postOverframeImport })
-  const result = mutation.data
+  const rawMutation = useMutation({ mutationFn: importPastedOverframe })
+
+  // Newest result wins so switching between URL and paste imports isn't
+  // confusing; same for the failure surfaced to the user.
+  const result = rawMutation.data ?? mutation.data
+  const isError = mutation.isError || rawMutation.isError
+  const errorMessage = (
+    (rawMutation.error ?? mutation.error) as Error | undefined
+  )?.message
+
+  const submitPaste = (text: string) => {
+    if (text.trim()) rawMutation.mutate(text)
+  }
+
+  // Set the bookmarklet href imperatively — React strips `javascript:` hrefs.
+  useEffect(() => {
+    if (bookmarkRef.current) {
+      bookmarkRef.current.href = buildBookmarklet(window.location.origin)
+    }
+  }, [])
+
+  // Arriving via the bookmarklet (`?paste=1`): focus the box and best-effort
+  // pull the copied payload straight off the clipboard so the user just
+  // confirms. Clipboard read can be blocked without a gesture — that's fine,
+  // they can paste manually (Ctrl/Cmd+V).
+  useEffect(() => {
+    if (!isPasteMode) return
+    pasteRef.current?.focus()
+    void (async () => {
+      try {
+        const text = await navigator.clipboard.readText()
+        if (text.trim()) {
+          setPasteText(text)
+          submitPaste(text)
+        }
+      } catch {
+        // No clipboard permission without a gesture — manual paste still works.
+      }
+    })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const fatalWarning = result?.warnings.find(
     (w) => w.type === "invalid_url" || w.type === "fetch_failed",
@@ -177,13 +284,72 @@ function ImportPage() {
             </div>
           </form>
 
-          {mutation.isError && (
+          <details
+            className="bg-card rounded-md border p-4"
+            // Only force-open on arrival via the bookmarklet; otherwise leave
+            // it uncontrolled so the user can freely toggle it.
+            {...(isPasteMode ? { open: true } : {})}
+          >
+            <summary className="cursor-pointer text-sm font-medium">
+              Import blocked? Use the bookmarklet
+            </summary>
+            <div className="mt-4 flex flex-col gap-4 text-sm">
+              <p className="text-muted-foreground">
+                Overframe sits behind Cloudflare bot protection, so we
+                can&apos;t fetch builds server-side. Instead, drag this button
+                to your bookmarks bar:
+              </p>
+              <div>
+                {/* href is set imperatively in an effect — React strips
+                    javascript: hrefs. */}
+                <a
+                  ref={bookmarkRef}
+                  href="https://www.arsenyx.com/import"
+                  onClick={(e) => e.preventDefault()}
+                  className="border-primary/40 bg-primary/10 text-primary inline-flex cursor-grab items-center gap-2 rounded-md border px-3 py-1.5 font-medium"
+                  title="Drag me to your bookmarks bar"
+                >
+                  <UploadCloud className="h-4 w-4" /> Import to Arsenyx
+                </a>
+              </div>
+              <ol className="text-muted-foreground list-decimal space-y-1 pl-5">
+                <li>Open the Overframe build page you want to import.</li>
+                <li>
+                  Click the bookmarklet — it copies the build and reopens this
+                  page.
+                </li>
+                <li>
+                  Paste below (Ctrl/Cmd+V) if it isn&apos;t filled in
+                  automatically, then Import.
+                </li>
+              </ol>
+              <textarea
+                ref={pasteRef}
+                value={pasteText}
+                onChange={(e) => setPasteText(e.target.value)}
+                placeholder="Paste copied Overframe build data here…"
+                rows={4}
+                disabled={rawMutation.isPending}
+                className="border-input bg-background focus-visible:ring-ring w-full rounded-md border px-3 py-2 font-mono text-xs focus-visible:ring-2 focus-visible:outline-none"
+              />
+              <div>
+                <Button
+                  type="button"
+                  onClick={() => submitPaste(pasteText)}
+                  disabled={rawMutation.isPending || !pasteText.trim()}
+                >
+                  <ClipboardPaste className="h-4 w-4" />
+                  {rawMutation.isPending ? "Importing…" : "Import pasted data"}
+                </Button>
+              </div>
+            </div>
+          </details>
+
+          {isError && (
             <WarningBox
               fatal
               title="Import failed"
-              items={[
-                { tag: "error", text: (mutation.error as Error).message },
-              ]}
+              items={[{ tag: "error", text: errorMessage ?? "Import failed" }]}
             />
           )}
 


### PR DESCRIPTION
## What & why

Overframe now sits behind a Cloudflare managed challenge, so every server-side fetch of a build page returns `403` — the server scraper is permanently broken and can't be tweaked around (confirmed with a full browser fingerprint). This adds a fetch-less import path so users can still bring builds over.

A **bookmarklet** reads `__NEXT_DATA__` off the user's own already-challenge-cleared Overframe tab, copies it to the clipboard, and opens `/import?paste=1`, which POSTs it to a new `POST /imports/overframe/raw` endpoint (`scrapeOverframeFromNextData`). This reuses the existing extraction/matching pipeline — no browser automation, no challenge to bypass, and arguably less load on Overframe than the old server scrape (one real human visit vs. our server fetching).

The old `POST /imports/overframe` (server fetch) still exists and now returns a friendly Cloudflare message on `403` instead of a bare `HTTP 403`.

## Changes

- **API:** `extractOverframeData` split out of `extractOverframeDataFromHtml` (start from a parsed object, not HTML); `scrapeOverframeFromNextData` + shared `assembleScrapeResponse`; new `/imports/overframe/raw` route (1.5 MB body cap); friendly 403 message on the fetch path.
- **Web:** bookmarklet builder, paste parser, `/import?paste=1` flow with best-effort clipboard auto-read, and an "Import blocked? Use the bookmarklet" section on the import page.
- **Auth (incidental):** point Better Auth at `cf-connecting-ip` for client IP on Workers — re-enables its built-in `/auth/*` rate limiting and silences a per-request CF dashboard warning.
- **Tests:** new `import.test.ts` (10 cases) covering URL validation, the paste path, the friendly-403 vs. verbatim-status fetch path, and the raw route handler.

## Review-pass hardening (second commit)

A follow-up `/code-review` + `/simplify` pass:

- Reset the sibling mutation on each submit so a stale success card can't render next to a fresh error; collapsed `result`/`isError`/`errorMessage` into a single active-mutation read.
- Treat `next_data_missing` as fatal (a bad paste shows one clear error, not a soft warning + "could not match item").
- Reject non-object pasted JSON client-side → friendly message instead of a 400.
- Consolidated `isValidOverframeBuildUrl` + build-id extraction into one `parseOverframeBuildUrl()` (removed a divergent regex and a redundant URL parse); extracted the clipboard sentinel and the apiFetch error-wrapper.

## Notes for reviewers

- **Fragility:** depends on Overframe keeping the `__NEXT_DATA__` JSON blob in their HTML — a move to Next streaming/RSC would break extraction (same assumption the old scraper made).
- **Anon exposure — now closed:** both import endpoints previously accepted anonymous POSTs (and `rateLimitUser` is a no-op without a session), leaving the 1.5 MB parse + tree-walk unthrottled. Both handlers now require a session (`401` otherwise), matching every other mutation route, and the web `/import` route redirects anon users to sign-in. Authed callers stay capped by the per-user `import` limiter. (A wider audit of the API surface found no other anon-reachable mutation or unthrottled expensive read — import was the lone outlier.)

## Verification

`bun run typecheck`, `just check` (lint + fmt), 38 API tests, and a browser preview of the import page (friendly error path confirmed, clean console) all green.

