### PR TITLE
Add changelog entries for data refresh and Overframe import fixes

### DIFF
--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -13,12 +13,41 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-06-07",
+    changes: [
+      {
+        type: "chore",
+        description: "Game data refreshed to the latest Warframe build.",
+      },
+    ],
+  },
+  {
     date: "2026-06-05",
     changes: [
       {
         type: "feat",
         description:
           "Overframe imports now have a paste-and-bookmarklet fallback for builds the server can't fetch directly, so Cloudflare-protected builds still come through.",
+      },
+      {
+        type: "feat",
+        description:
+          "Overframe imports now pull in the build's guide and any YouTube embeds, not just the mods.",
+      },
+      {
+        type: "fix",
+        description:
+          "Forma polarities now import from Overframe correctly across universal/Aya, zenurik, and umbra slots, so the forma count matches the original build.",
+      },
+      {
+        type: "fix",
+        description:
+          "Melee stance, exilus, and arcane mods from Overframe now land in the right slots instead of each shifting down by one.",
+      },
+      {
+        type: "fix",
+        description:
+          "Forma counts no longer come up short when an aura or exilus slot shares a polarity with a regular mod slot.",
       },
     ],
   },


### PR DESCRIPTION
## What & why

Updates the public changelog ([apps/web/src/routes/changelog.tsx](apps/web/src/routes/changelog.tsx)) to cover work that shipped but had not been recorded.

**New 2026-06-07 entry**
- Game data refreshed to the latest Warframe build (#221).

**Backfilled into the 2026-06-05 entry** — the Overframe import fixes from #216 and #217 merged that day but never made it into the changelog:
- Imports now pull in the build guide and any YouTube embeds, not just the mods.
- Forma polarities (universal/Aya, zenurik, umbra) now import correctly, so the forma count matches the original.
- Melee stance, exilus, and arcane mods land in the right slots instead of each shifting down by one.
- Forma counts no longer undercount when an aura or exilus slot shares a polarity with a regular slot.

## Notes for reviewer

- Copy-only change to a typed static array; `bun run typecheck` (web + api + shared + scripts) is clean. No browser verification since the entries are static strings.
- Wording was run through the human-writing pass: dropped stacked em dashes and varied the repeated "Overframe imports now..." openers to match the changelog's existing plain voice.
