### PR TITLE
Fix variant Duplicate losing the duplicated variant

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -334,17 +334,27 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   const setVariants = (
     next: SavedVariant[] | ((prev: SavedVariant[]) => SavedVariant[]),
   ) => {
-    _setVariants((prev) => {
-      const value =
-        typeof next === "function"
-          ? (next as (p: SavedVariant[]) => SavedVariant[])(prev)
-          : next
-      // Preserve `shared` — setVariants only owns the variants array.
-      const sharedSlot =
-        cachedVariants?.key === storeKey ? cachedVariants.shared : undefined
-      cachedVariants = { key: storeKey, data: value, shared: sharedSlot }
-      return value
-    })
+    // Write the module cache SYNCHRONOUSLY rather than inside the React state
+    // updater. A structural mutation (add/duplicate/delete) calls setVariants
+    // and then navigate() + bumpVariantEpoch() in the same tick, which changes
+    // EditorShell's key and unmounts this fiber. React discards a queued
+    // updater on an unmounting fiber, so a cache write performed *inside* the
+    // updater is silently lost and the remount re-reads stale data. Computing
+    // the value here and writing the cache eagerly makes it survive the
+    // remount. Base off the cache (kept in lockstep with `variants`) so
+    // multiple setVariants in one tick — e.g. commitRename() then
+    // duplicateActive() — compose correctly instead of stranding the last one.
+    const base =
+      cachedVariants?.key === storeKey ? cachedVariants.data : variants
+    const value =
+      typeof next === "function"
+        ? (next as (p: SavedVariant[]) => SavedVariant[])(base)
+        : next
+    // Preserve `shared` — setVariants only owns the variants array.
+    const sharedSlot =
+      cachedVariants?.key === storeKey ? cachedVariants.shared : undefined
+    cachedVariants = { key: storeKey, data: value, shared: sharedSlot }
+    _setVariants(value)
   }
   const clampedActiveIndex = Math.min(
     Math.max(0, activeVariantIndex),


### PR DESCRIPTION
## What

Duplicating a build variant via the gear menu silently failed — no copy was created and the user was dumped on an existing (often empty) variant instead of a populated copy.

## Why

The variants list is mirrored in a module-level cache (`cachedVariants`) that survives the deliberate `EditorShell` remount each structural change triggers. That cache was written **inside** the React state updater:

```js
_setVariants((prev) => { …; cachedVariants = {…}; return value })
```

The Duplicate handler runs two mutations in one tick — `commitRename()` then `duplicateActive()` — and `duplicateActive()` ends with `navigate()` + an epoch bump that changes `EditorShell`'s `key` and unmounts the fiber. React **discards a queued updater on an unmounting fiber**, so the duplicate's cache write never ran. The earlier `commitRename` write (the variant list *without* the copy) is what survived, and the remount re-read that stale list and navigated to a now-wrong index. `addVariant` escaped the bug only because it has no preceding `commitRename` to strand its update.

## Fix

`setVariants` now computes the next value and writes `cachedVariants` **synchronously** (basing functional updates off the cache so same-tick mutations compose correctly), then calls `_setVariants(value)`. The cache write no longer depends on a queued updater committing, so it survives the remount.

## Testing

Reproduced and verified in the live editor (place mod → add variant → switch to Main → Duplicate):

- **Before:** lands on an empty existing variant, no copy created.
- **After:** a populated **"Main (copy)"** tab appears and becomes active, with mods/capacity/stats carried over.

`just check` (typecheck + lint + format across all workspaces) passes; no console errors.