### PR TITLE
Migrate user DB from Neon to PlanetScale Postgres (via Hyperdrive)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,9 +2,14 @@
 # Drives the dev-only email+password sign-in path.
 NODE_ENV="development"
 
-# Neon "rewrite" branch. Use the UNPOOLED connection string in dev (needed for
-# `prisma db push`). In production we can swap to the pooled (-pooler) URL.
-DATABASE_URL="postgresql://user:password@ep-xxx.eu-central-1.aws.neon.tech/arsenyx?sslmode=require"
+# PlanetScale Postgres DIRECT connection. Used by the Prisma CLI only
+# (db:push / db:studio / db:generate) — the Worker runtime connects via
+# Hyperdrive instead (see below + wrangler.toml). Use an admin/DDL-capable role.
+DATABASE_URL="postgresql://USER:PASS@HOST.pg.psdb.cloud:5432/postgres?sslmode=verify-full&sslrootcert=system"
+
+# Local-dev connection for the Hyperdrive binding. `wrangler dev` reads this so
+# the Worker can reach PlanetScale without --remote. Use the read+write role.
+CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="postgresql://USER:PASS@HOST.pg.psdb.cloud:5432/postgres?sslmode=require"
 
 # Better Auth
 BETTER_AUTH_SECRET="generate with: openssl rand -base64 32"

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — apps/api
 
-Hono on Cloudflare Workers (Bun-compatible for local dev). Better Auth + Prisma 7 (`@prisma/adapter-neon`, `workerd` runtime) + Neon Postgres. Locally on `:8787`, deployed to `api.arsenyx.com`. Serves **user data only** — game data is static JSON under `apps/web/public/data/`.
+Hono on Cloudflare Workers (Bun-compatible for local dev). Better Auth + Prisma 7 (`@prisma/adapter-pg` + `pg`, `workerd` runtime) + PlanetScale Postgres reached through **Cloudflare Hyperdrive** (`env.HYPERDRIVE.connectionString`). Locally on `:8787`, deployed to `api.arsenyx.com`. Serves **user data only** — game data is static JSON under `apps/web/public/data/`.
 
 ## Conventions
 
@@ -16,7 +16,9 @@ Hono on Cloudflare Workers (Bun-compatible for local dev). Better Auth + Prisma 
 - Dev uses `bun run db:push`. Destructive migrations go in [scripts/migrations/](scripts/migrations/) as dated `.sql` files applied manually against Neon via `prisma db execute --file`.
 - Prisma 7 quirk: datasource `url` lives in [prisma.config.ts](prisma.config.ts), not the schema file.
 - Generator output: `src/generated/prisma` (gitignored). Import as `import { Prisma } from "../generated/prisma/client"`.
-- **PrismaClient is request-scoped** via `AsyncLocalStorage` in [src/db.ts](src/db.ts) — Workers reuses isolates across requests and the Neon Pool is request-scoped, so a module-level singleton leaks I/O between requests. Routes keep `import { prisma }` unchanged (Proxy reads the per-request client); the fetch handler in [src/index.ts](src/index.ts) wraps everything in `withPrisma`.
+- **PrismaClient is request-scoped** via `AsyncLocalStorage` in [src/db.ts](src/db.ts) — Workers reuses isolates across requests and the pg Pool is request-scoped, so a module-level singleton leaks I/O between requests. Routes keep `import { prisma }` unchanged (Proxy reads the per-request client); the fetch handler in [src/index.ts](src/index.ts) wraps everything in `withPrisma(env.HYPERDRIVE.connectionString, ctx, …)`. The connection string is a Hyperdrive **runtime binding** (not `process.env`); Hyperdrive owns the upstream pool so a fresh per-request client is cheap.
+- **Two connection paths:** the Worker **runtime** uses the `HYPERDRIVE` binding; the **Prisma CLI** (`db:push`/`db:studio`/`db:generate`, manual `db execute`) uses `DATABASE_URL` (PlanetScale **direct** string) via [prisma.config.ts](prisma.config.ts). Hyperdrive is Workers-only — CLI tools bypass it.
+- **Full-text search lives outside Prisma:** the `searchVector Unsupported("tsvector")` column, its GIN index, and the populating trigger are **not** in the schema or migrations — they exist only in the live DB. Any DB rebuild must come from a `pg_dump` of the live schema, **never `prisma db push`** (which would drop the GIN index + trigger and silently break search).
 
 ## Env
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,18 +14,19 @@
   },
   "dependencies": {
     "@arsenyx/shared": "workspace:*",
-    "@neondatabase/serverless": "^1.1.0",
-    "@prisma/adapter-neon": "7.7.0",
-    "@prisma/client": "7.7.0",
+    "@prisma/adapter-pg": "7.8.0",
+    "@prisma/client": "7.8.0",
     "better-auth": "^1.5.5",
     "hono": "^4.6.14",
-    "nanoid": "^5.1.9"
+    "nanoid": "^5.1.9",
+    "pg": "^8.21.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260420.1",
     "@types/bun": "latest",
+    "@types/pg": "^8.20.0",
     "dotenv": "^16.4.7",
-    "prisma": "7.7.0",
+    "prisma": "7.8.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.5",
     "wrangler": "^4.86.0"

--- a/apps/api/scripts/seed-admin.ts
+++ b/apps/api/scripts/seed-admin.ts
@@ -4,15 +4,14 @@
  * Invoked by scripts/setup.ts at the end of `just setup`. Safe to re-run.
  *
  * Bypasses Prisma entirely because the API's Prisma client is generated with
- * `runtime = "workerd"` and won't load outside wrangler. Talks to Neon via
- * @neondatabase/serverless and hashes the password with Better Auth's own
- * utility so the resulting account is indistinguishable from one created via
- * `/auth/sign-up/email`.
+ * `runtime = "workerd"` and won't load outside wrangler. Talks to Postgres via
+ * `pg` and hashes the password with Better Auth's own utility so the resulting
+ * account is indistinguishable from one created via `/auth/sign-up/email`.
  */
 
-import { neon } from "@neondatabase/serverless"
 import { hashPassword } from "better-auth/crypto"
 import { nanoid } from "nanoid"
+import { Client } from "pg"
 
 // Refuse to run outside local development. A misconfigured NODE_ENV in CI/prod
 // would otherwise create a known-credential admin account.
@@ -30,98 +29,132 @@ const USERNAME = process.env.SEED_ADMIN_USERNAME ?? "admin"
 const PASSWORD_FROM_ENV = process.env.SEED_ADMIN_PASSWORD
 const PASSWORD = PASSWORD_FROM_ENV ?? nanoid(20)
 
-async function main() {
+// Build a pg Client from DATABASE_URL. Strip libpq-only params node's `pg`
+// can't honour: `sslrootcert=system` would make it readFileSync("system") and
+// crash, and `sslnegotiation` is unknown. TLS is verified against Node's
+// built-in CA bundle, which covers PlanetScale's public certificate.
+function makeClient(): Client {
   if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is not set")
-  const sql = neon(process.env.DATABASE_URL)
+  const url = new URL(process.env.DATABASE_URL)
+  const sslmode = url.searchParams.get("sslmode") ?? "require"
+  url.searchParams.delete("sslrootcert")
+  url.searchParams.delete("sslnegotiation")
+  return new Client({
+    connectionString: url.toString(),
+    ssl: sslmode === "disable" ? false : { rejectUnauthorized: true },
+  })
+}
 
-  const passwordHash = await hashPassword(PASSWORD)
+async function main() {
+  const client = makeClient()
+  await client.connect()
 
-  // Match strictly by email. Matching on username too (the previous behaviour)
-  // would clobber a developer's real local user if they happened to pick the
-  // same username — we'd email-migrate them and overwrite their password hash.
-  const existing = (await sql`
-    SELECT id FROM users WHERE email = ${EMAIL} LIMIT 1
-  `) as Array<{ id: string }>
-  if (existing.length > 0) {
-    const row = existing[0]!
-    // Upsert the credential row: an OAuth-only user (no providerId='credential'
-    // row) needs one created; an existing credential row gets its password
-    // rotated so the freshly-printed password actually works.
-    const updated = (await sql`
-      UPDATE accounts
-      SET password = ${passwordHash}, "updatedAt" = NOW()
-      WHERE "userId" = ${row.id} AND "providerId" = 'credential'
-      RETURNING id
+  // Tagged-template helper mirroring @neondatabase/serverless's `sql`: turns
+  // sql`… ${a} … ${b}` into a parameterised query ($1, $2, …) and returns rows.
+  const sql = async (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<unknown[]> => {
+    const text = strings.reduce(
+      (acc, s, i) => acc + s + (i < values.length ? `$${i + 1}` : ""),
+      "",
+    )
+    const { rows } = await client.query(text, values)
+    return rows
+  }
+
+  try {
+    const passwordHash = await hashPassword(PASSWORD)
+
+    // Match strictly by email. Matching on username too (the previous behaviour)
+    // would clobber a developer's real local user if they happened to pick the
+    // same username — we'd email-migrate them and overwrite their password hash.
+    const existing = (await sql`
+      SELECT id FROM users WHERE email = ${EMAIL} LIMIT 1
     `) as Array<{ id: string }>
-    if (updated.length === 0) {
-      await sql`
-        INSERT INTO accounts (
-          id, "userId", "accountId", "providerId", password,
-          "createdAt", "updatedAt"
-        ) VALUES (
-          ${nanoid()}, ${row.id}, ${row.id}, 'credential', ${passwordHash},
-          NOW(), NOW()
-        )
-      `
+    if (existing.length > 0) {
+      const row = existing[0]!
+      // Upsert the credential row: an OAuth-only user (no providerId='credential'
+      // row) needs one created; an existing credential row gets its password
+      // rotated so the freshly-printed password actually works.
+      const updated = (await sql`
+        UPDATE accounts
+        SET password = ${passwordHash}, "updatedAt" = NOW()
+        WHERE "userId" = ${row.id} AND "providerId" = 'credential'
+        RETURNING id
+      `) as Array<{ id: string }>
+      if (updated.length === 0) {
+        await sql`
+          INSERT INTO accounts (
+            id, "userId", "accountId", "providerId", password,
+            "createdAt", "updatedAt"
+          ) VALUES (
+            ${nanoid()}, ${row.id}, ${row.id}, 'credential', ${passwordHash},
+            NOW(), NOW()
+          )
+        `
+        if (!PASSWORD_FROM_ENV) {
+          console.log(`✓ ${EMAIL} credential added → ${PASSWORD}`)
+        } else {
+          console.log(`✓ ${EMAIL} credential added`)
+        }
+        return
+      }
       if (!PASSWORD_FROM_ENV) {
-        console.log(`✓ ${EMAIL} credential added → ${PASSWORD}`)
+        console.log(`✓ ${EMAIL} password rotated → ${PASSWORD}`)
       } else {
-        console.log(`✓ ${EMAIL} credential added`)
+        console.log(`✓ ${EMAIL} password rotated`)
       }
       return
     }
-    if (!PASSWORD_FROM_ENV) {
-      console.log(`✓ ${EMAIL} password rotated → ${PASSWORD}`)
-    } else {
-      console.log(`✓ ${EMAIL} password rotated`)
+
+    // Refuse to clobber another user that already owns the requested username.
+    // (The seed previously took it over; safer to fail loudly.)
+    const usernameClash = (await sql`
+      SELECT id FROM users WHERE username = ${USERNAME} LIMIT 1
+    `) as Array<{ id: string }>
+    if (usernameClash.length > 0) {
+      console.error(
+        `seed-admin: username "${USERNAME}" is already taken by a different user — refusing to overwrite. ` +
+          `Set SEED_ADMIN_USERNAME to a different value or delete the existing row.`,
+      )
+      process.exit(1)
     }
-    return
-  }
 
-  // Refuse to clobber another user that already owns the requested username.
-  // (The seed previously took it over; safer to fail loudly.)
-  const usernameClash = (await sql`
-    SELECT id FROM users WHERE username = ${USERNAME} LIMIT 1
-  `) as Array<{ id: string }>
-  if (usernameClash.length > 0) {
-    console.error(
-      `seed-admin: username "${USERNAME}" is already taken by a different user — refusing to overwrite. ` +
-        `Set SEED_ADMIN_USERNAME to a different value or delete the existing row.`,
-    )
-    process.exit(1)
-  }
+    const userId = nanoid()
+    const accountId = nanoid()
 
-  const userId = nanoid()
-  const accountId = nanoid()
+    await sql`
+      INSERT INTO users (
+        id, name, email, "emailVerified",
+        username, "displayUsername",
+        "isAdmin", "isVerified",
+        "defaultBuildVisibility", "createdAt", "updatedAt"
+      ) VALUES (
+        ${userId}, ${USERNAME}, ${EMAIL}, true,
+        ${USERNAME}, ${USERNAME},
+        true, true,
+        'PUBLIC', NOW(), NOW()
+      )
+    `
 
-  await sql`
-    INSERT INTO users (
-      id, name, email, "emailVerified",
-      username, "displayUsername",
-      "isAdmin", "isVerified",
-      "defaultBuildVisibility", "createdAt", "updatedAt"
-    ) VALUES (
-      ${userId}, ${USERNAME}, ${EMAIL}, true,
-      ${USERNAME}, ${USERNAME},
-      true, true,
-      'PUBLIC', NOW(), NOW()
-    )
-  `
+    await sql`
+      INSERT INTO accounts (
+        id, "userId", "accountId", "providerId", password,
+        "createdAt", "updatedAt"
+      ) VALUES (
+        ${accountId}, ${userId}, ${userId}, 'credential', ${passwordHash},
+        NOW(), NOW()
+      )
+    `
 
-  await sql`
-    INSERT INTO accounts (
-      id, "userId", "accountId", "providerId", password,
-      "createdAt", "updatedAt"
-    ) VALUES (
-      ${accountId}, ${userId}, ${userId}, 'credential', ${passwordHash},
-      NOW(), NOW()
-    )
-  `
-
-  if (!PASSWORD_FROM_ENV) {
-    console.log(`✓ seeded ${EMAIL} / ${PASSWORD} (admin)`)
-  } else {
-    console.log(`✓ seeded ${EMAIL} (admin)`)
+    if (!PASSWORD_FROM_ENV) {
+      console.log(`✓ seeded ${EMAIL} / ${PASSWORD} (admin)`)
+    } else {
+      console.log(`✓ seeded ${EMAIL} (admin)`)
+    }
+  } finally {
+    await client.end()
   }
 }
 

--- a/apps/api/src/bindings.ts
+++ b/apps/api/src/bindings.ts
@@ -14,4 +14,9 @@ export interface Bindings {
   // Configured in wrangler.toml under [[unsafe.bindings]].
   ANON_SEARCH_LIMITER: RateLimitBinding
   ANON_READ_LIMITER: RateLimitBinding
+
+  // Cloudflare Hyperdrive — pools + caches connections to PlanetScale Postgres.
+  // `connectionString` is resolved at runtime (dynamic local port) and fed to
+  // the Prisma pg adapter in db.ts. Configured under [[hyperdrive]].
+  HYPERDRIVE: Hyperdrive
 }

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -1,26 +1,31 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 
-import { PrismaNeon } from "@prisma/adapter-neon"
+import { PrismaPg } from "@prisma/adapter-pg"
 
 import { PrismaClient } from "./generated/prisma/client"
 
-// Workers reuses isolates across requests, and the Neon driver's Pool is
-// request-scoped. A module-level PrismaClient singleton leaks I/O across
-// requests → `Cannot perform I/O on behalf of a different request`. We scope
-// one client per request via AsyncLocalStorage; routes keep using the
-// `prisma` proxy unchanged.
+// Workers reuses isolates across requests, and the pg Pool is request-scoped.
+// A module-level PrismaClient singleton leaks I/O across requests → `Cannot
+// perform I/O on behalf of a different request`. We scope one client per
+// request via AsyncLocalStorage; routes keep using the `prisma` proxy
+// unchanged.
+//
+// The connection string comes from the Hyperdrive binding
+// (`env.HYPERDRIVE.connectionString`), threaded in through `withPrisma`.
+// Unlike the old Neon `DATABASE_URL`, it can't be read from `process.env` —
+// it's a runtime binding with a dynamically-allocated local port. Hyperdrive
+// owns the upstream pool, so spinning up a fresh client per request is cheap.
 
 type RequestScope = {
+  connectionString: string
   client: PrismaClient | null
   pending: Set<Promise<unknown>>
 }
 
 const als = new AsyncLocalStorage<RequestScope>()
 
-function createPrismaClient() {
-  const adapter = new PrismaNeon({
-    connectionString: process.env.DATABASE_URL!,
-  })
+function createPrismaClient(connectionString: string) {
+  const adapter = new PrismaPg({ connectionString })
   return new PrismaClient({
     adapter,
     log:
@@ -42,11 +47,12 @@ function currentScope(): RequestScope {
 
 function currentClient(): PrismaClient {
   const scope = currentScope()
-  if (!scope.client) scope.client = createPrismaClient()
+  if (!scope.client) scope.client = createPrismaClient(scope.connectionString)
   return scope.client
 }
 
 export function withPrisma<T>(
+  connectionString: string,
   ctx: ExecutionContext,
   fn: () => T | Promise<T>,
 ): Promise<T> {
@@ -55,6 +61,7 @@ export function withPrisma<T>(
   // Better Auth's cookieCache (the common /auth/get-session path) never
   // pay the Prisma init cost.
   const scope: RequestScope = {
+    connectionString,
     client: null,
     pending: new Set(),
   }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 
 import { auth } from "./auth"
+import type { Bindings } from "./bindings"
 import { withPrisma } from "./db"
 import { webOrigins } from "./env"
 import { rateLimitAnonRead } from "./middleware/rate-limit"
@@ -81,5 +82,7 @@ app.get("/health", (c) => c.json({ ok: true }))
 export default {
   port: 8787,
   fetch: (req: Request, env: unknown, ctx: ExecutionContext) =>
-    withPrisma(ctx, () => app.fetch(req, env, ctx)),
+    withPrisma((env as Bindings).HYPERDRIVE.connectionString, ctx, () =>
+      app.fetch(req, env, ctx),
+    ),
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -82,7 +82,15 @@ app.get("/health", (c) => c.json({ ok: true }))
 export default {
   port: 8787,
   fetch: (req: Request, env: unknown, ctx: ExecutionContext) =>
-    withPrisma((env as Bindings).HYPERDRIVE.connectionString, ctx, () =>
-      app.fetch(req, env, ctx),
+    // Read the binding defensively: a missing/misapplied HYPERDRIVE binding
+    // yields "" here rather than throwing in the fetch export (which would
+    // escape app.onError and 500 every request, incl. /health and CORS
+    // preflights). With "", only routes that actually touch `prisma.*`
+    // fail — surfaced as a clean JSON 500 via onError — matching the old
+    // lazy process.env.DATABASE_URL behavior.
+    withPrisma(
+      (env as Bindings | undefined)?.HYPERDRIVE?.connectionString ?? "",
+      ctx,
+      () => app.fetch(req, env, ctx),
     ),
 }

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -11,7 +11,9 @@ routes = [
 ]
 
 # Secrets (set via `bunx wrangler secret put <NAME>`):
-#   DATABASE_URL              — Neon production pooled connection string
+#   DATABASE_URL              — PlanetScale *direct* connection string. Used by
+#                               the Prisma CLI (db:push/studio/generate) ONLY.
+#                               The Worker runtime reads HYPERDRIVE instead.
 #   BETTER_AUTH_SECRET        — `openssl rand -base64 32`
 #   GITHUB_CLIENT_ID
 #   GITHUB_CLIENT_SECRET
@@ -40,6 +42,19 @@ name = "ANON_READ_LIMITER"
 type = "ratelimit"
 namespace_id = "1002"
 simple = { limit = 120, period = 60 }
+
+# Cloudflare Hyperdrive → PlanetScale Postgres. The Worker runtime connects via
+# env.HYPERDRIVE.connectionString (see src/db.ts); Hyperdrive owns the upstream
+# pool. Point it at PlanetScale's DIRECT endpoint (let Hyperdrive do pooling).
+#   Create with: bunx wrangler hyperdrive create arsenyx-pg \
+#     --connection-string="postgres://USER:PASS@HOST:5432/postgres?sslmode=require"
+#   then paste the returned id below.
+# TODO(cutover): replace the placeholder id before deploying.
+# localConnectionString lets `wrangler dev` reach a real Postgres without --remote.
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "REPLACE_WITH_HYPERDRIVE_ID"
+localConnectionString = "postgres://USER:PASS@HOST:5432/postgres?sslmode=require"
 
 [observability]
 enabled = true

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -45,16 +45,16 @@ simple = { limit = 120, period = 60 }
 
 # Cloudflare Hyperdrive → PlanetScale Postgres. The Worker runtime connects via
 # env.HYPERDRIVE.connectionString (see src/db.ts); Hyperdrive owns the upstream
-# pool. Point it at PlanetScale's DIRECT endpoint (let Hyperdrive do pooling).
-#   Create with: bunx wrangler hyperdrive create arsenyx-pg \
-#     --connection-string="postgres://USER:PASS@HOST:5432/postgres?sslmode=require"
-#   then paste the returned id below.
-# TODO(cutover): replace the placeholder id before deploying.
-# localConnectionString lets `wrangler dev` reach a real Postgres without --remote.
+# pool, pointed at PlanetScale's direct endpoint. Recreate (e.g. after a role
+# rotation) with:
+#   bunx wrangler hyperdrive update c99d68f482634c9b944449a03bc6b13d \
+#     --connection-string="postgresql://USER:PASS@HOST:5432/postgres?sslmode=verify-full"
 [[hyperdrive]]
 binding = "HYPERDRIVE"
-id = "REPLACE_WITH_HYPERDRIVE_ID"
-localConnectionString = "postgres://USER:PASS@HOST:5432/postgres?sslmode=require"
+id = "c99d68f482634c9b944449a03bc6b13d"
+# Local dev connection is read from a gitignored env var so the credential is
+# never committed: set CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE
+# in apps/api/.env (see .env.example).
 
 [observability]
 enabled = true

--- a/bun.lock
+++ b/bun.lock
@@ -24,18 +24,19 @@
       "name": "arsenyx-api",
       "dependencies": {
         "@arsenyx/shared": "workspace:*",
-        "@neondatabase/serverless": "^1.1.0",
-        "@prisma/adapter-neon": "7.7.0",
-        "@prisma/client": "7.7.0",
+        "@prisma/adapter-pg": "7.8.0",
+        "@prisma/client": "7.8.0",
         "better-auth": "^1.5.5",
         "hono": "^4.6.14",
         "nanoid": "^5.1.9",
+        "pg": "^8.21.0",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260420.1",
         "@types/bun": "latest",
+        "@types/pg": "^8.20.0",
         "dotenv": "^16.4.7",
-        "prisma": "7.7.0",
+        "prisma": "7.8.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.5",
         "wrangler": "^4.86.0",
@@ -444,25 +445,25 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
-    "@prisma/adapter-neon": ["@prisma/adapter-neon@7.7.0", "", { "dependencies": { "@neondatabase/serverless": ">0.6.0 <2", "@prisma/driver-adapter-utils": "7.7.0", "postgres-array": "3.0.4" } }, "sha512-nnQBGUqDBuLDbClSNyZ7T8jv3+wXx9ncA8zaZhVZtP+utq7SdT4azLotTfZjP4hJaP1NXIvCKjp0RfzMq5dyew=="],
+    "@prisma/adapter-pg": ["@prisma/adapter-pg@7.8.0", "", { "dependencies": { "@prisma/driver-adapter-utils": "7.8.0", "@types/pg": "^8.16.0", "pg": "^8.16.3", "postgres-array": "3.0.4" } }, "sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg=="],
 
-    "@prisma/client": ["@prisma/client@7.7.0", "", { "dependencies": { "@prisma/client-runtime-utils": "7.7.0" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-5Ar4OsZpJ54s21sy5oDNNW9gQtd4NuxCaiM7+JDTOU07D6VvlpLjYzAVCMB1+JzokN+08dAVomlx+b7bhJd3ww=="],
+    "@prisma/client": ["@prisma/client@7.8.0", "", { "dependencies": { "@prisma/client-runtime-utils": "7.8.0" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw=="],
 
-    "@prisma/client-runtime-utils": ["@prisma/client-runtime-utils@7.7.0", "", {}, "sha512-BLyd0UpFYOtyJFTHm7jS9vesHW7P83abibodQMiIofqjBKzDHQ1VAsQkdfvXyYDkPlONPfOTz7/rv3x/+CQqvQ=="],
+    "@prisma/client-runtime-utils": ["@prisma/client-runtime-utils@7.8.0", "", {}, "sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw=="],
 
-    "@prisma/config": ["@prisma/config@7.7.0", "", { "dependencies": { "c12": "3.1.0", "deepmerge-ts": "7.1.5", "effect": "3.20.0", "empathic": "2.0.0" } }, "sha512-hmPI3tKLO2aP0Y5vugbjcnA9qqlfJndiT6ds4tw28U5hNHLWg+mHJEWAhjsSPgxjtmxhJ/EDIeIlyh+3Us0OPg=="],
+    "@prisma/config": ["@prisma/config@7.8.0", "", { "dependencies": { "c12": "3.3.4", "deepmerge-ts": "7.1.5", "effect": "3.20.0", "empathic": "2.0.0" } }, "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw=="],
 
-    "@prisma/debug": ["@prisma/debug@7.7.0", "", {}, "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA=="],
+    "@prisma/debug": ["@prisma/debug@7.8.0", "", {}, "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA=="],
 
     "@prisma/dev": ["@prisma/dev@0.24.3", "", { "dependencies": { "@electric-sql/pglite": "0.4.1", "@electric-sql/pglite-socket": "0.1.1", "@electric-sql/pglite-tools": "0.3.1", "@hono/node-server": "1.19.11", "@prisma/get-platform": "7.2.0", "@prisma/query-plan-executor": "7.2.0", "@prisma/streams-local": "0.1.2", "foreground-child": "3.3.1", "get-port-please": "3.2.0", "hono": "^4.12.8", "http-status-codes": "2.3.0", "pathe": "2.0.3", "proper-lockfile": "4.1.2", "remeda": "2.33.4", "std-env": "3.10.0", "valibot": "1.2.0", "zeptomatch": "2.1.0" } }, "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg=="],
 
-    "@prisma/driver-adapter-utils": ["@prisma/driver-adapter-utils@7.7.0", "", { "dependencies": { "@prisma/debug": "7.7.0" } }, "sha512-gZXREeu6mOk7zXfGFJgh86p7Vhj0sXNKp+4Cg1tWYo7V2dfncP2qxS2BiTmbIIha8xPqItkl0WSw38RuSq1HoQ=="],
+    "@prisma/driver-adapter-utils": ["@prisma/driver-adapter-utils@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A=="],
 
-    "@prisma/engines": ["@prisma/engines@7.7.0", "", { "dependencies": { "@prisma/debug": "7.7.0", "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711", "@prisma/fetch-engine": "7.7.0", "@prisma/get-platform": "7.7.0" } }, "sha512-7fmcbT7HHXBq/b+3h/dO1JI3fd8l8q7erf7xP7pRprh58hmSSnG8mg9K3yjW3h9WaHWUwngVFpSxxxivaitQ2w=="],
+    "@prisma/engines": ["@prisma/engines@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0", "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a", "@prisma/fetch-engine": "7.8.0", "@prisma/get-platform": "7.8.0" } }, "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw=="],
 
-    "@prisma/engines-version": ["@prisma/engines-version@7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711", "", {}, "sha512-r51DLcJ8bDRSrBEJF3J4cinoWyGA7rfP2mG6lD90VqIbGNOkbfcLcXalSVjq5Y6brQS3vcjrq4GbyUb1Cb7vkw=="],
+    "@prisma/engines-version": ["@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a", "", {}, "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA=="],
 
-    "@prisma/fetch-engine": ["@prisma/fetch-engine@7.7.0", "", { "dependencies": { "@prisma/debug": "7.7.0", "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711", "@prisma/get-platform": "7.7.0" } }, "sha512-TfyzveBQoK4xALzsTpVhB/0KG1N8zOK0ap+RnBMkzGUu3f98fnQ4QtXa2wlKPhsO2X8a3N5ugFQgcKNoHGmDfw=="],
+    "@prisma/fetch-engine": ["@prisma/fetch-engine@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0", "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a", "@prisma/get-platform": "7.8.0" } }, "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ=="],
 
     "@prisma/get-platform": ["@prisma/get-platform@7.2.0", "", { "dependencies": { "@prisma/debug": "7.2.0" } }, "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA=="],
 
@@ -650,6 +651,8 @@
 
     "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -728,7 +731,7 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
-    "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
+    "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -754,8 +757,6 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
-    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
-
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
@@ -773,8 +774,6 @@
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
-
-    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -924,7 +923,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
+    "giget": ["giget@3.2.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1172,13 +1171,9 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
-
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
-
-    "nypm": ["nypm@0.6.6", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.1.1" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -1206,17 +1201,17 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
-    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+    "pg": ["pg@8.21.0", "", { "dependencies": { "pg-connection-string": "^2.13.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.14.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA=="],
 
-    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
 
-    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+    "pg-connection-string": ["pg-connection-string@2.13.0", "", {}, "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig=="],
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 
-    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
 
     "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
 
@@ -1248,7 +1243,7 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
-    "prisma": ["prisma@7.7.0", "", { "dependencies": { "@prisma/config": "7.7.0", "@prisma/dev": "0.24.3", "@prisma/engines": "7.7.0", "@prisma/studio-core": "0.27.3", "mysql2": "3.15.3", "postgres": "3.4.7" }, "peerDependencies": { "better-sqlite3": ">=9.0.0", "typescript": ">=5.4.0" }, "optionalPeers": ["better-sqlite3", "typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-HlgwRBt1uEFB9LStHL4HLYDvoi4BNu1rYA0hPG0zCAEyK9SaZBqp7E5Rjpc3Qh8Lex/ye/svoHZ0OWoFNhWxuQ=="],
+    "prisma": ["prisma@7.8.0", "", { "dependencies": { "@prisma/config": "7.8.0", "@prisma/dev": "0.24.3", "@prisma/engines": "7.8.0", "@prisma/studio-core": "0.27.3", "mysql2": "3.15.3", "postgres": "3.4.7" }, "peerDependencies": { "better-sqlite3": ">=9.0.0", "typescript": ">=5.4.0" }, "optionalPeers": ["better-sqlite3", "typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw=="],
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
@@ -1264,7 +1259,7 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
-    "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
+    "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
@@ -1516,9 +1511,9 @@
 
     "@prisma/dev/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "@prisma/engines/@prisma/get-platform": ["@prisma/get-platform@7.7.0", "", { "dependencies": { "@prisma/debug": "7.7.0" } }, "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ=="],
+    "@prisma/engines/@prisma/get-platform": ["@prisma/get-platform@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw=="],
 
-    "@prisma/fetch-engine/@prisma/get-platform": ["@prisma/get-platform@7.7.0", "", { "dependencies": { "@prisma/debug": "7.7.0" } }, "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ=="],
+    "@prisma/fetch-engine/@prisma/get-platform": ["@prisma/get-platform@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw=="],
 
     "@prisma/get-platform/@prisma/debug": ["@prisma/debug@7.2.0", "", {}, "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw=="],
 
@@ -1552,7 +1547,9 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "c12/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+    "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "c12/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1562,9 +1559,9 @@
 
     "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
-    "nypm/citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
-
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "pg/pg-protocol": ["pg-protocol@1.14.0", "", {}, "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA=="],
 
     "pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
@@ -1582,7 +1579,7 @@
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "c12/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+    "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 


### PR DESCRIPTION
## What

Move the API's Postgres from **Neon** to **PlanetScale PS-5**, reached through **Cloudflare Hyperdrive**. The Prisma schema, all queries, and Better Auth are unchanged — only the connection layer.

## Why

Neon's free tier (100 CU-hr/mo) was projecting to ~180: the endpoint is effectively always-on because steady traffic keeps tripping its non-configurable 5-min autosuspend, so it bills near its compute floor 24/7. PlanetScale PS-5 is a flat **$5/mo** always-on box — cheaper than Neon's $19 Launch tier, and "no scale-to-zero" is irrelevant since the DB was always-on anyway.

## Changes

- Deps: `@prisma/adapter-neon` + `@neondatabase/serverless` → `@prisma/adapter-pg` + `pg` (Prisma bumped to 7.8.0).
- `src/db.ts`: connection string threaded through `withPrisma` from the Hyperdrive binding (a runtime binding, not `process.env`); request-scoped client lifecycle unchanged.
- `src/index.ts` / `src/bindings.ts`: type and pass `env.HYPERDRIVE.connectionString`, read **defensively** so a missing/misapplied binding can't 500 every request (incl. `/health`).
- `wrangler.toml`: `[[hyperdrive]]` binding.
- `scripts/seed-admin.ts`: ported off the removed Neon driver to `pg`.
- Docs: `apps/api/CLAUDE.md`, `.env.example`.

## Connection model

- Worker **runtime** → `HYPERDRIVE` binding → PlanetScale (no `DATABASE_URL` at runtime).
- Prisma **CLI** (`db:push`/`studio`/`generate`) → `DATABASE_URL` = PlanetScale **direct**.

## Verification

- Data migrated via `pg_dump`/`pg_restore`; row counts match Neon **exactly** (220 builds, 58 users, 156 guides, 119 sessions, …); `searchVector` 220/220 populated + trigger present.
- Local `wrangler dev` smoke test against PlanetScale via Hyperdrive: `/health`, build list (raw SQL), and full-text search (`?q=`) all serve real data.
- typecheck + oxlint + oxfmt + **43/43 api tests** green.

## Cutover notes

- **Merging this = the production cutover.** On merge to `main`, Workers Builds deploys the API with the Hyperdrive binding and prod flips to PlanetScale.
- Keep Neon as a warm fallback for ~a week before decommissioning.
- **Known follow-up:** `searchVector` has no GIN index in prod (search seq-scans — fine at 220 builds, but `_build-list.ts` assumes one exists). Optional perf add.