### PR TITLE
refactor(ui): group header actions with ButtonGroup and theme picker with ToggleGroup

### DIFF
--- a/apps/web/src/components/build-viewer/viewer-header.tsx
+++ b/apps/web/src/components/build-viewer/viewer-header.tsx
@@ -4,6 +4,7 @@ import { Pencil } from "lucide-react"
 import { EndoFormaBadges } from "@/components/endo-forma-badges"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { ButtonGroup } from "@/components/ui/button-group"
 import {
   Tooltip,
   TooltipContent,
@@ -137,8 +138,10 @@ export function ViewerHeader({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <SocialActions build={build} />
-          <ShareMenu slug={build.slug} />
+          <ButtonGroup>
+            <SocialActions build={build} />
+            <ShareMenu slug={build.slug} />
+          </ButtonGroup>
           {build.isOwner ? (
             <Button
               size="sm"

--- a/apps/web/src/components/create-editor/editor-header.tsx
+++ b/apps/web/src/components/create-editor/editor-header.tsx
@@ -14,6 +14,7 @@ import { type PublishVisibility } from "@/components/build-editor"
 import { EndoFormaBadges } from "@/components/endo-forma-badges"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { ButtonGroup } from "@/components/ui/button-group"
 import { Input } from "@/components/ui/input"
 import { Kbd } from "@/components/ui/kbd"
 import { formatVisibility } from "@/lib/util/user-display"
@@ -169,7 +170,7 @@ export function EditorHeader({
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <div className="flex items-center gap-1">
+          <ButtonGroup>
             <Button
               variant="outline"
               size="icon-sm"
@@ -190,7 +191,7 @@ export function EditorHeader({
             >
               <Redo2 />
             </Button>
-          </div>
+          </ButtonGroup>
           {settings && (
             <Button
               variant="outline"

--- a/apps/web/src/components/settings-dialog/appearance-tab.tsx
+++ b/apps/web/src/components/settings-dialog/appearance-tab.tsx
@@ -1,11 +1,11 @@
 import { useTheme } from "@/components/theme-provider"
-import { Button } from "@/components/ui/button"
 import {
   Field,
   FieldDescription,
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 const THEMES = [
   { value: "light" as const, label: "Light" },
@@ -22,18 +22,24 @@ export function AppearancePanel() {
         <FieldDescription>
           Choose how Arsenyx looks. System follows your OS preference.
         </FieldDescription>
-        <div className="flex gap-2 pt-1">
+        <ToggleGroup
+          value={[theme]}
+          onValueChange={(value) => {
+            const next = value[0]
+            if (next === "light" || next === "dark" || next === "system")
+              setTheme(next)
+          }}
+          variant="outline"
+          size="sm"
+          spacing={0}
+          className="mt-1"
+        >
           {THEMES.map((t) => (
-            <Button
-              key={t.value}
-              variant={theme === t.value ? "default" : "outline"}
-              size="sm"
-              onClick={() => setTheme(t.value)}
-            >
+            <ToggleGroupItem key={t.value} value={t.value}>
               {t.label}
-            </Button>
+            </ToggleGroupItem>
           ))}
-        </div>
+        </ToggleGroup>
       </Field>
     </FieldGroup>
   )

--- a/apps/web/src/components/ui/button-group.tsx
+++ b/apps/web/src/components/ui/button-group.tsx
@@ -1,0 +1,87 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/util/utils"
+import { Separator } from "@/components/ui/separator"
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch *:focus-visible:relative *:focus-visible:z-10 has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-lg [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "*:data-slot:rounded-r-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-lg! [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0",
+        vertical:
+          "flex-col *:data-slot:rounded-b-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-lg! [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+)
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupText({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "flex items-center gap-2 rounded-lg border bg-muted px-2.5 text-sm font-medium [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "button-group-text",
+    },
+  })
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+}


### PR DESCRIPTION
Splits the UI grouping changes that landed on the now-merged `feat/codemirror-guide-editor` branch *after* PR #225 was merged, onto a fresh branch off `main`.

## Changes
- **viewer-header / editor-header** — wrap social/share and undo/redo header actions in `ButtonGroup`
- **appearance-tab** — switch the theme picker to a segmented `ToggleGroup` (outline, `spacing={0}`)
- **button-group.tsx** — new shadcn `ui/` component

`just check` (typecheck + lint + format) passes on top of current `main`.