### PR TITLE
Overframe import: slot/forma correctness + richer debug

### DIFF
--- a/apps/api/src/lib/overframe/import.test.ts
+++ b/apps/api/src/lib/overframe/import.test.ts
@@ -104,6 +104,27 @@ describe("scrapeOverframeFromNextData", () => {
     expect(res.slots[0].polarityCode).toBe(9)
   })
 
+  it("maps polarity code 4 to zenurik", () => {
+    // Confirmed via Prey of Dynar (a zenurik augment) sitting in a code-4 slot
+    // with polarity_match === 2. Code 4 was previously unmapped, so the slot's
+    // zenurik forma was silently dropped and the forma count came up short.
+    const nextData = {
+      props: {
+        pageProps: {
+          data: {
+            title: "T",
+            name: "Voruna Prime",
+            formas: 5,
+            slots: [{ slot_id: 3, mod: 6745, rank: 3, polarity: 4 }],
+          },
+        },
+      },
+    }
+    const res = scrapeOverframeFromNextData(nextData, BUILD_URL)
+    expect(res.slots[0].polarity).toBe("zenurik")
+    expect(res.slots[0].polarityCode).toBe(4)
+  })
+
   it("prefers the plain data.description guide over the link-marked guideMarkdown", () => {
     const nextData = {
       props: {

--- a/apps/api/src/lib/overframe/import.test.ts
+++ b/apps/api/src/lib/overframe/import.test.ts
@@ -125,6 +125,27 @@ describe("scrapeOverframeFromNextData", () => {
     expect(res.slots[0].polarityCode).toBe(4)
   })
 
+  it("maps polarity code 8 to umbra", () => {
+    // Confirmed via Umbral Vitality / Umbral Intensify (umbra mods) in code-8
+    // slots. Previously unmapped, so an umbra-forma'd slot imported as a
+    // spurious "universal" (cleared) forma and the count came up short.
+    const nextData = {
+      props: {
+        pageProps: {
+          data: {
+            title: "T",
+            name: "Valkyr Prime",
+            formas: 5,
+            slots: [{ slot_id: 6, mod: 695, rank: 10, polarity: 8 }],
+          },
+        },
+      },
+    }
+    const res = scrapeOverframeFromNextData(nextData, BUILD_URL)
+    expect(res.slots[0].polarity).toBe("umbra")
+    expect(res.slots[0].polarityCode).toBe(8)
+  })
+
   it("prefers the plain data.description guide over the link-marked guideMarkdown", () => {
     const nextData = {
       props: {

--- a/apps/api/src/lib/overframe/polarity.ts
+++ b/apps/api/src/lib/overframe/polarity.ts
@@ -10,6 +10,8 @@ import type { Polarity } from "@arsenyx/shared/warframe/types"
 //     code-4 slot with polarity_match === 2, i.e. the slot equals the mod's
 //     own zenurik polarity)
 // 5 = penjaga
+// 8 = umbra (confirmed via Umbral Vitality / Umbral Intensify — umbra mods —
+//     sitting in code-8 slots across two Valkyr Prime builds)
 // 9 = "any" — the Universal ("Any" / Aya) forma that matches every mod.
 //     NB: this is our `"any"` polarity, NOT `"universal"`. In calculations.ts
 //     `"universal"` means "slot cleared to no polarity" (full drain, no aura
@@ -23,7 +25,7 @@ import type { Polarity } from "@arsenyx/shared/warframe/types"
 // like a zenurik match). Confirmed via Corrosive Projection (naramon) sitting
 // in a code-9 slot with its aura capacity doubled.
 //
-// Codes 6, 7, 8 are not yet observed; unairu / umbra mappings remain unknown.
+// Codes 6, 7 are not yet observed; unairu (and any others) remain unknown.
 // Add them once a build with a confirmed match surfaces.
 const OVERFRAME_POLARITY_CODE_MAP: Record<number, Polarity | undefined> = {
   0: undefined,
@@ -32,6 +34,7 @@ const OVERFRAME_POLARITY_CODE_MAP: Record<number, Polarity | undefined> = {
   3: "naramon",
   4: "zenurik",
   5: "penjaga",
+  8: "umbra",
   9: "any",
 }
 

--- a/apps/api/src/lib/overframe/polarity.ts
+++ b/apps/api/src/lib/overframe/polarity.ts
@@ -6,6 +6,9 @@ import type { Polarity } from "@arsenyx/shared/warframe/types"
 // 1 = madurai
 // 2 = vazarin
 // 3 = naramon
+// 4 = zenurik (confirmed via Prey of Dynar — a zenurik augment — sitting in a
+//     code-4 slot with polarity_match === 2, i.e. the slot equals the mod's
+//     own zenurik polarity)
 // 5 = penjaga
 // 9 = "any" — the Universal ("Any" / Aya) forma that matches every mod.
 //     NB: this is our `"any"` polarity, NOT `"universal"`. In calculations.ts
@@ -20,13 +23,14 @@ import type { Polarity } from "@arsenyx/shared/warframe/types"
 // like a zenurik match). Confirmed via Corrosive Projection (naramon) sitting
 // in a code-9 slot with its aura capacity doubled.
 //
-// Codes 4, 6, 7, 8 are not yet observed; zenurik / unairu / umbra mappings
-// remain unknown. Add them once a build with a confirmed match surfaces.
+// Codes 6, 7, 8 are not yet observed; unairu / umbra mappings remain unknown.
+// Add them once a build with a confirmed match surfaces.
 const OVERFRAME_POLARITY_CODE_MAP: Record<number, Polarity | undefined> = {
   0: undefined,
   1: "madurai",
   2: "vazarin",
   3: "naramon",
+  4: "zenurik",
   5: "penjaga",
   9: "any",
 }

--- a/apps/web/src/components/build-editor/calculations.test.ts
+++ b/apps/web/src/components/build-editor/calculations.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 import {
   auraBonusForMod,
   calculateCapacity,
+  calculateFormaCount,
   type CapacityInput,
   getMatchState,
 } from "./calculations"
@@ -185,5 +186,64 @@ describe('"any"-polarity mods match every polarized slot', () => {
       }),
     )
     expect(result.max).toBe(74) // 60 + 14
+  })
+})
+
+// Regression: forma must dedup within a slot type, never across types. A
+// forma'd Aura previously shared the normal pool and could cancel a
+// same-polarity normal forma, undercounting vs Overframe (matches OF here).
+describe("calculateFormaCount", () => {
+  const NO_NORMALS = Array<undefined>(8).fill(undefined)
+
+  it("does not let a forma'd aura offset a same-polarity normal forma", () => {
+    // Valkyr Prime (aura madurai + 3 madurai normals). Aura forma'd madurai→any,
+    // two blank normals forma'd to madurai, plus umbra/zenurik/vazarin. OF = 5.
+    const count = calculateFormaCount({
+      auraInnates: ["madurai"],
+      normalInnates: [
+        "madurai",
+        "madurai",
+        "madurai",
+        ...Array(5).fill(undefined),
+      ],
+      formaPolarities: {
+        "aura-0": "any",
+        "normal-2": "umbra",
+        "normal-3": "zenurik",
+        "normal-4": "madurai",
+        "normal-5": "vazarin",
+        "normal-6": "madurai",
+      },
+    })
+    expect(count).toBe(5)
+  })
+
+  it("dedups a polarity move within the interchangeable normal pool", () => {
+    // Sarofang Prime (1 innate naramon normal, stance madurai). naramon moved
+    // off slot 0 and onto slot 2 is 1 net forma; stance mod matches innate. OF = 5.
+    const count = calculateFormaCount({
+      auraInnates: [],
+      stanceInnate: "madurai",
+      normalInnates: ["naramon", ...Array(7).fill(undefined)],
+      formaPolarities: {
+        "normal-0": "madurai",
+        "normal-1": "madurai",
+        "normal-2": "naramon",
+        "normal-3": "madurai",
+        "normal-4": "madurai",
+        "normal-6": "madurai",
+      },
+    })
+    expect(count).toBe(5)
+  })
+
+  it("scores a forma'd exilus separately from the normal pool", () => {
+    const count = calculateFormaCount({
+      auraInnates: [],
+      exilusInnate: "madurai",
+      normalInnates: NO_NORMALS,
+      formaPolarities: { exilus: "vazarin", "normal-0": "madurai" },
+    })
+    expect(count).toBe(2)
   })
 })

--- a/apps/web/src/components/build-editor/calculations.ts
+++ b/apps/web/src/components/build-editor/calculations.ts
@@ -268,25 +268,26 @@ export function calculateFormaCount(input: FormaCountInput): number {
     formaPolarities,
   } = input
 
-  // Aura, exilus, and normal slots share a single dedup pool: moving a
-  // polarity between them (e.g. exilus → normal) costs no net forma. Stance
-  // is separate — melee stance changes always cost forma.
-  const pool: NormalSlotEntry[] = [
-    ...auraInnates.map((innate, i) => ({
-      innate,
-      forma: formaPolarities[`aura-${i}` as SlotId],
-    })),
-    {
-      innate: exilusInnate,
-      forma: formaPolarities.exilus,
-    },
-    ...normalInnates.map((innate, i) => ({
-      innate,
-      forma: formaPolarities[`normal-${i}` as SlotId],
-    })),
-  ]
+  // Forma dedups WITHIN a slot type, never across types: an innate polarity
+  // only offsets a mod of its own slot type. A frame's innate Aura polarity
+  // can't make a normal-slot mod cheaper because a normal mod can't sit in the
+  // Aura slot — so a forma'd aura must not cancel a same-polarity normal forma.
+  // Normal slots are interchangeable, so they share one dedup pool; Aura (its
+  // own pool, for 2-aura frames like Jade), Exilus, and Stance are scored
+  // separately. This matches Overframe's forma count.
+  const normalPool: NormalSlotEntry[] = normalInnates.map((innate, i) => ({
+    innate,
+    forma: formaPolarities[`normal-${i}` as SlotId],
+  }))
+  const auraPool: NormalSlotEntry[] = auraInnates.map((innate, i) => ({
+    innate,
+    forma: formaPolarities[`aura-${i}` as SlotId],
+  }))
 
   return (
-    groupForma(pool) + singleSlotForma(stanceInnate, formaPolarities.stance)
+    groupForma(normalPool) +
+    groupForma(auraPool) +
+    singleSlotForma(exilusInnate, formaPolarities.exilus) +
+    singleSlotForma(stanceInnate, formaPolarities.stance)
   )
 }

--- a/apps/web/src/lib/overframe/index.ts
+++ b/apps/web/src/lib/overframe/index.ts
@@ -30,6 +30,30 @@ export type ApplyWarning = {
   message: string
 }
 
+/**
+ * One row per Overframe slot, capturing how it was interpreted. Purely
+ * diagnostic — surfaced by the import page's "Copy debug JSON" so slot/forma
+ * mismaps are visible without re-deriving the decode by hand. `matchedType`
+ * (the matched mod's `type`, e.g. "Stance"/"Melee"/"Primary") is the tell for
+ * layout bugs: a Stance mod landing in `exilus`, or an exilus mod in `arcane`.
+ */
+export type OverframeSlotTrace = {
+  ofSlotId: number
+  ofName: string | null
+  ofPolarityCode: number
+  ofPolarity: string | null
+  rank: number
+  /** Where it landed: a SlotId ("normal-3"/"exilus"/"aura-0"), "arcane-N", or "unmapped". */
+  target: string
+  kind: "mod" | "arcane" | "unmapped"
+  /** Mod slots only: innate polarity, the forma we recorded, the matched mod. */
+  innate?: string | null
+  forma?: string | null
+  matched?: string | null
+  matchedType?: string
+  note?: string
+}
+
 export type ApplyResult = {
   item: BrowseItem
   category: BrowseCategory
@@ -37,6 +61,8 @@ export type ApplyResult = {
   buildName?: string
   /** Author's guide prose, normalized for our markdown renderer. */
   guideDescription?: string
+  /** Per-slot interpretation trace for the debug payload (not persisted). */
+  trace: OverframeSlotTrace[]
   warnings: ApplyWarning[]
 }
 
@@ -137,8 +163,8 @@ function interpretSlot(
   if (!mapping) return null
   if (mapping.kind === "arcane") return mapping
   const id: SlotId =
-    mapping.slotType === "exilus"
-      ? "exilus"
+    mapping.slotType === "exilus" || mapping.slotType === "stance"
+      ? mapping.slotType
       : (`${mapping.slotType}-${mapping.slotIndex}` as SlotId)
   return { kind: "mod", id }
 }
@@ -157,6 +183,9 @@ function innatePolarityFor(
   }
   if (slotId === "exilus") {
     return (detail.exilusPolarity ?? undefined) as Polarity | undefined
+  }
+  if (slotId === "stance") {
+    return (detail.stancePolarity ?? undefined) as Polarity | undefined
   }
   if (slotId.startsWith("normal-")) {
     const idx = Number(slotId.slice("normal-".length))
@@ -197,35 +226,69 @@ export function applyOverframeScrape(args: {
   )
   const arcanesByName = new Map(arcanes.map((a) => [normalizeName(a.name), a]))
 
+  const trace: OverframeSlotTrace[] = []
+
   for (const rawSlot of scrape.slots) {
+    const base = {
+      ofSlotId: rawSlot.slot_id,
+      ofName: rawSlot.overframeName ?? null,
+      ofPolarityCode: rawSlot.polarityCode,
+      ofPolarity: rawSlot.polarity ?? null,
+      rank: rawSlot.rank,
+    }
     const interp = interpretSlot(rawSlot.slot_id, category)
-    if (!interp) continue
+    if (!interp) {
+      trace.push({
+        ...base,
+        target: "unmapped",
+        kind: "unmapped",
+        note: `slot_id ${rawSlot.slot_id} has no ${category} mapping`,
+      })
+      continue
+    }
 
     if (interp.kind === "arcane") {
-      if (!rawSlot.overframeId || !rawSlot.overframeName) continue
+      const target = `arcane-${interp.index}`
+      if (!rawSlot.overframeId || !rawSlot.overframeName) {
+        trace.push({ ...base, target, kind: "arcane", matched: null })
+        continue
+      }
       const arcane = arcanesByName.get(normalizeName(rawSlot.overframeName))
       if (!arcane) {
         warnings.push({
           type: "arcane_not_found",
           message: `No arcane match for "${rawSlot.overframeName}"`,
         })
+        trace.push({
+          ...base,
+          target,
+          kind: "arcane",
+          matched: null,
+          note: "no arcane match",
+        })
         continue
       }
       while (arcaneSlots.length <= interp.index) arcaneSlots.push(null)
       arcaneSlots[interp.index] = { arcane, rank: rawSlot.rank }
+      trace.push({ ...base, target, kind: "arcane", matched: arcane.name })
       continue
     }
 
     const slotId = interp.id
     const importedPolarity = rawSlot.polarity as Polarity | undefined
     const innate = innatePolarityFor(detailItem, slotId)
+    let forma: Polarity | undefined
     if (importedPolarity && importedPolarity !== innate) {
+      forma = importedPolarity
       formaPolarities[slotId] = importedPolarity
     } else if (!importedPolarity && innate) {
       // OF reports no polarity but slot has innate → universal forma cleared it.
+      forma = "universal"
       formaPolarities[slotId] = "universal"
     }
 
+    let matchedName: string | null = null
+    let matchedType: string | undefined
     if (rawSlot.overframeId && rawSlot.overframeName) {
       const match = matchModByName(
         rawSlot.overframeName,
@@ -244,8 +307,21 @@ export function applyOverframeScrape(args: {
           Math.min(rawSlot.rank ?? 0, matched.fusionLimit ?? rawSlot.rank ?? 0),
         )
         slots[slotId] = { mod: matched, rank: boundedRank }
+        matchedName = matched.name
+        matchedType = matched.type
       }
     }
+
+    trace.push({
+      ...base,
+      target: slotId,
+      kind: "mod",
+      innate: innate ?? null,
+      forma: forma ?? null,
+      matched: matchedName,
+      matchedType,
+      note: rawSlot.overframeName && !matchedName ? "no mod match" : undefined,
+    })
   }
 
   // Helminth: warframes only.
@@ -284,6 +360,7 @@ export function applyOverframeScrape(args: {
     data,
     buildName: scrape.source.pageTitle,
     guideDescription: normalizeOverframeGuide(scrape.source.guideDescription),
+    trace,
     warnings,
   }
 }

--- a/apps/web/src/routes/import.tsx
+++ b/apps/web/src/routes/import.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { requireUser } from "@/lib/auth-guards"
 import { saveDraft } from "@/lib/import-draft"
 import {
+  type ApplyResult,
   applyOverframeScrape,
   matchOverframeItem,
   type ScrapeResponse,
@@ -30,6 +31,7 @@ import { itemsIndexQuery } from "@/lib/queries/items-index-query"
 import { modsQuery } from "@/lib/queries/mods-query"
 import { apiErrorMessage, apiFetch, ApiError } from "@/lib/util/api-client"
 import { copyToClipboard } from "@/lib/util/clipboard"
+import type { BrowseCategory, BrowseItem, DetailItem } from "@/lib/warframe"
 
 export const Route = createFileRoute("/import")({
   // Import feeds the sign-in-only editor/save flow, and the API endpoints are
@@ -489,7 +491,14 @@ function ImportPage() {
                       </dd>
                     </dl>
                     <div className="mt-4 flex items-center justify-between">
-                      <CopyDebugButton payload={{ scrape: result, applied }} />
+                      <CopyDebugButton
+                        payload={buildImportDebug(
+                          result,
+                          applied,
+                          matchedItem,
+                          detailItem,
+                        )}
+                      />
                       <Button onClick={onOpenInEditor}>Open in editor</Button>
                     </div>
                   </div>
@@ -531,6 +540,85 @@ function ImportPage() {
       <Footer />
     </div>
   )
+}
+
+/**
+ * Compact, diagnostic debug payload for the "Copy debug JSON" button. The raw
+ * `scrape`/`applied` dump is huge (every mod's full `levelStats`) and hides the
+ * things that actually matter when an import looks wrong. This keeps only the
+ * signal: the item's innate polarities, the computed-vs-Overframe forma counts,
+ * and a per-slot trace (`applied.trace`) showing where every Overframe slot
+ * landed and the matched mod's `type` — so a Stance mod in `exilus`, an exilus
+ * mod mapped to `arcane`, or a spurious forma is obvious at a glance.
+ */
+function buildImportDebug(
+  result: ScrapeResponse,
+  applied: ApplyResult,
+  matchedItem: { item: BrowseItem; category: BrowseCategory },
+  detailItem: DetailItem | undefined,
+) {
+  const { category } = matchedItem
+  const auraInnates = detailItem
+    ? getAuraPolarities(detailItem, getAuraSlotCount(category, detailItem))
+    : []
+  const normalInnates = detailItem
+    ? Array.from({ length: getNormalSlotCount(category) }, (_, i) =>
+        toPolarity(detailItem.polarities?.[i]),
+      )
+    : []
+  const exilusInnate = detailItem
+    ? getExilusInnatePolarity(detailItem)
+    : undefined
+  const stanceInnate = detailItem
+    ? getStanceInnatePolarity(detailItem)
+    : undefined
+
+  return {
+    url: result.source.url,
+    buildId: result.source.buildId,
+    buildString: result.source.buildString,
+    item: {
+      name: matchedItem.item.name,
+      slug: matchedItem.item.slug,
+      category,
+      displayClass: matchedItem.item.displayClass,
+    },
+    innates: detailItem
+      ? {
+          aura: auraInnates.map((p) => p ?? null),
+          exilus: exilusInnate ?? null,
+          stance: stanceInnate ?? null,
+          normals: normalInnates.map((p) => p ?? null),
+        }
+      : null,
+    forma: {
+      computed: detailItem
+        ? calculateFormaCount({
+            auraInnates,
+            exilusInnate,
+            stanceInnate,
+            normalInnates,
+            formaPolarities: applied.data.formaPolarities ?? {},
+          })
+        : null,
+      ofReported: result.formaCount,
+    },
+    formaPolarities: applied.data.formaPolarities ?? {},
+    slots: applied.trace,
+    arcanes: (applied.data.arcanes ?? [])
+      .map((a, i) =>
+        a ? { index: i, name: a.arcane.name, rank: a.rank } : null,
+      )
+      .filter(Boolean),
+    helminth: applied.data.helminth
+      ? Object.entries(applied.data.helminth).map(([slot, ab]) => ({
+          slot: Number(slot),
+          name: ab.name,
+        }))
+      : null,
+    guideChars: applied.guideDescription?.length ?? 0,
+    warnings: { scrape: result.warnings, apply: applied.warnings },
+  }
 }
 
 function CopyDebugButton({ payload }: { payload: unknown }) {

--- a/packages/shared/src/warframe/forma.ts
+++ b/packages/shared/src/warframe/forma.ts
@@ -4,7 +4,9 @@
 // changes, so a targeted recompute can find stale rows with
 // `WHERE "formaCalcVersion" < FORMA_CALC_VERSION` instead of rescanning the
 // whole table. See scripts/recompute-forma.ts.
-export const FORMA_CALC_VERSION = 1
+// v2: forma is deduped within a slot type, not across them — a forma'd Aura no
+// longer cancels a same-polarity normal-slot forma (see calculateFormaCount).
+export const FORMA_CALC_VERSION = 2
 
 // `formaCalcVersion` value for a row whose count was never computed by the
 // current calc — a pre-backfill row, or a write that didn't carry a valid

--- a/packages/shared/src/warframe/overframe-slots.test.ts
+++ b/packages/shared/src/warframe/overframe-slots.test.ts
@@ -53,6 +53,28 @@ describe("overframe slot mapping round-trips", () => {
     })
   })
 
+  it("maps melee slot ids with a Stance slot at 9 (Exilus→10, Arcanes→11+)", () => {
+    expect(decodeOverframeSlotId(8, "melee")).toEqual({
+      kind: "mod",
+      slotType: "normal",
+      slotIndex: 0,
+    })
+    expect(decodeOverframeSlotId(9, "melee")).toEqual({
+      kind: "mod",
+      slotType: "stance",
+      slotIndex: 0,
+    })
+    expect(decodeOverframeSlotId(10, "melee")).toEqual({
+      kind: "mod",
+      slotType: "exilus",
+      slotIndex: 0,
+    })
+    expect(decodeOverframeSlotId(11, "melee")).toEqual({
+      kind: "arcane",
+      index: 0,
+    })
+  })
+
   it("counts companion normals down from the highest slot id", () => {
     // 10 normal slots → slot_id 1 is the last normal, slot_id 10 the first.
     expect(decodeOverframeSlotId(1, "companions")).toEqual({

--- a/packages/shared/src/warframe/overframe-slots.ts
+++ b/packages/shared/src/warframe/overframe-slots.ts
@@ -1,6 +1,7 @@
 import {
   getNormalSlotCount,
   hasExilusSlot,
+  hasStanceSlot,
   isWarframeLike,
 } from "./slot-layout"
 import type { BrowseCategory } from "./types"
@@ -15,10 +16,19 @@ import type { BrowseCategory } from "./types"
 // It returns slot type + index (not a web `SlotId` string) so this stays free
 // of web-only types.
 
-export type OverframeSlotType = "normal" | "aura" | "exilus" | "arcane"
+export type OverframeSlotType =
+  | "normal"
+  | "aura"
+  | "exilus"
+  | "stance"
+  | "arcane"
 
 export type SlotMapping =
-  | { kind: "mod"; slotType: "normal" | "aura" | "exilus"; slotIndex: number }
+  | {
+      kind: "mod"
+      slotType: "normal" | "aura" | "exilus" | "stance"
+      slotIndex: number
+    }
   | { kind: "arcane"; index: number }
 
 /**
@@ -46,6 +56,15 @@ export function decodeOverframeSlotId(
   }
   if (slotId >= 1 && slotId <= 8) {
     return { kind: "mod", slotType: "normal", slotIndex: 8 - slotId }
+  }
+  // Melee inserts a Stance slot at slot_id 9, shifting Exilus to 10 and Arcanes
+  // to 11+. (Other exilus-bearing non-warframe categories — primary/secondary —
+  // have no stance, so Exilus sits at 9.)
+  if (hasStanceSlot(category)) {
+    if (slotId === 9) return { kind: "mod", slotType: "stance", slotIndex: 0 }
+    if (slotId === 10) return { kind: "mod", slotType: "exilus", slotIndex: 0 }
+    if (slotId >= 11) return { kind: "arcane", index: slotId - 11 }
+    return null
   }
   const warframeLike = isWarframeLike(category)
   if (slotId === 9) {
@@ -88,6 +107,21 @@ export function encodeOverframeSlotId(
     }
     return getNormalSlotCount(category) - slotIndex
   }
+  // Melee: Stance at 9, Exilus at 10, Arcanes at 11+ (inverse of decode above).
+  if (hasStanceSlot(category)) {
+    switch (slotType) {
+      case "normal":
+        return 8 - slotIndex
+      case "stance":
+        return 9
+      case "exilus":
+        return 10
+      case "arcane":
+        return 11 + slotIndex
+      case "aura":
+        throw new Error(`encodeOverframeSlotId: ${category} has no aura slot`)
+    }
+  }
   switch (slotType) {
     case "normal":
       return 8 - slotIndex
@@ -97,5 +131,7 @@ export function encodeOverframeSlotId(
       return warframeLike ? 10 : 9
     case "arcane":
       return warframeLike ? 11 + slotIndex : 10 + slotIndex
+    case "stance":
+      throw new Error(`encodeOverframeSlotId: ${category} has no stance slot`)
   }
 }

--- a/packages/shared/src/warframe/slot-layout.ts
+++ b/packages/shared/src/warframe/slot-layout.ts
@@ -38,3 +38,11 @@ export function hasExilusSlot(category: BrowseCategory): boolean {
 export function isWarframeLike(category: BrowseCategory): boolean {
   return category === "warframes" || category === "necramechs"
 }
+
+/** Categories whose Overframe slot numbering includes a Stance slot at slot_id
+ *  9 — which pushes Exilus to slot_id 10 and Arcanes to 11+. Only melee weapons
+ *  hit this here: beast companion weapons carry a Posture (stance) slot too, but
+ *  they have no Exilus/Arcane slots and are handled by the all-normal path. */
+export function hasStanceSlot(category: BrowseCategory): boolean {
+  return category === "melee"
+}


### PR DESCRIPTION
Follow-up to #216. A pass over Overframe import correctness, driven by real builds (Sarofang Prime, two Valkyr Prime builds, Perigale Prime).

## Polarity codes
- **`4` → zenurik** — was unmapped, so a zenurik-forma'd slot (e.g. Prey of Dynar) imported with no polarity and the forma count came up short.
- **`8` → umbra** — was unmapped, so umbra-forma'd slots (Umbral Vitality/Intensify) imported as a spurious `"universal"` (cleared) forma.

Both confirmed via builds where the mod's own polarity pins the slot (`polarity_match === 2`).

## Melee stance slot
Overframe numbers melee as `slot 9 = stance, 10 = exilus, 11+ = arcane`. The decoder modeled melee like a primary (no stance), so everything after slot 8 shifted by one: the **stance landed in exilus**, the **exilus mod was treated as an arcane** (→ "no arcane match"), and the **arcane went to the wrong index**. Added a stance slot to `decodeOverframeSlotId`/`encodeOverframeSlotId` (round-trip tested) and wired it through the web interpreter.

## Forma: dedup within slot type
`calculateFormaCount` pooled aura + exilus *with* the normal slots, so a forma'd aura could cancel a same-polarity normal forma and undercount. An innate aura polarity can't offset a normal mod (a normal mod can't sit in the aura slot), so aura/exilus/stance are now scored **separately** and only the interchangeable normal slots share a dedup pool. This reproduces Overframe's count exactly on all the sample builds.

- Bumped `FORMA_CALC_VERSION` 1 → 2.
- **Requires a recompute backfill after deploy** (`bun run recompute:forma --apply`) to refresh stored counts on existing builds. Editor live counts and new saves are already correct.
- Dev dry run: **47 / 212 builds corrected, every change upward** (the old calc could only under-count, so nothing regresses).

## Richer import debug payload
The "Copy debug JSON" button now emits a compact, diagnostic object — item innate polarities, computed-vs-Overframe forma, and a **per-slot trace** (where each Overframe slot landed + the matched mod's `type`) — instead of the giant raw dump. A Stance mod in `exilus` or an exilus mod mapped to `arcane` is obvious at a glance; this is what surfaced the bugs above.

## Tests
All suites pass — shared 92, api 43, web 89. Added: codes 4/8, melee layout round-trip, and three `calculateFormaCount` regressions (cross-type no-dedup, within-normal dedup, separate exilus). Typecheck + lint clean.