### PR TITLE
Fix Overframe import polarity (code 9) and bring guides over

### DIFF
--- a/apps/api/src/lib/overframe/import.test.ts
+++ b/apps/api/src/lib/overframe/import.test.ts
@@ -81,6 +81,49 @@ describe("scrapeOverframeFromNextData", () => {
     expect(byId[9].polarity).toBe("vazarin") // code 2
   })
 
+  it('maps polarity code 9 to "any" (Universal forma), not zenurik', () => {
+    // The Universal ("Any") forma matches every mod, so Overframe still reports
+    // polarity_match === 2 for it — which is how code 9 was once mis-read as
+    // zenurik. It must map to "any" (matches everything, doubles aura), NOT
+    // "universal" (which means "slot cleared" in calculations.ts). See
+    // polarity.ts.
+    const nextData = {
+      props: {
+        pageProps: {
+          data: {
+            title: "T",
+            name: "Voruna Prime",
+            formas: 5,
+            slots: [{ slot_id: 9, mod: 303, rank: 5, polarity: 9 }],
+          },
+        },
+      },
+    }
+    const res = scrapeOverframeFromNextData(nextData, BUILD_URL)
+    expect(res.slots[0].polarity).toBe("any")
+    expect(res.slots[0].polarityCode).toBe(9)
+  })
+
+  it("prefers the plain data.description guide over the link-marked guideMarkdown", () => {
+    const nextData = {
+      props: {
+        pageProps: {
+          guideMarkdown:
+            "Use [\\[Hunt\\]](/items/arsenal/213/hunt/) early then nuke.",
+          data: {
+            title: "T",
+            name: "Voruna Prime",
+            formas: 5,
+            description: "Use Hunt early then nuke.",
+            slots: [{ slot_id: 1, mod: 1, rank: 0, polarity: 0 }],
+          },
+        },
+      },
+    }
+    const res = scrapeOverframeFromNextData(nextData, BUILD_URL)
+    expect(res.source.guideDescription).toBe("Use Hunt early then nuke.")
+  })
+
   it("keeps a valid url but ignores a non-overframe one", () => {
     expect(
       scrapeOverframeFromNextData(makeNextData(), BUILD_URL).source.url,

--- a/apps/api/src/lib/overframe/next-data.ts
+++ b/apps/api/src/lib/overframe/next-data.ts
@@ -231,14 +231,19 @@ export function extractOverframeData(
     "pageDescription",
   ])
 
+  // Two copies of the guide live in __NEXT_DATA__: `data.description` is the
+  // plain author text; `guideMarkdown` is the same prose with Overframe's
+  // internal item links woven in. Prefer the plain copy; either way the web
+  // importer's `normalizeOverframeGuide` sanitizes Overframe-specific markup
+  // before it's rendered.
   const guideMarkdown = readStringAtPath(nextData, [
     "props",
     "pageProps",
     "guideMarkdown",
   ])
   const guideDescription =
-    guideMarkdown ??
-    readStringAtPath(nextData, ["props", "pageProps", "data", "description"])
+    readStringAtPath(nextData, ["props", "pageProps", "data", "description"]) ??
+    guideMarkdown
 
   const helminthAbilityRes = findFirstHelminthAbility(nextData)
 

--- a/apps/api/src/lib/overframe/polarity.ts
+++ b/apps/api/src/lib/overframe/polarity.ts
@@ -1,17 +1,26 @@
 import type { Polarity } from "@arsenyx/shared/warframe/types"
 
 // Overframe numeric codes observed in pageProps.data.slots[].polarity.
-// Verified empirically by cross-referencing slots where polarity_match === 2
-// (slot polarity == mod's known polarity) across 7 sample builds.
 //
 // 0 = none/unchanged
 // 1 = madurai
 // 2 = vazarin
 // 3 = naramon
 // 5 = penjaga
-// 9 = zenurik
+// 9 = "any" — the Universal ("Any" / Aya) forma that matches every mod.
+//     NB: this is our `"any"` polarity, NOT `"universal"`. In calculations.ts
+//     `"universal"` means "slot cleared to no polarity" (full drain, no aura
+//     doubling), whereas `"any"` is the matches-everything forma (half drain,
+//     doubled aura) — which is what an Aya-forma'd slot actually does.
 //
-// Codes 4, 6, 7, 8 are not yet observed; unairu / umbra / any mappings
+// Caution on `polarity_match === 2`: it means the slot polarity satisfies the
+// mod's polarity, NOT that they're equal. An "any" slot (code 9) matches every
+// mod, so it also reports `polarity_match === 2` — which is how code 9 was
+// previously mis-read as zenurik (a zenurik mod sitting in an "any" slot looked
+// like a zenurik match). Confirmed via Corrosive Projection (naramon) sitting
+// in a code-9 slot with its aura capacity doubled.
+//
+// Codes 4, 6, 7, 8 are not yet observed; zenurik / unairu / umbra mappings
 // remain unknown. Add them once a build with a confirmed match surfaces.
 const OVERFRAME_POLARITY_CODE_MAP: Record<number, Polarity | undefined> = {
   0: undefined,
@@ -19,7 +28,7 @@ const OVERFRAME_POLARITY_CODE_MAP: Record<number, Polarity | undefined> = {
   2: "vazarin",
   3: "naramon",
   5: "penjaga",
-  9: "zenurik",
+  9: "any",
 }
 
 /** Map an Overframe polarity code to our `Polarity`, or `undefined` for the

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -539,6 +539,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       cachedShared?.guideDescription ??
       localDraft?.guideDescription ??
       existingBuild?.guide?.description ??
+      draft?.guideDescription ??
       "",
   )
   // Scope of the GuideEditor — build-wide vs a specific variant. Resets

--- a/apps/web/src/lib/import-draft.ts
+++ b/apps/web/src/lib/import-draft.ts
@@ -5,6 +5,7 @@ const STORAGE_PREFIX = "arsenyx:import-draft:"
 export type ImportDraft = {
   data: SavedBuildData
   buildName?: string
+  guideDescription?: string
 }
 
 export function saveDraft(draft: ImportDraft): string {

--- a/apps/web/src/lib/overframe/index.ts
+++ b/apps/web/src/lib/overframe/index.ts
@@ -35,7 +35,36 @@ export type ApplyResult = {
   category: BrowseCategory
   data: SavedBuildData
   buildName?: string
+  /** Author's guide prose, normalized for our markdown renderer. */
+  guideDescription?: string
   warnings: ApplyWarning[]
+}
+
+/**
+ * Normalize an Overframe guide into the markdown our viewer renders.
+ *
+ * - Overframe embeds videos with a `[[ youtube id="VIDEOID" ]]` shortcode our
+ *   renderer doesn't understand; rewrite it to a bare youtu.be URL on its own
+ *   line, which `MarkdownBody` auto-upgrades to an embedded player. The id may
+ *   carry a `?si=...` share suffix — keep only the leading id chars.
+ * - Overframe's `guideMarkdown` weaves in root-relative item links like
+ *   `[\[Hunt\]](/items/arsenal/213/hunt/)` that 404 anywhere off overframe.gg
+ *   (and `MarkdownBody` has no custom anchor renderer to rewrite them). Our
+ *   preferred source — `data.description` — has none, but the fallback does, so
+ *   drop the link wrapper and keep the de-escaped label text. Absolute external
+ *   links (e.g. `https://overframe.gg/...`) are left intact.
+ */
+function normalizeOverframeGuide(raw: string | undefined): string | undefined {
+  if (!raw) return undefined
+  const normalized = raw
+    .replace(
+      /\[\[\s*youtube\s+id=["']([A-Za-z0-9_-]+)[^"']*["']\s*\]\]/gi,
+      (_m, id: string) => `\n\nhttps://youtu.be/${id}\n\n`,
+    )
+    .replace(/\[((?:\\.|[^\]\\])*)\]\(\/[^)]*\)/g, (_m, label: string) =>
+      label.replace(/\\(.)/g, "$1"),
+    )
+  return normalized.trim() || undefined
 }
 
 export function matchOverframeItem(
@@ -254,6 +283,7 @@ export function applyOverframeScrape(args: {
     category,
     data,
     buildName: scrape.source.pageTitle,
+    guideDescription: normalizeOverframeGuide(scrape.source.guideDescription),
     warnings,
   }
 }

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -260,6 +260,7 @@ function ImportPage() {
     const id = saveDraft({
       data: applied.data,
       buildName: applied.buildName,
+      guideDescription: applied.guideDescription,
     })
     navigate({
       to: "/create",
@@ -480,6 +481,12 @@ function ImportPage() {
                           </dd>
                         </>
                       )}
+                      <dt className="text-muted-foreground">Guide</dt>
+                      <dd>
+                        {applied.guideDescription
+                          ? `Imported (${applied.guideDescription.length.toLocaleString()} chars)`
+                          : "—"}
+                      </dd>
                     </dl>
                     <div className="mt-4 flex items-center justify-between">
                       <CopyDebugButton payload={{ scrape: result, applied }} />


### PR DESCRIPTION
## What & why

Two fixes to the Overframe importer, surfaced by importing a Voruna Prime build.

### 1. Polarity code 9 was mislabeled (`zenurik` → `any`)

Overframe's polarity code `9` is the **Universal ("Any" / Aya) forma** that matches every mod — not zenurik. The old mapping inferred zenurik from `polarity_match === 2`, but a universal forma *also* reports `polarity_match === 2` because it satisfies any mod's polarity, so a zenurik mod in a universal slot looked like a zenurik match.

It now maps to our **`"any"`** polarity, which `calculations.ts` treats as matches-everything (half drain, doubled aura). Crucially **not** `"universal"`, which that same module treats as a *cleared* slot (full drain, no aura doubling) — the opposite capacity behavior.

Confirmed against the sample build: Corrosive Projection (naramon aura) sits in a code-9 slot with its aura capacity doubled (`drain: -14`), which only `"any"` reproduces.

### 2. Bring the build guide over

The guide was already extracted into `scrape.source.guideDescription` but nothing consumed it. Now wired end-to-end:

- **Prefer the plain `data.description`** over `guideMarkdown` — the latter weaves in Overframe-internal `[\[Name\]](/items/arsenal/.../)` links that 404 anywhere off overframe.gg.
- **`normalizeOverframeGuide`** converts Overframe's `[[ youtube id="..." ]]` shortcode into a bare `youtu.be` URL (our `MarkdownBody` auto-embeds it), and strips any surviving root-relative Overframe links down to their de-escaped label text (covers the `guideMarkdown` fallback path).
- Plumbed `guideDescription` through `ApplyResult` → import draft → editor guide field, mirroring the existing `buildName` path, and surfaced it in the import preview ("Guide: Imported (N chars)").

## Reviewer notes

- The `"any"` vs `"universal"` distinction is the subtle bit — see the expanded comment in `polarity.ts`. They render the same "Any" glyph but have opposite drain/aura math.
- Overframe markup sanitization lives in `normalizeOverframeGuide` (web), coupled to the markdown renderer's bare-URL embed contract; the api just selects the cleaner source.
- Non-YouTube shortcodes (e.g. vimeo) aren't normalized yet — they'd render as literal text. Left out since Overframe's exact format is unverified.

## Testing

- Added api unit tests: code 9 → `"any"`, and guide source preference (`data.description` over `guideMarkdown`).
- `bun run typecheck` (web + api + shared + scripts) clean; 13/13 overframe import tests pass; `just fix` reports 0 lint errors.