### PR TITLE
Set-bonus display on mod cards (#72) + catalog validation gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Game data (items, mods, arcanes) is static JSON precomputed at build time and se
 ## Deployment
 
 - Web (Vite SPA) → Cloudflare Workers (Static Assets), `www.arsenyx.com` + `arsenyx.com`. SPA fallback + cache headers via [apps/web/wrangler.toml](apps/web/wrangler.toml) and [apps/web/public/\_headers](apps/web/public/_headers).
-- API (Hono on Workers) → `api.arsenyx.com`, Prisma 7 + `@prisma/adapter-neon` (workerd runtime)
-- DB → Neon Postgres, EU (`eu-central-1`)
+- API (Hono on Workers) → `api.arsenyx.com`, Prisma 7 + `@prisma/adapter-pg` (workerd runtime)
+- DB → PlanetScale Postgres, reached through Cloudflare Hyperdrive (see [apps/api/CLAUDE.md](apps/api/CLAUDE.md))
 - CI deploys both Workers on push to `main` via Workers Builds (configured in the CF dashboard). Secrets live in the CF dashboard, not in `.env`.
 
 ## Monorepo

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -13,7 +13,7 @@ Hono on Cloudflare Workers (Bun-compatible for local dev). Better Auth + Prisma 
 ## Prisma
 
 - Schema: [prisma/schema.prisma](prisma/schema.prisma) (single file). Generator has `runtime = "workerd"` — emits the `wasm-compiler-edge` runtime so the bundle works on Workers (no `fileURLToPath`, no `node:fs` at init).
-- Dev uses `bun run db:push`. Destructive migrations go in [scripts/migrations/](scripts/migrations/) as dated `.sql` files applied manually against Neon via `prisma db execute --file`.
+- Dev uses `bun run db:push`. Destructive migrations go in [scripts/migrations/](scripts/migrations/) as dated `.sql` files applied manually against PlanetScale via `prisma db execute --file`.
 - Prisma 7 quirk: datasource `url` lives in [prisma.config.ts](prisma.config.ts), not the schema file.
 - Generator output: `src/generated/prisma` (gitignored). Import as `import { Prisma } from "../generated/prisma/client"`.
 - **PrismaClient is request-scoped** via `AsyncLocalStorage` in [src/db.ts](src/db.ts) — Workers reuses isolates across requests and the pg Pool is request-scoped, so a module-level singleton leaks I/O between requests. Routes keep `import { prisma }` unchanged (Proxy reads the per-request client); the fetch handler in [src/index.ts](src/index.ts) wraps everything in `withPrisma(env.HYPERDRIVE.connectionString, ctx, …)`. The connection string is a Hyperdrive **runtime binding** (not `process.env`); Hyperdrive owns the upstream pool so a fresh per-request client is cheap.

--- a/apps/web/src/components/build-editor/mod-card.tsx
+++ b/apps/web/src/components/build-editor/mod-card.tsx
@@ -304,11 +304,12 @@ function ExpandedModCard({
   // Set bonus (DE ExportModSet, one tier per equipped set member — tier
   // count == set size for every set). With n set mods equipped show the
   // active tier; with none (mod picker, browse) preview the max tier.
+  // modSetStats is ordered ascending (tier 1 = one member … tier N = full set).
+  // With n members equipped show tier n (capped at the set size); with none
+  // equipped — the picker/browse preview — show the full-set max tier.
   const setSize = mod.modSetStats?.length ?? 0
-  const setBonus =
-    setSize > 0
-      ? mod.modSetStats?.[Math.min(Math.max(setCount, 1), setSize) - 1]
-      : undefined
+  const setTier = setCount > 0 ? Math.min(setCount, setSize) : setSize
+  const setBonus = setSize > 0 ? mod.modSetStats?.[setTier - 1] : undefined
   const maxRank = modMaxRank(mod)
   const drain = drainOverride ?? baseDrainForMod(mod, rank)
   const compatLabel =

--- a/apps/web/src/components/build-editor/mod-card.tsx
+++ b/apps/web/src/components/build-editor/mod-card.tsx
@@ -301,6 +301,14 @@ function ExpandedModCard({
   vtPrefix,
 }: ExpandedProps) {
   const stats = getModStats(mod, rank, setCount)
+  // Set bonus (DE ExportModSet, one tier per equipped set member — tier
+  // count == set size for every set). With n set mods equipped show the
+  // active tier; with none (mod picker, browse) preview the max tier.
+  const setSize = mod.modSetStats?.length ?? 0
+  const setBonus =
+    setSize > 0
+      ? mod.modSetStats?.[Math.min(Math.max(setCount, 1), setSize) - 1]
+      : undefined
   const maxRank = modMaxRank(mod)
   const drain = drainOverride ?? baseDrainForMod(mod, rank)
   const compatLabel =
@@ -376,6 +384,23 @@ function ExpandedModCard({
                   </Fragment>
                 ))}
               </span>
+            </div>
+          )}
+
+          {setBonus && (
+            <div className="mt-1 w-full px-1 text-center">
+              <span
+                className="text-[10px] font-medium tracking-wide text-gray-400 uppercase"
+                style={{ fontFamily: "Roboto, sans-serif" }}
+              >
+                Set Bonus{setCount > 0 ? ` (${setCount}/${setSize})` : ""}
+              </span>
+              <div
+                className="text-[11px] leading-snug font-normal text-gray-300"
+                style={{ fontFamily: "Roboto, sans-serif" }}
+              >
+                <StatText text={setBonus} />
+              </div>
             </div>
           )}
 

--- a/apps/web/src/components/build-editor/mod-grid.tsx
+++ b/apps/web/src/components/build-editor/mod-grid.tsx
@@ -91,6 +91,14 @@ export function ModGrid({
   // calculateCapacity, not from `slots.placed`.
   const lockedStance = getLockedStance(item, category)
 
+  // Equipped count per mod set (modSet path → n). Drives the set-bonus tier
+  // and Umbral scaling on each placed set mod's expanded card.
+  const setCounts = new Map<string, number>()
+  for (const placed of Object.values(slots.placed)) {
+    const set = placed?.mod.modSet
+    if (set) setCounts.set(set, (setCounts.get(set) ?? 0) + 1)
+  }
+
   const slotProps = (
     id: SlotId,
     innate?: Polarity,
@@ -104,6 +112,9 @@ export function ModGrid({
       formaPolarity: forma,
       mod: placed?.mod,
       rank: placed?.rank,
+      setCount: placed?.mod.modSet
+        ? (setCounts.get(placed.mod.modSet) ?? 0)
+        : 0,
       selected: slots.selected === id,
       onClick: () => slots.select(id),
       onRemove: placed ? () => slots.remove(id) : undefined,

--- a/apps/web/src/components/build-editor/mod-slot.tsx
+++ b/apps/web/src/components/build-editor/mod-slot.tsx
@@ -58,6 +58,9 @@ interface ModSlotProps {
   formaPolarity?: Polarity
   mod?: Mod
   rank?: number
+  /** Equipped mods from this mod's set (this one included). Drives the
+   * active set-bonus tier + Umbral scaling on the expanded card. */
+  setCount?: number
   /** Whether this slot is the current placement target. */
   selected?: boolean
   /** LClick: toggle select / open picker (fires for both empty and filled). */
@@ -91,6 +94,7 @@ export function ModSlot({
   formaPolarity,
   mod,
   rank = 0,
+  setCount = 0,
   selected,
   onClick,
   onRemove,
@@ -339,6 +343,7 @@ export function ModSlot({
                 <ModCard
                   mod={mod}
                   rank={rank}
+                  setCount={setCount}
                   disableHover={popoverOpen || detailOpen || isAnyDragging}
                   drainOverride={cardDrain}
                   matchState={cardMatch}
@@ -431,6 +436,7 @@ export function ModSlot({
             <ModCard
               mod={mod}
               rank={rank}
+              setCount={setCount}
               alwaysExpanded
               drainOverride={cardDrain}
               matchState={cardMatch}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,7 +27,7 @@ Oxlint / oxfmt config lives at the repo root (`.oxlintrc.json`, `.oxfmtrc.json`)
 
 ## Database (apps/api)
 
-Postgres is on Neon — no local Postgres process. Connection string lives in `apps/api/.env`.
+Postgres is on PlanetScale (via Cloudflare Hyperdrive at runtime) — no local Postgres process. The Prisma CLI uses the direct `DATABASE_URL` in `apps/api/.env`.
 
 ```bash
 bun --cwd apps/api run db:push     # dev: push schema without migrations

--- a/scripts/build-items-index.ts
+++ b/scripts/build-items-index.ts
@@ -76,6 +76,7 @@ import {
 import { readPePlusUpgrades, readPePlusWeaponTags } from "./build/read-pe-plus"
 import { readWikiModule } from "./build/read-wiki"
 import { resolveImages } from "./build/resolve-images"
+import { validateOutputs } from "./build/validate-output"
 import { writeItemDetails } from "./build/write-details"
 
 const REPO_ROOT = resolve(import.meta.dirname, "..")
@@ -459,6 +460,28 @@ async function main() {
     wikiModUniqueNameByName,
   )
 
+  // ---------- 8c. Validate before touching the output dir ----------
+  // Shape-check every emitted record and compare counts against the previous
+  // build's meta.json (see validate-output.ts). Throws before the rm below,
+  // so a broken merge can't replace a good catalog with a hollowed-out one.
+  const prevMeta = await Bun.file(resolve(OUT_DIR, "meta.json"))
+    .json()
+    .catch(() => undefined)
+  const nextCounts = {
+    itemCount: Object.values(stats.perCategory).reduce((a, b) => a + b, 0),
+    modCount: mergedMods.length,
+    arcaneCount: arcanesWithImages.length,
+    perCategory: stats.perCategory,
+  }
+  validateOutputs({
+    byCategory: byCategory as Record<string, Array<Record<string, unknown>>>,
+    mods: mergedMods as unknown as Array<Record<string, unknown>>,
+    arcanes: arcanesWithImages as unknown as Array<Record<string, unknown>>,
+    prevMeta,
+    nextCounts,
+  })
+  console.log("  OK  validation (shape + count regression vs previous build)")
+
   // ---------- 9. Write outputs ----------
   await rm(OUT_DIR, { recursive: true, force: true })
   await mkdir(OUT_DIR, { recursive: true })
@@ -665,8 +688,10 @@ async function main() {
         generatedAt: new Date().toISOString(),
         source: "DE PublicExport + wiki Lua (v2 pipeline)",
         pipelineVersion: 2,
-        itemCount: Object.values(stats.perCategory).reduce((a, b) => a + b, 0),
-        modCount: mergedMods.length,
+        itemCount: nextCounts.itemCount,
+        modCount: nextCounts.modCount,
+        arcaneCount: nextCounts.arcaneCount,
+        perCategory: nextCounts.perCategory,
         unmatchedWeapons: stats.weapons.unmatched,
         unmatchedFrames: frameUnmatched.size,
       },

--- a/scripts/build/validate-output.test.ts
+++ b/scripts/build/validate-output.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  type ValidationIssue,
+  validateArcanes,
+  validateBrowseItems,
+  validateCounts,
+  validateMods,
+} from "./validate-output"
+
+const goodMod = {
+  uniqueName: "/Lotus/Upgrades/Mods/Warframe/AvatarHealthMaxMod",
+  name: "Vitality",
+  polarity: "vazarin",
+  rarity: "Common",
+  baseDrain: 2,
+  fusionLimit: 10,
+  levelStats: [{ stats: ["+40% Health"] }],
+}
+
+function run(fn: (issues: ValidationIssue[]) => void): ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+  fn(issues)
+  return issues
+}
+
+describe("validateMods", () => {
+  it("passes a well-formed mod", () => {
+    expect(run((i) => validateMods([goodMod], i))).toEqual([])
+  })
+
+  it("flags missing core fields and non-numeric drain", () => {
+    const issues = run((i) =>
+      validateMods([{ ...goodMod, polarity: "", baseDrain: undefined }], i),
+    )
+    expect(issues.map((x) => x.msg)).toEqual([
+      "missing/empty polarity",
+      "baseDrain is not a number",
+    ])
+  })
+
+  it("flags duplicate uniqueNames", () => {
+    const issues = run((i) => validateMods([goodMod, { ...goodMod }], i))
+    expect(issues.map((x) => x.msg)).toEqual(["duplicate uniqueName"])
+  })
+
+  it("flags malformed levelStats tiers", () => {
+    const issues = run((i) =>
+      validateMods([{ ...goodMod, levelStats: [{ stats: [42] }] }], i),
+    )
+    expect(issues.map((x) => x.msg)).toEqual([
+      "levelStats tier without stats[]",
+    ])
+  })
+
+  it("flags modSetStats without modSet (and vice versa)", () => {
+    const issues = run((i) =>
+      validateMods([{ ...goodMod, modSetStats: ["bonus"] }], i),
+    )
+    expect(issues.map((x) => x.msg)).toEqual([
+      "modSet/modSetStats present without the other",
+    ])
+  })
+})
+
+describe("validateBrowseItems", () => {
+  it("flags empty fields and duplicate slugs within a category", () => {
+    const item = { uniqueName: "/Lotus/X", name: "X", slug: "x" }
+    const issues = run((i) =>
+      validateBrowseItems(
+        { warframes: [item, { ...item }, { ...item, slug: "", name: "" }] },
+        i,
+      ),
+    )
+    expect(issues.map((x) => x.msg)).toEqual([
+      "duplicate slug in warframes",
+      "missing/empty name",
+      "missing/empty slug",
+    ])
+  })
+})
+
+describe("validateArcanes", () => {
+  it("flags missing names", () => {
+    const issues = run((i) =>
+      validateArcanes([{ uniqueName: "/Lotus/A", name: "" }], i),
+    )
+    expect(issues.map((x) => x.msg)).toEqual(["missing/empty name"])
+  })
+})
+
+describe("validateCounts", () => {
+  const next = {
+    itemCount: 900,
+    modCount: 1400,
+    arcaneCount: 130,
+    perCategory: { warframes: 60, primary: 200 },
+  }
+
+  it("passes with no previous meta (first run)", () => {
+    expect(run((i) => validateCounts(undefined, next, i))).toEqual([])
+  })
+
+  it("tolerates small drops (vaulting / dedup fixes)", () => {
+    const prev = { ...next, modCount: 1404, perCategory: { warframes: 61 } }
+    expect(run((i) => validateCounts(prev, next, i))).toEqual([])
+  })
+
+  it("fails on a large drop in a total", () => {
+    const prev = { ...next, modCount: 1595 }
+    const issues = run((i) => validateCounts(prev, next, i))
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.msg).toContain("modCount dropped 1595 → 1400")
+  })
+
+  it("fails on a large per-category drop, including a vanished category", () => {
+    const prev = {
+      ...next,
+      perCategory: { warframes: 60, primary: 200, melee: 250 },
+    }
+    const issues = run((i) => validateCounts(prev, next, i))
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.msg).toContain("perCategory.melee dropped 250 → 0")
+  })
+})

--- a/scripts/build/validate-output.ts
+++ b/scripts/build/validate-output.ts
@@ -1,0 +1,193 @@
+/**
+ * Build-output gate — runs after every merge phase and BEFORE the write
+ * phase wipes apps/web/public/data/, so a failing build leaves the last
+ * good catalog on disk untouched.
+ *
+ * Two layers:
+ *
+ *   1. **Shape validation** — every emitted record gets a cheap structural
+ *      check against the fields the web app dereferences without guards
+ *      (the loaders are typed but do no runtime validation, so a drifted
+ *      upstream field would otherwise surface as a component-level
+ *      TypeError in production).
+ *
+ *   2. **Count regression** — compares item/mod/arcane totals (and
+ *      per-category counts) against the previous build's meta.json. Game
+ *      data only ever grows or shrinks by a handful of entries per update;
+ *      a large drop means an upstream schema change or a broken merge
+ *      silently discarding records, not a real removal. Override with
+ *      ARSENYX_ALLOW_SHRINK=1 when a big drop is intentional.
+ */
+
+/** A drop is a regression when it exceeds BOTH bounds — small absolute
+ *  removals (vaulting, dedup fixes) and tiny relative wobble stay legal. */
+const MAX_DROP_FRACTION = 0.02
+const MAX_DROP_ABSOLUTE = 5
+
+export interface ValidationIssue {
+  where: string
+  msg: string
+}
+
+interface CountedMeta {
+  itemCount?: number
+  modCount?: number
+  arcaneCount?: number
+  perCategory?: Record<string, number>
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0
+}
+
+/** Fields the browse pages dereference unguarded on every BrowseItem. */
+export function validateBrowseItems(
+  byCategory: Record<string, Array<Record<string, unknown>>>,
+  issues: ValidationIssue[],
+): void {
+  for (const [cat, items] of Object.entries(byCategory)) {
+    const seenSlugs = new Set<string>()
+    for (const it of items) {
+      const where = `items-index.json ${cat}/${String(it["slug"] ?? it["name"] ?? "?")}`
+      for (const field of ["uniqueName", "name", "slug"]) {
+        if (!isNonEmptyString(it[field])) {
+          issues.push({ where, msg: `missing/empty ${field}` })
+        }
+      }
+      const slug = it["slug"]
+      if (isNonEmptyString(slug)) {
+        if (seenSlugs.has(slug)) {
+          issues.push({ where, msg: `duplicate slug in ${cat}` })
+        }
+        seenSlugs.add(slug)
+      }
+    }
+  }
+}
+
+/** Fields the mod picker / cards / conflict graph dereference unguarded. */
+export function validateMods(
+  mods: Array<Record<string, unknown>>,
+  issues: ValidationIssue[],
+): void {
+  const seen = new Set<string>()
+  for (const m of mods) {
+    const where = `mods-all.json ${String(m["name"] ?? m["uniqueName"] ?? "?")}`
+    for (const field of ["uniqueName", "name", "polarity", "rarity"]) {
+      if (!isNonEmptyString(m[field])) {
+        issues.push({ where, msg: `missing/empty ${field}` })
+      }
+    }
+    for (const field of ["baseDrain", "fusionLimit"]) {
+      if (typeof m[field] !== "number" || Number.isNaN(m[field])) {
+        issues.push({ where, msg: `${field} is not a number` })
+      }
+    }
+    const uniqueName = m["uniqueName"]
+    if (isNonEmptyString(uniqueName)) {
+      if (seen.has(uniqueName)) {
+        issues.push({ where, msg: "duplicate uniqueName" })
+      }
+      seen.add(uniqueName)
+    }
+    const levelStats = m["levelStats"]
+    if (levelStats !== undefined) {
+      if (!Array.isArray(levelStats)) {
+        issues.push({ where, msg: "levelStats is not an array" })
+      } else {
+        for (const tier of levelStats) {
+          const stats = (tier as Record<string, unknown>)?.["stats"]
+          if (
+            !Array.isArray(stats) ||
+            stats.some((s) => typeof s !== "string")
+          ) {
+            issues.push({ where, msg: "levelStats tier without stats[]" })
+            break
+          }
+        }
+      }
+    }
+    // The set-bonus card renders modSetStats[n-1] keyed off modSet — one
+    // without the other means the ExportModSet join drifted.
+    if ((m["modSetStats"] !== undefined) !== (m["modSet"] !== undefined)) {
+      issues.push({ where, msg: "modSet/modSetStats present without the other" })
+    }
+  }
+}
+
+export function validateArcanes(
+  arcanes: Array<Record<string, unknown>>,
+  issues: ValidationIssue[],
+): void {
+  for (const a of arcanes) {
+    const where = `arcanes-all.json ${String(a["name"] ?? a["uniqueName"] ?? "?")}`
+    for (const field of ["uniqueName", "name"]) {
+      if (!isNonEmptyString(a[field])) {
+        issues.push({ where, msg: `missing/empty ${field}` })
+      }
+    }
+  }
+}
+
+function checkDrop(
+  label: string,
+  prev: number | undefined,
+  next: number,
+  issues: ValidationIssue[],
+): void {
+  if (prev === undefined || prev <= 0) return
+  const drop = prev - next
+  if (drop > MAX_DROP_ABSOLUTE && drop / prev > MAX_DROP_FRACTION) {
+    issues.push({
+      where: "meta.json",
+      msg: `${label} dropped ${prev} → ${next} (−${drop}); a real game update removes a handful of entries, not this many — likely upstream drift or a broken merge. Set ARSENYX_ALLOW_SHRINK=1 if intentional.`,
+    })
+  }
+}
+
+/** Compare this build's counts against the previous build's meta.json
+ *  (absent fields — first run after this gate landed — are skipped). */
+export function validateCounts(
+  prevMeta: CountedMeta | undefined,
+  next: Required<CountedMeta>,
+  issues: ValidationIssue[],
+): void {
+  if (!prevMeta) return
+  checkDrop("itemCount", prevMeta.itemCount, next.itemCount, issues)
+  checkDrop("modCount", prevMeta.modCount, next.modCount, issues)
+  checkDrop("arcaneCount", prevMeta.arcaneCount, next.arcaneCount, issues)
+  for (const [cat, prevCount] of Object.entries(prevMeta.perCategory ?? {})) {
+    checkDrop(
+      `perCategory.${cat}`,
+      prevCount,
+      next.perCategory[cat] ?? 0,
+      issues,
+    )
+  }
+}
+
+export function validateOutputs(opts: {
+  byCategory: Record<string, Array<Record<string, unknown>>>
+  mods: Array<Record<string, unknown>>
+  arcanes: Array<Record<string, unknown>>
+  prevMeta: CountedMeta | undefined
+  nextCounts: Required<CountedMeta>
+}): void {
+  const issues: ValidationIssue[] = []
+  validateBrowseItems(opts.byCategory, issues)
+  validateMods(opts.mods, issues)
+  validateArcanes(opts.arcanes, issues)
+  if (process.env["ARSENYX_ALLOW_SHRINK"] !== "1") {
+    validateCounts(opts.prevMeta, opts.nextCounts, issues)
+  }
+  if (issues.length > 0) {
+    const list = issues
+      .slice(0, 50)
+      .map((i) => `  - [${i.where}] ${i.msg}`)
+      .join("\n")
+    const more = issues.length > 50 ? `\n  … and ${issues.length - 50} more` : ""
+    throw new Error(
+      `Catalog validation failed (${issues.length} issue${issues.length === 1 ? "" : "s"}) — nothing was written, the previous catalog is untouched:\n${list}${more}`,
+    )
+  }
+}

--- a/scripts/sync-images.ts
+++ b/scripts/sync-images.ts
@@ -178,8 +178,19 @@ function contentTypeForKey(key: string): string {
  *  the edge to HIT for all types; this header makes browsers cache long too. */
 const CACHE_CONTROL = "public, max-age=31536000, immutable"
 
+// Upstream fetches go through fetchRetry (per-attempt timeout + backoff), but
+// the R2 S3 calls below were bare `aws.fetch` — behind the same kind of
+// Cloudflare edge where a half-open connection can stall forever with no
+// feedback. Same fix as scripts/build/http.ts: abort per attempt. 60s covers
+// the PUTs (multi-MB bodies on a slow uplink), which is generous for
+// HEAD/CopyObject too.
+const R2_TIMEOUT_MS = 60_000
+
 async function existsInBucket(key: string): Promise<boolean> {
-  const res = await aws.fetch(objectUrl(key), { method: "HEAD" })
+  const res = await aws.fetch(objectUrl(key), {
+    method: "HEAD",
+    signal: AbortSignal.timeout(R2_TIMEOUT_MS),
+  })
   if (res.status === 200) return true
   if (res.status === 404) return false
   throw new Error(`HEAD ${key} → HTTP ${res.status}`)
@@ -191,6 +202,7 @@ async function existsInBucket(key: string): Promise<boolean> {
 async function refreshMetadata(key: string): Promise<void> {
   const res = await aws.fetch(objectUrl(key), {
     method: "PUT",
+    signal: AbortSignal.timeout(R2_TIMEOUT_MS),
     headers: {
       "x-amz-copy-source": `/${BUCKET}/${encodeURI(key)}`,
       "x-amz-metadata-directive": "REPLACE",
@@ -224,6 +236,7 @@ async function ensureUploaded(url: string, key: string): Promise<UploadResult> {
   const put = await aws.fetch(objectUrl(key), {
     method: "PUT",
     body,
+    signal: AbortSignal.timeout(R2_TIMEOUT_MS),
     headers: {
       // Set Content-Type from our key's extension, not the upstream
       // response — see MIME_BY_EXT comment above. Content-Disposition:


### PR DESCRIPTION
## What

Two related pieces from a data-pipeline maintainability pass, plus a small docs/reliability cleanup.

### Set bonus on mod cards (closes #72)
The pipeline already merged DE's `ExportModSet` — `mods-all.json` has carried `modSet` + `modSetStats` on all 72 set mods for a while, so the issue's data-pipeline step was already done. What was missing was rendering:

- The expanded mod card now shows a **Set Bonus** block: the active tier with `(n/size)` when set members are equipped, or the full-set max tier as a preview when browsing/picking. (Verified against the data: tier count == set size for all 19 sets.)
- `ModGrid` counts equipped set members from build state and threads `setCount` through `ModSlot` into both the hover card and the pinned view-mode detail card — editor, viewer, and embed all get it.
- Side effect: the Umbral stat-scaling in `getModStats` existed but was dead code (no caller ever passed `setCount`). It's now live, so 2–3 equipped Umbral mods scale their displayed stats like in-game. (Multipliers confirmed against the wiki: Intensify 25%/75%, Vitality+Fiber 30%/80%.)

Not in scope: folding set bonuses into the stats-panel calculations (they're freeform text, not structured stats — separate issue-worthy design).

### Catalog validation gate (`scripts/build/validate-output.ts`)
Runs after all merge phases and **before** the build wipes `apps/web/public/data/`, so a failing build leaves the previous catalog untouched:

- Shape-checks every emitted browse item / mod / arcane against the fields the web loaders dereference unguarded (the loaders are typed but do no runtime validation — upstream drift previously surfaced as production TypeErrors).
- Fails on count drops >2% and >5 absolute vs the previous build's `meta.json` — the signature of DE/wiki schema drift or a broken merge, not a real game update. `ARSENYX_ALLOW_SHRINK=1` bypasses for intentional removals.
- `meta.json` now records `arcaneCount` + `perCategory` to feed the comparison.

### Docs + R2 reliability (commit `f17c2eaa`)
Bundled here since it came out of the same pass — not on `main`:
- Fixed stale Neon references in `CLAUDE.md` / `docs/commands.md` / `apps/api/CLAUDE.md` left over from the PlanetScale+Hyperdrive migration (#229).
- Added a 60s `AbortSignal.timeout` to the three R2 `aws.fetch` S3 calls in `sync-images.ts` — they were the pipeline's last bare network calls that could hang forever.

## Verification
- `bun run typecheck` + `just check` green
- 11 new unit tests (`validate-output.test.ts`) pass
- Full pipeline run against a fresh `data:sync`: 894 items, 1398 mods, 0 unmatched, gate green (catalog churn not committed — code-only PR)
- Set-bonus card verified in the browser: equipped path shows the partial tier (4 Augur mods → `(4/6)` 160%), picker preview shows the full-set max tier (240%) — see fix `c0ef9ab1` below

## Review fix (`c0ef9ab1`)
Addressed the one correctness bug from review: the unequipped preview clamped `setCount` up to 1, so a set mod in the picker showed tier 1 (weakest) instead of the promised max tier. Now previews the full-set tier. Umbral multipliers were checked against the wiki and are correct as-is.