### PR TITLE
feat(web): Ko-fi donation nudges (footer + post-publish toast)

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -81,6 +81,11 @@ import { myOrgsQuery } from "@/lib/queries/org-query"
 import { padShards, type PlacedShard } from "@/lib/shards"
 import { apiErrorMessage, apiFetch } from "@/lib/util/api-client"
 import { copyToClipboard } from "@/lib/util/clipboard"
+import { EXTERNAL_LINKS } from "@/lib/util/constants"
+import {
+  hasShownDonationNudge,
+  markDonationNudgeShown,
+} from "@/lib/util/donation-nudge"
 import { getCategoryLabel, type BrowseCategory } from "@/lib/warframe"
 
 import { AutoFormaDialog } from "./auto-forma-dialog"
@@ -1019,6 +1024,37 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       cachedVariants = null
       clearEditorDraft(storeKey)
       toast.success(isUpdate ? "Build saved" : "Build published")
+      // Moment-of-value donation ask: only after a *new* build is published
+      // (not on edits), and only ever once per browser — whether the user
+      // tips, dismisses, or ignores it. Kept as a dismissible toast, never a
+      // modal/banner, so it stays gentle.
+      if (!isUpdate && !hasShownDonationNudge()) {
+        markDonationNudgeShown()
+        toast(
+          <div className="flex flex-col gap-2">
+            <div>
+              <p className="font-medium">Thanks for building with Arsenyx</p>
+              <p className="text-muted-foreground text-sm">
+                It&apos;s free and runs on ~$5/mo of server costs. If it&apos;s
+                useful to you, a small tip keeps it online.
+              </p>
+            </div>
+            <div className="flex gap-4 text-sm">
+              <a
+                href={EXTERNAL_LINKS.koFi}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2"
+              >
+                Support on Ko-fi
+              </a>
+            </div>
+          </div>,
+          // Explicit close button — dismissal shouldn't rely on the user
+          // knowing they can swipe a toast away.
+          { duration: 12000, closeButton: true },
+        )
+      }
       navigate({ to: "/builds/$slug", params: { slug } })
     } catch (err) {
       // Re-enable the Save button and surface the failure as a toast with a

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/components/link"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { Separator } from "@/components/ui/separator"
 import type { NavLink } from "@/lib/types"
-import { SITE_CONFIG, FOOTER_LINKS } from "@/lib/util/constants"
+import { SITE_CONFIG, FOOTER_LINKS, EXTERNAL_LINKS } from "@/lib/util/constants"
 
 function FooterLink({ label, href, external }: NavLink) {
   return (
@@ -65,6 +65,20 @@ export function Footer() {
         </div>
 
         <Separator className="my-8" />
+
+        <p className="text-muted-foreground mb-6 text-center text-sm">
+          Arsenyx is free and runs on ~$5/mo of server costs. If it&apos;s
+          useful to you, a small tip keeps it online —{" "}
+          <a
+            href={EXTERNAL_LINKS.koFi}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground/80 hover:text-foreground font-medium underline underline-offset-2"
+          >
+            Ko-fi
+          </a>
+          .
+        </p>
 
         <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <p className="text-muted-foreground text-sm">

--- a/apps/web/src/lib/util/constants.ts
+++ b/apps/web/src/lib/util/constants.ts
@@ -39,6 +39,8 @@ export const EXTERNAL_LINKS = {
   github: "https://github.com/Reuzehagel/arsenyx",
   wiki: "https://wiki.warframe.com",
   apiBase: "https://api.arsenyx.com",
+  // Donation destination surfaced by the footer + post-publish nudge.
+  koFi: "https://ko-fi.com/reuzehagel",
 } as const
 
 // Navigation items for header

--- a/apps/web/src/lib/util/donation-nudge.ts
+++ b/apps/web/src/lib/util/donation-nudge.ts
@@ -1,0 +1,24 @@
+// One-time, per-browser gate for the post-publish donation nudge.
+//
+// The ask should fire at most once per user — whether they tip, dismiss, or
+// ignore it. We persist a single flag in localStorage; if storage is
+// unavailable (private mode, blocked) we treat the nudge as already shown so
+// we never nag in a context where we can't remember having asked.
+
+const STORAGE_KEY = "arsenyx:donation-nudge-shown"
+
+export function hasShownDonationNudge(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1"
+  } catch {
+    return true
+  }
+}
+
+export function markDonationNudgeShown(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, "1")
+  } catch {
+    // Best-effort: if we can't persist, the nudge simply won't repeat-suppress.
+  }
+}


### PR DESCRIPTION
Adds two gentle, Ko-fi-only donation nudges. Both are SPA-only and never mount in the embed graph (`embed-main.tsx`), keeping them off iframes on dev.profit-taker.com.

## What's added

- **Footer support line** — passive, always-on. One honest line above the copyright: *"Arsenyx is free and runs on ~$5/mo of server costs. If it's useful to you, a small tip keeps it online — Ko-fi."*
- **Post-publish toast** — the moment-of-value ask. A dismissible `sonner` toast fires right after a **new** build is published (not on edits), with a visible close button. Shown **once per browser** via a `localStorage` flag (`arsenyx:donation-nudge-shown`); storage-blocked contexts are treated as already-shown so it never nags where it can't remember asking.

No modals, no interstitials, no re-surfacing, no fake urgency.

## Files

- `lib/util/constants.ts` — `EXTERNAL_LINKS.koFi`
- `components/footer.tsx` — support line
- `lib/util/donation-nudge.ts` (new) — once-per-user gate
- `components/build-editor/editor-shell.tsx` — post-publish toast

## Verified

Typecheck + oxlint + oxfmt clean. Footer + toast previewed locally (toast fired through the live `sonner` instance, no DB writes).
