### PR TITLE
Refresh user-facing copy and add recent changelog entries

### DIFF
--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -43,7 +43,7 @@ function AboutPage() {
               love of the game.
             </p>
 
-            <h2>Open Source</h2>
+            <h2>Open source</h2>
             <p>
               Arsenyx is fully open source. Anyone can contribute code, suggest
               features, or report bugs.
@@ -64,7 +64,7 @@ function AboutPage() {
               </Button>
             </div>
 
-            <h2>Shoutouts</h2>
+            <h2>Shout-outs</h2>
             <p>
               Big thanks to{" "}
               <Link
@@ -78,12 +78,11 @@ function AboutPage() {
               opening PRs that made Arsenyx better.
             </p>
 
-            <h2>Community Focused</h2>
+            <h2>Where the data comes from</h2>
             <p>
-              From real-time stats updates to seamless sharing, every feature is
-              designed to help the Warframe community. Data is sourced directly
-              from Digital Extremes&apos; public game data and the Warframe wiki
-              to ensure accuracy.
+              Items, mods, and arcanes come straight from Digital Extremes&apos;
+              public game data, with the Warframe wiki filling the gaps. When
+              the game updates, the data does too.
             </p>
           </article>
         </div>

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -13,6 +13,36 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-06-05",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Overframe imports now have a paste-and-bookmarklet fallback for builds the server can't fetch directly, so Cloudflare-protected builds still come through.",
+      },
+    ],
+  },
+  {
+    date: "2026-06-03",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Arsenyx now shows a one-click reload prompt when a new version ships, so you're not stuck on a stale tab.",
+      },
+      {
+        type: "feat",
+        description:
+          "Embedded builds that don't match a curated highlight strip — plain primaries and secondaries, archwings, and the like — now show a header bar with the item name and a link back to Arsenyx.",
+      },
+      {
+        type: "refactor",
+        description:
+          "Build embeds now load from a lightweight, router-free entry, so guide pages with many embedded builds load noticeably faster.",
+      },
+    ],
+  },
+  {
     date: "2026-06-02",
     changes: [
       {
@@ -71,7 +101,7 @@ const CHANGELOG: ChangelogEntry[] = [
       {
         type: "feat",
         description:
-          "Editor drafts autosave to your browser, so you can pick up where you left off — with restore and reset controls.",
+          "Editor drafts autosave to your browser, so you can pick up where you left off, with restore and reset controls.",
       },
       {
         type: "feat",
@@ -140,7 +170,7 @@ const CHANGELOG: ChangelogEntry[] = [
       {
         type: "chore",
         description:
-          "Game data is now sourced directly from the official Warframe export and the wiki, keeping items, mods, and arcanes more accurate and up to date.",
+          "Game data is now sourced directly from the official Warframe export and the wiki, so items, mods, and arcanes stay accurate and up to date.",
       },
       {
         type: "fix",

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -342,7 +342,7 @@ function ImportPage() {
               <ol className="text-muted-foreground list-decimal space-y-1 pl-5">
                 <li>Open the Overframe build page you want to import.</li>
                 <li>
-                  Click the bookmarklet — it copies the build and reopens this
+                  Click the bookmarklet. It copies the build and reopens this
                   page.
                 </li>
                 <li>


### PR DESCRIPTION
## Summary

A small writing pass over user-facing copy, plus the changelog brought current through today.

- **about** — Rewrote the "Community Focused" section, which was the one genuinely AI-sounding block on the site (false range "from real-time stats updates to seamless sharing", "every feature is designed to", "to ensure accuracy"). It's now "Where the data comes from" in the plainspoken voice of the rest of the page. Also normalized heading case: "Open Source" → "Open source", "Shoutouts" → "Shout-outs".
- **import** — Split the bookmarklet step's tacked-on em-dash into two clean sentences.
- **changelog** — Added entries for June 3 (deploy reload prompt #210, embed fallback header #212/#213, lightweight router-free embed entry #211) and June 5 (Overframe paste/bookmarklet import fallback #214). Also tidied two older descriptions: dropped a superficial "keeping … more accurate" participle clause and swapped a bolted-on em-dash for a comma.

Em-dashes that are part of the established voice (the about page and docs use them naturally) were left alone.

## Test plan

- [x] `just check` — typecheck + oxlint (0/0) + oxfmt all pass
- [x] Verified `/about` and `/changelog` render correctly in the local preview