### PR TITLE
feat(web): interactive mod/arcane references in build guides (#228)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",

--- a/apps/web/src/components/build-editor/arcane.tsx
+++ b/apps/web/src/components/build-editor/arcane.tsx
@@ -32,14 +32,8 @@ import { marketUrl, wikiUrl } from "@/lib/util/warframe-links"
 import { StatText } from "../stat-text"
 import { BuildItemDetail } from "./item-detail"
 import { useRankHover } from "./rank-hover"
-import { arcaneMaxRank } from "./slot-ranks"
+import { arcaneMaxRank, arcaneStatsAt as statsAt } from "./slot-ranks"
 import type { PlacedArcane } from "./use-arcane-slots"
-
-function statsAt(arcane: Arcane, rank: number): string[] {
-  if (!arcane.levelStats || arcane.levelStats.length === 0) return []
-  const i = Math.min(rank, arcane.levelStats.length - 1)
-  return arcane.levelStats[i]?.stats ?? []
-}
 
 interface ArcaneCardProps {
   arcane: Arcane

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -62,6 +62,7 @@ import {
   saveEditorDraft,
   type EditorDraftPayload,
 } from "@/lib/editor-draft"
+import { collectGuideRefs } from "@/lib/guide-refs"
 import { useHotkey } from "@/lib/hooks/hotkeys"
 import { consumeDraft } from "@/lib/import-draft"
 import { arcanesQuery } from "@/lib/queries/arcanes-query"
@@ -1137,6 +1138,14 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     const nextVariants = variants.map((v, i) =>
       i === clampedActiveIndex ? activeSnapshot : v,
     )
+    // Snapshot every mod/arcane referenced from guide text (build-wide +
+    // per-variant) so the viewer renders hover cards without the catalog —
+    // see lib/guide-refs.ts.
+    const guideRefs = collectGuideRefs(
+      [guide.buildDescription, ...nextVariants.map((v) => v.guideDescription)],
+      allMods,
+      allArcanes,
+    )
     return stripPersistedImages({
       version: 1,
       slots: slots.placed,
@@ -1151,6 +1160,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       incarnonEnabled,
       incarnonPerks,
       deploymentContext,
+      guideRefs,
       // Emit `variants` whenever there's more than one OR the single
       // remaining variant has a user-assigned label/id — otherwise the
       // synthetic placeholder from getVariants() would silently overwrite

--- a/apps/web/src/components/build-editor/markdown-editor/codemirror-theme.ts
+++ b/apps/web/src/components/build-editor/markdown-editor/codemirror-theme.ts
@@ -50,6 +50,39 @@ const editorTheme = EditorView.theme({
   ".cm-selectionMatch": {
     backgroundColor: "color-mix(in oklab, var(--primary) 14%, transparent)",
   },
+  // Tooltips (the `[[` ref autocomplete) otherwise fall back to CM's default
+  // light theme — a white box that's unreadable in dark mode. Mirror the
+  // site's popover tokens instead.
+  ".cm-tooltip": {
+    backgroundColor: "var(--popover)",
+    color: "var(--popover-foreground)",
+    border: "1px solid var(--border)",
+    borderRadius: "var(--radius)",
+    overflow: "hidden",
+    boxShadow:
+      "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  },
+  ".cm-tooltip.cm-tooltip-autocomplete > ul": {
+    fontFamily: "var(--font-geist-mono)",
+    fontSize: "0.8125rem",
+  },
+  ".cm-tooltip.cm-tooltip-autocomplete > ul > li": {
+    padding: "0.25rem 0.5rem",
+  },
+  ".cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]": {
+    backgroundColor: "var(--accent)",
+    color: "var(--accent-foreground)",
+  },
+  ".cm-completionDetail": {
+    color: "var(--muted-foreground)",
+    fontStyle: "normal",
+    marginLeft: "0.5rem",
+  },
+  ".cm-completionMatchedText": {
+    textDecoration: "none",
+    color: "var(--primary)",
+    fontWeight: "600",
+  },
 })
 
 /**

--- a/apps/web/src/components/build-editor/markdown-editor/markdown-editor.tsx
+++ b/apps/web/src/components/build-editor/markdown-editor/markdown-editor.tsx
@@ -1,8 +1,13 @@
+import { isRivenMod } from "@arsenyx/shared/warframe/rivens"
 import { type EditorState } from "@codemirror/state"
 import { type EditorView } from "@codemirror/view"
-import { memo, useCallback, useEffect, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { MarkdownBody } from "@/components/markdown-body"
+import { makeRefResolver, type GuideRefResolver } from "@/lib/guide-refs"
+import { arcanesQuery } from "@/lib/queries/arcanes-query"
+import { modsQuery } from "@/lib/queries/mods-query"
 import { cn } from "@/lib/util/utils"
 
 import {
@@ -11,6 +16,7 @@ import {
   type ActiveFormat,
 } from "./markdown-active"
 import { MarkdownToolbar, type ViewMode } from "./markdown-toolbar"
+import type { RefCandidate } from "./ref-autocomplete"
 import { useCodeMirror } from "./use-codemirror"
 
 /** Shared prose styling for the live preview — matches the published guide. */
@@ -24,6 +30,7 @@ function CodeEditor({
   viewRef,
   onStateChange,
   onScroll,
+  getRefCandidates,
 }: {
   value: string
   onChange: (value: string) => void
@@ -31,6 +38,7 @@ function CodeEditor({
   viewRef: React.RefObject<EditorView | null>
   onStateChange: (state: EditorState) => void
   onScroll: (scroller: HTMLElement) => void
+  getRefCandidates: () => RefCandidate[]
 }) {
   const containerRef = useCodeMirror({
     value,
@@ -39,13 +47,20 @@ function CodeEditor({
     viewRef,
     onStateChange,
     onScroll,
+    getRefCandidates,
   })
   return <div ref={containerRef} className="h-full min-h-64" />
 }
 
 // Memoized so a parent re-render (every keystroke) doesn't re-parse markdown
 // when the (debounced) source is unchanged. react-markdown isn't cheap.
-const Preview = memo(function Preview({ source }: { source: string }) {
+const Preview = memo(function Preview({
+  source,
+  resolveGuideRef,
+}: {
+  source: string
+  resolveGuideRef: GuideRefResolver
+}) {
   if (!source.trim()) {
     return (
       <p className="text-muted-foreground p-3 text-sm italic">
@@ -55,7 +70,11 @@ const Preview = memo(function Preview({ source }: { source: string }) {
   }
   return (
     <div className="p-3">
-      <MarkdownBody source={source} className={PREVIEW_PROSE_CLASS} />
+      <MarkdownBody
+        source={source}
+        className={PREVIEW_PROSE_CLASS}
+        resolveGuideRef={resolveGuideRef}
+      />
     </div>
   )
 })
@@ -85,6 +104,37 @@ export function MarkdownEditor({
 }) {
   const viewRef = useRef<EditorView | null>(null)
   const previewRef = useRef<HTMLDivElement>(null)
+  // Catalogs for the `[[` reference typeahead + live-preview hover cards.
+  // Both are cached app-wide (the editor routes ensureQueryData them), so
+  // this is a cache read, not a fresh ~1.35 MB download.
+  const { data: allMods } = useQuery(modsQuery)
+  const { data: allArcanes } = useQuery(arcanesQuery)
+  const refCandidates = useMemo<RefCandidate[]>(() => {
+    const out: RefCandidate[] = []
+    for (const m of allMods ?? []) {
+      // Rivens carry stub uniqueNames that resolve to nothing useful.
+      if (isRivenMod(m)) continue
+      out.push({
+        kind: "mod",
+        uniqueName: m.uniqueName,
+        name: m.name,
+        detail: m.compatName || m.type,
+      })
+    }
+    for (const a of allArcanes ?? []) {
+      out.push({
+        kind: "arcane",
+        uniqueName: a.uniqueName,
+        name: a.name,
+        detail: "Arcane",
+      })
+    }
+    return out
+  }, [allMods, allArcanes])
+  const resolveGuideRef = useMemo(
+    () => makeRefResolver(allMods, allArcanes),
+    [allMods, allArcanes],
+  )
   // Split is the default on a roomy screen; on narrow ones it stacks awkwardly,
   // so start in single-pane write mode there.
   const [viewMode, setViewMode] = useState<ViewMode>(() =>
@@ -167,10 +217,16 @@ export function MarkdownEditor({
             key={docKey ?? "build"}
             value={value}
             onChange={onChange}
-            placeholder={placeholder ?? "Write your build guide in Markdown…"}
+            placeholder={
+              placeholder ??
+              "Write your build guide in Markdown… Type [[ to link a mod or arcane."
+            }
             viewRef={viewRef}
             onStateChange={handleStateChange}
             onScroll={handleScroll}
+            // Identity doesn't matter: useCodeMirror reads this through its
+            // own ref at completion time.
+            getRefCandidates={() => refCandidates}
           />
         </div>
         {showPreview ? (
@@ -184,7 +240,7 @@ export function MarkdownEditor({
                 "border-input border-t sm:border-t-0 sm:border-l",
             )}
           >
-            <Preview source={previewSource} />
+            <Preview source={previewSource} resolveGuideRef={resolveGuideRef} />
           </div>
         ) : null}
       </div>

--- a/apps/web/src/components/build-editor/markdown-editor/ref-autocomplete.ts
+++ b/apps/web/src/components/build-editor/markdown-editor/ref-autocomplete.ts
@@ -1,0 +1,88 @@
+import {
+  autocompletion,
+  type Completion,
+  type CompletionContext,
+  type CompletionResult,
+} from "@codemirror/autocomplete"
+import type { Extension } from "@codemirror/state"
+
+/** A mod/arcane the `[[` autocomplete can insert — see guide-refs.ts for the
+ *  reference syntax this expands to. */
+export type RefCandidate = {
+  kind: "mod" | "arcane"
+  uniqueName: string
+  name: string
+  /** Disambiguator shown dimmed after the name (e.g. "Warframe", "Rifle"). */
+  detail?: string
+}
+
+/**
+ * `[[` typeahead for guide-ref links (issue #228). Typing `[[vita` offers
+ * matching mods/arcanes; picking one replaces the `[[query` text with the
+ * resolved markdown link `[Vitality](mod:/Lotus/…)`. Candidates are read
+ * through a getter because the catalogs load async (React Query) after the
+ * editor mounts — the extension itself is created once.
+ *
+ * Plain `[` keeps its normal markdown-link meaning; only a double bracket
+ * triggers the popup, so prose with brackets doesn't get ambushed.
+ */
+export function refAutocomplete(
+  getCandidates: () => RefCandidate[],
+): Extension {
+  // The mapped options (~1800 objects + apply closures) are cached on the
+  // candidate array's identity — the caller memoizes it per catalog load, so
+  // re-triggering `[[` reuses the same options instead of re-allocating.
+  let cachedFor: RefCandidate[] | undefined
+  let cachedOptions: Completion[] = []
+
+  const optionsFor = (candidates: RefCandidate[]): Completion[] => {
+    if (candidates === cachedFor) return cachedOptions
+    cachedFor = candidates
+    cachedOptions = candidates.map((c) => ({
+      label: c.name,
+      detail: c.detail,
+      type: c.kind === "mod" ? "variable" : "constant",
+      apply: (view, _completion, from, to) => {
+        // `from` is the result position (after `[[`); also remove the
+        // brackets themselves, plus a trailing `]]` the author (or an
+        // auto-close pair) may have already typed after the cursor.
+        const after = view.state.sliceDoc(to, to + 2)
+        const end = after === "]]" ? to + 2 : after[0] === "]" ? to + 1 : to
+        view.dispatch({
+          changes: {
+            from: from - 2,
+            to: end,
+            insert: `[${c.name}](${c.kind}:${c.uniqueName})`,
+          },
+        })
+      },
+    }))
+    return cachedOptions
+  }
+
+  const source = (context: CompletionContext): CompletionResult | null => {
+    // Everything from `[[` to the cursor, same line, no closing bracket yet.
+    const match = context.matchBefore(/\[\[[^\][\n]*$/)
+    if (!match) return null
+    // Without explicit invocation, require at least one typed character so
+    // bare `[[` doesn't pop a 1600-entry list.
+    if (!context.explicit && match.to - match.from < 3) return null
+
+    return {
+      // Position after `[[` so CodeMirror filters labels against the typed
+      // query, not the brackets.
+      from: match.from + 2,
+      options: optionsFor(getCandidates()),
+      // Keep this result active (re-filtered client-side) while the user
+      // keeps typing name characters — avoids re-running the source per key.
+      validFor: /^[^\][\n]*$/,
+    }
+  }
+
+  return autocompletion({
+    override: [source],
+    icons: false,
+    // The list is long; cap rendering work.
+    maxRenderedOptions: 40,
+  })
+}

--- a/apps/web/src/components/build-editor/markdown-editor/use-codemirror.ts
+++ b/apps/web/src/components/build-editor/markdown-editor/use-codemirror.ts
@@ -12,6 +12,7 @@ import { useEffect, useRef } from "react"
 
 import { arsenyxEditorTheme } from "./codemirror-theme"
 import { markdownFormatKeymap, pasteLinkHandler } from "./markdown-commands"
+import { refAutocomplete, type RefCandidate } from "./ref-autocomplete"
 
 /**
  * Mounts a raw CodeMirror 6 instance and keeps it in sync with React state.
@@ -38,6 +39,9 @@ export function useCodeMirror(opts: {
   onStateChange?: (state: EditorView["state"]) => void
   /** Fires on editor scroll — drives split-view scroll sync. */
   onScroll?: (scroller: HTMLElement) => void
+  /** Candidates for the `[[` mod/arcane reference typeahead. Read through a
+   *  ref at completion time, so async catalog loads need no editor rebuild. */
+  getRefCandidates?: () => RefCandidate[]
 }) {
   const { value, placeholder: ph, autoFocus, viewRef, onReady } = opts
   const containerRef = useRef<HTMLDivElement>(null)
@@ -47,6 +51,8 @@ export function useCodeMirror(opts: {
   onStateChangeRef.current = opts.onStateChange
   const onScrollRef = useRef(opts.onScroll)
   onScrollRef.current = opts.onScroll
+  const getRefCandidatesRef = useRef(opts.getRefCandidates)
+  getRefCandidatesRef.current = opts.getRefCandidates
 
   useEffect(() => {
     const parent = containerRef.current
@@ -66,6 +72,7 @@ export function useCodeMirror(opts: {
         Prec.high(keymap.of(markdownFormatKeymap)),
         keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
         placeholder(ph),
+        refAutocomplete(() => getRefCandidatesRef.current?.() ?? []),
         EditorView.domEventHandlers({ paste: pasteLinkHandler }),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {

--- a/apps/web/src/components/build-editor/mod-slot.tsx
+++ b/apps/web/src/components/build-editor/mod-slot.tsx
@@ -1,6 +1,5 @@
 import { isRivenMod } from "@arsenyx/shared/warframe/rivens"
 import type { Mod, Polarity } from "@arsenyx/shared/warframe/types"
-import { useQuery } from "@tanstack/react-query"
 import { Pencil, Plus, X, type LucideIcon } from "lucide-react"
 import {
   useEffect,
@@ -16,9 +15,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import { modTradableQuery } from "@/lib/queries/mod-tradable-query"
+import { useModMarketHref } from "@/lib/queries/mod-tradable-query"
 import { cn } from "@/lib/util/utils"
-import { marketUrl, wikiUrl } from "@/lib/util/warframe-links"
+import { wikiUrl } from "@/lib/util/warframe-links"
 
 import {
   auraBonusForMod,
@@ -180,21 +179,10 @@ export function ModSlot({
   // `readOnly`.
   const detailEnabled = readOnly && !!mod
 
-  // Compact non-tradable list (deduped across all slots by React Query).
-  // Gates the Market link: a mod is tradable unless listed. Rivens carry a stub
-  // uniqueName with no Market page, so never link them. Only fetched once a
-  // detail is actually opened — not on every filled slot of every build view.
-  const { data: nonTradable } = useQuery({
-    ...modTradableQuery,
-    enabled: detailEnabled && detailOpen,
-  })
-  const marketHref =
-    mod &&
-    nonTradable &&
-    !isRivenMod(mod) &&
-    !nonTradable.includes(mod.uniqueName)
-      ? marketUrl(mod.name)
-      : undefined
+  // Market link, gated on the compact non-tradable index (deduped across all
+  // slots by React Query). Only fetched once a detail is actually opened —
+  // not on every filled slot of every build view.
+  const marketHref = useModMarketHref(mod, detailEnabled && detailOpen)
 
   // Shared by the in-slot card and the pinned detail card so the two can't show
   // a different drain / polarity-match for the same mod. Aura & stance slots

--- a/apps/web/src/components/build-editor/slot-ranks.ts
+++ b/apps/web/src/components/build-editor/slot-ranks.ts
@@ -15,3 +15,10 @@ export function modMaxRank(mod: Mod): number {
 export function arcaneMaxRank(arcane: Arcane): number {
   return arcane.levelStats ? arcane.levelStats.length - 1 : 5
 }
+
+/** Stat lines an arcane shows at the given rank, clamped to its level data. */
+export function arcaneStatsAt(arcane: Arcane, rank: number): string[] {
+  if (!arcane.levelStats || arcane.levelStats.length === 0) return []
+  const i = Math.min(rank, arcane.levelStats.length - 1)
+  return arcane.levelStats[i]?.stats ?? []
+}

--- a/apps/web/src/components/build-viewer/build-viewer-body.tsx
+++ b/apps/web/src/components/build-viewer/build-viewer-body.tsx
@@ -24,6 +24,7 @@ import {
   refreshImagesFromMap,
   selectVariant,
 } from "@/lib/codec/build-codec-adapter"
+import { makeRefResolver } from "@/lib/guide-refs"
 import { arcanesQuery } from "@/lib/queries/arcanes-query"
 import type { BuildDetail } from "@/lib/queries/build-query"
 import {
@@ -146,6 +147,14 @@ function BuildViewerBodyInner({
   )
 
   const variants = useMemo(() => getVariants(savedAll), [savedAll])
+  // Memoized so MarkdownBody's anchor renderer keeps a stable component
+  // identity across re-renders — a fresh resolver each render would remount
+  // every guide-ref hover card (and drop open popovers) on variant switches.
+  const resolveGuideRef = useMemo(
+    () =>
+      makeRefResolver(savedAll.guideRefs?.mods, savedAll.guideRefs?.arcanes),
+    [savedAll.guideRefs],
+  )
   const activeIndex = useMemo(() => {
     const raw = rawActiveIndex ?? 0
     if (raw < 0) return 0
@@ -283,7 +292,11 @@ function BuildViewerBodyInner({
 
         {!embed && (
           <Suspense fallback={null}>
-            <GuideDisplay build={build} activeVariant={variants[activeIndex]} />
+            <GuideDisplay
+              build={build}
+              activeVariant={variants[activeIndex]}
+              resolveGuideRef={resolveGuideRef}
+            />
           </Suspense>
         )}
       </div>

--- a/apps/web/src/components/build-viewer/guide-display.tsx
+++ b/apps/web/src/components/build-viewer/guide-display.tsx
@@ -1,4 +1,5 @@
 import { MarkdownBody } from "@/components/markdown-body"
+import type { GuideRefResolver } from "@/lib/guide-refs"
 import type { BuildDetail } from "@/lib/queries/build-query"
 import type { SavedVariant } from "@/lib/queries/build-query"
 
@@ -16,9 +17,13 @@ import type { SavedVariant } from "@/lib/queries/build-query"
 export function GuideDisplay({
   build,
   activeVariant,
+  resolveGuideRef,
 }: {
   build: Pick<BuildDetail, "guide">
   activeVariant: SavedVariant | undefined
+  /** Resolves `[Name](mod:…)` references against the build's stored
+   *  snapshots — see lib/guide-refs.ts. */
+  resolveGuideRef?: GuideRefResolver
 }) {
   const variantSummary = activeVariant?.guideSummary?.trim()
   const variantDescription = activeVariant?.guideDescription?.trim()
@@ -39,6 +44,7 @@ export function GuideDisplay({
         <MarkdownBody
           source={effectiveDescription}
           className="prose prose-sm dark:prose-invert max-w-none"
+          resolveGuideRef={resolveGuideRef}
         />
       ) : null}
     </div>

--- a/apps/web/src/components/guide-ref-link.tsx
+++ b/apps/web/src/components/guide-ref-link.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState, type ReactNode } from "react"
+
+// Deep imports (not the build-editor barrel) so this stays safe to pull into
+// the embed bundle — same rule as build-viewer-body.
+import {
+  BuildItemDetail,
+  DetailLinks,
+} from "@/components/build-editor/item-detail"
+import { ModCard } from "@/components/build-editor/mod-card"
+import {
+  arcaneMaxRank,
+  arcaneStatsAt,
+} from "@/components/build-editor/slot-ranks"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import type { GuideRefTarget } from "@/lib/guide-refs"
+import { DISPLAY_SIZE } from "@/lib/mod-card-config"
+import { useModMarketHref } from "@/lib/queries/mod-tradable-query"
+import { getArcaneImageUrl } from "@/lib/util/arcane-images"
+import { marketUrl, wikiUrl } from "@/lib/util/warframe-links"
+
+const HOVER_OPEN_MS = 150
+const HOVER_CLOSE_MS = 250
+
+/**
+ * Inline mod/arcane reference inside guide markdown (issue #228). Renders the
+ * link text; hovering (desktop) or tapping (mobile) opens a detail popover —
+ * the full expanded mod card, or the arcane text card — with Wiki/Market
+ * links, mirroring what clicking a build slot shows in view mode.
+ *
+ * Hover uses an intent delay on both trigger and content so the pointer can
+ * travel into the card without it closing; click toggles, and the Popover
+ * itself handles outside-click/Escape dismissal for the tap path.
+ */
+export function GuideRefLink({
+  target,
+  children,
+}: {
+  target: GuideRefTarget
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  const timer = useRef<number | undefined>(undefined)
+  const schedule = (next: boolean, delay: number) => {
+    window.clearTimeout(timer.current)
+    timer.current = window.setTimeout(() => setOpen(next), delay)
+  }
+  const cancel = () => window.clearTimeout(timer.current)
+  // A pending hover timer must not fire setOpen after unmount (variant
+  // switch / guide re-render while the pointer is mid-hover).
+  useEffect(() => () => window.clearTimeout(timer.current), [])
+
+  const name = target.kind === "mod" ? target.mod.name : target.arcane.name
+
+  // Market link: mods gate on the lazily-fetched non-tradable index (same
+  // hook as the slot detail popover); arcanes carry `tradable` inline.
+  const modMarketHref = useModMarketHref(
+    target.kind === "mod" ? target.mod : undefined,
+    open,
+  )
+  const marketHref =
+    target.kind === "mod"
+      ? modMarketHref
+      : target.arcane.tradable
+        ? marketUrl(name)
+        : undefined
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        nativeButton={false}
+        render={
+          <span
+            role="button"
+            tabIndex={0}
+            className="text-primary cursor-pointer underline decoration-dotted underline-offset-2"
+          />
+        }
+        onMouseEnter={() => schedule(true, HOVER_OPEN_MS)}
+        onMouseLeave={() => schedule(false, HOVER_CLOSE_MS)}
+        onClick={() => {
+          cancel()
+          setOpen((o) => !o)
+        }}
+      >
+        {children}
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-auto"
+        onMouseEnter={cancel}
+        onMouseLeave={() => schedule(false, HOVER_CLOSE_MS)}
+      >
+        {target.kind === "mod" ? (
+          <div
+            className="flex flex-col items-center gap-2"
+            style={{ width: DISPLAY_SIZE.expanded.width }}
+          >
+            <div style={{ height: DISPLAY_SIZE.expanded.height }}>
+              <ModCard mod={target.mod} alwaysExpanded />
+            </div>
+            <DetailLinks wikiHref={wikiUrl(name)} marketHref={marketHref} />
+          </div>
+        ) : (
+          <BuildItemDetail
+            name={name}
+            imageUrl={getArcaneImageUrl(target.arcane.imageName)}
+            meta={target.arcane.type}
+            rank={arcaneMaxRank(target.arcane)}
+            maxRank={arcaneMaxRank(target.arcane)}
+            stats={arcaneStatsAt(target.arcane, arcaneMaxRank(target.arcane))}
+            description={target.arcane.description}
+            wikiHref={wikiUrl(name)}
+            marketHref={marketHref}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/markdown-body.tsx
+++ b/apps/web/src/components/markdown-body.tsx
@@ -1,10 +1,16 @@
 import { useMemo } from "react"
-import ReactMarkdown, { type Components } from "react-markdown"
+import ReactMarkdown, {
+  defaultUrlTransform,
+  type Components,
+} from "react-markdown"
 import remarkBreaks from "remark-breaks"
 import remarkGfm from "remark-gfm"
 
+import { GuideRefLink } from "@/components/guide-ref-link"
+import { parseGuideRefHref, type GuideRefResolver } from "@/lib/guide-refs"
 import { proxyImage } from "@/lib/util/image-proxy"
 import { getVideoEmbed } from "@/lib/util/video-embed"
+import { wikiUrl } from "@/lib/util/warframe-links"
 
 /**
  * Renders user-authored markdown for build guides. Bare YouTube/Vimeo URLs
@@ -19,21 +25,74 @@ import { getVideoEmbed } from "@/lib/util/video-embed"
 export function MarkdownBody({
   source,
   className,
+  resolveGuideRef,
 }: {
   source: string
   className?: string
+  /** Resolves `[Name](mod:…)` / `[Name](arcane:…)` references to hover-card
+   *  data (issue #228). Omitted → those links render as plain wiki links. */
+  resolveGuideRef?: GuideRefResolver
 }) {
   const prepared = useMemo(() => isolateVideoLines(source), [source])
+  const mergedComponents = useMemo<Components>(
+    () => ({ ...components, a: makeAnchorRenderer(resolveGuideRef) }),
+    [resolveGuideRef],
+  )
   return (
     <div className={className}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
-        components={components}
+        components={mergedComponents}
+        // Let the custom mod:/arcane: schemes through; everything else gets
+        // react-markdown's default sanitization.
+        urlTransform={(url) =>
+          parseGuideRefHref(url) ? url : defaultUrlTransform(url)
+        }
       >
         {prepared}
       </ReactMarkdown>
     </div>
   )
+}
+
+/**
+ * Anchor renderer that intercepts guide-ref hrefs. Resolved refs become the
+ * interactive hover card; unresolved ones (old build without snapshots, name
+ * removed from the game) degrade to a plain wiki link on the link text, which
+ * is still a useful destination. Normal links render as before.
+ */
+function makeAnchorRenderer(
+  resolveGuideRef: GuideRefResolver | undefined,
+): Components["a"] {
+  return function Anchor({ node: _node, href, children, ...rest }) {
+    const ref = href ? parseGuideRefHref(href) : null
+    if (ref) {
+      const target = resolveGuideRef?.(ref.kind, ref.uniqueName)
+      if (target) return <GuideRefLink target={target}>{children}</GuideRefLink>
+      const label = textOf(children)
+      return (
+        <a
+          {...rest}
+          href={wikiUrl(label)}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {children}
+        </a>
+      )
+    }
+    return (
+      <a {...rest} href={href}>
+        {children}
+      </a>
+    )
+  }
+}
+
+function textOf(children: React.ReactNode): string {
+  if (typeof children === "string") return children
+  if (Array.isArray(children)) return children.map(textOf).join("")
+  return ""
 }
 
 /**

--- a/apps/web/src/lib/codec/build-codec-adapter.ts
+++ b/apps/web/src/lib/codec/build-codec-adapter.ts
@@ -296,6 +296,22 @@ export function buildStateToSavedData(
  * full catalog. Legacy builds already get fresh images via `toEditorPlacedMod`,
  * so this is a no-op for them. Falls back to the stored value on a map miss.
  */
+/** Apply `fn` to every mod/arcane snapshot in an optional `guideRefs` —
+ *  shared by the image refresh (below) and strip (stripPersistedImages)
+ *  passes so the two can't drift. The casts are safe: `fn` only adds or
+ *  removes `imageName`, never changes the entry's identity. */
+type GuideRefEntry = { uniqueName: string; imageName?: string }
+function mapGuideRefs(
+  refs: SavedBuildData["guideRefs"],
+  fn: (entry: GuideRefEntry) => GuideRefEntry,
+): SavedBuildData["guideRefs"] {
+  if (!refs) return refs
+  return {
+    ...(refs.mods && { mods: refs.mods.map((m) => fn(m) as Mod) }),
+    ...(refs.arcanes && { arcanes: refs.arcanes.map((a) => fn(a) as Arcane) }),
+  }
+}
+
 export function refreshImagesFromMap(
   data: SavedBuildData,
   imageMap: Record<string, string> | undefined,
@@ -353,6 +369,11 @@ export function refreshImagesFromMap(
     slots: fixSlots(data.slots),
     arcanes: fixArcanes(data.arcanes),
     helminth: fixHelminth(data.helminth),
+    // Guide-ref snapshots persist without imageName, same as placed slots.
+    guideRefs: mapGuideRefs(data.guideRefs, (entry) => {
+      const fresh = url(entry.uniqueName)
+      return fresh ? { ...entry, imageName: fresh } : entry
+    }),
     variants: data.variants?.map((v) => ({
       ...v,
       slots: fixSlots(v.slots) ?? v.slots,
@@ -415,6 +436,10 @@ export function stripPersistedImages(data: SavedBuildData): SavedBuildData {
     slots: stripSlots(data.slots),
     arcanes: stripArcanes(data.arcanes),
     helminth: stripHelminth(data.helminth),
+    guideRefs: mapGuideRefs(data.guideRefs, (entry) => {
+      const { imageName: _drop, ...rest } = entry
+      return rest
+    }),
     variants: data.variants?.map((v) => ({
       ...v,
       slots: stripSlots(v.slots) ?? v.slots,

--- a/apps/web/src/lib/guide-refs.test.ts
+++ b/apps/web/src/lib/guide-refs.test.ts
@@ -1,0 +1,73 @@
+import type { Arcane, Mod } from "@arsenyx/shared/warframe/types"
+import { describe, expect, it } from "vitest"
+
+import {
+  collectGuideRefs,
+  makeRefResolver,
+  parseGuideRefHref,
+} from "./guide-refs"
+
+const vitality = {
+  uniqueName: "/Lotus/Upgrades/Mods/Warframe/AvatarHealthMaxMod",
+  name: "Vitality",
+} as Mod
+
+const energize = {
+  uniqueName: "/Lotus/Upgrades/CosmeticEnhancers/Utility/EnergyOnEnergyPickup",
+  name: "Arcane Energize",
+} as Arcane
+
+describe("parseGuideRefHref", () => {
+  it("parses mod and arcane hrefs", () => {
+    expect(parseGuideRefHref(`mod:${vitality.uniqueName}`)).toEqual({
+      kind: "mod",
+      uniqueName: vitality.uniqueName,
+    })
+    expect(parseGuideRefHref(`arcane:${energize.uniqueName}`)).toEqual({
+      kind: "arcane",
+      uniqueName: energize.uniqueName,
+    })
+  })
+
+  it("rejects ordinary URLs and malformed refs", () => {
+    expect(parseGuideRefHref("https://example.com")).toBeNull()
+    expect(parseGuideRefHref("mod:NotAPath")).toBeNull()
+    expect(parseGuideRefHref("mod:/has space")).toBeNull()
+  })
+})
+
+describe("collectGuideRefs", () => {
+  it("snapshots referenced entries across multiple sources, deduped", () => {
+    const refs = collectGuideRefs(
+      [
+        `Run [Vitality](mod:${vitality.uniqueName}) always.`,
+        undefined,
+        `[Vitality](mod:${vitality.uniqueName}) again, plus [Energize](arcane:${energize.uniqueName}).`,
+      ],
+      [vitality],
+      [energize],
+    )
+    expect(refs).toEqual({ mods: [vitality], arcanes: [energize] })
+  })
+
+  it("skips unknown uniqueNames and returns undefined when nothing matches", () => {
+    expect(
+      collectGuideRefs(["[Gone](mod:/Lotus/Removed)"], [vitality], []),
+    ).toBeUndefined()
+    expect(collectGuideRefs(["no refs here"], [vitality], [])).toBeUndefined()
+  })
+})
+
+describe("makeRefResolver", () => {
+  it("resolves from snapshots and misses gracefully", () => {
+    const resolve = makeRefResolver([vitality], undefined)
+    expect(resolve("mod", vitality.uniqueName)).toEqual({
+      kind: "mod",
+      mod: vitality,
+    })
+    expect(resolve("arcane", energize.uniqueName)).toBeNull()
+    expect(
+      makeRefResolver(undefined, undefined)("mod", vitality.uniqueName),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/lib/guide-refs.ts
+++ b/apps/web/src/lib/guide-refs.ts
@@ -1,0 +1,107 @@
+import type { Arcane, Mod } from "@arsenyx/shared/warframe/types"
+
+/**
+ * Interactive mod/arcane references in build guides (issue #228).
+ *
+ * Authors write a normal markdown link whose href uses a custom scheme:
+ *
+ *   [Corrosive Projection](mod:/Lotus/Upgrades/Mods/Aura/EnemyArmorReductionAura)
+ *   [Arcane Energize](arcane:/Lotus/Upgrades/CosmeticEnhancers/Utility/EnergyOnEnergyPickup)
+ *
+ * The editor's `[[` autocomplete inserts these; MarkdownBody intercepts the
+ * scheme and renders a hover/click detail card instead of an anchor.
+ *
+ * Resolution is snapshot-first: at save time the editor copies each referenced
+ * mod/arcane from the catalog into `SavedBuildData.guideRefs`, so the viewer —
+ * including the embed, which deliberately never downloads the ~1.35 MB
+ * mods-all.json — renders cards from data already in the build payload.
+ * Snapshots follow the same rules as placed slots: `imageName` is stripped on
+ * persist and re-resolved by uniqueName at render (see build-codec-adapter's
+ * stripPersistedImages / refreshImagesFromMap).
+ */
+
+/** Snapshots of every mod/arcane referenced in any of a build's guide texts
+ *  (build-wide + per-variant), deduped by uniqueName. Stored inside
+ *  `Build.buildData` (opaque JSON to the API). */
+export type GuideRefs = {
+  mods?: Mod[]
+  arcanes?: Arcane[]
+}
+
+export type GuideRefTarget =
+  | { kind: "mod"; mod: Mod }
+  | { kind: "arcane"; arcane: Arcane }
+
+/** Resolves a guide-ref href to renderable data. Returns null when the
+ *  reference can't be resolved (no snapshot and no catalog entry) — the
+ *  renderer then falls back to a plain wiki link. */
+export type GuideRefResolver = (
+  kind: "mod" | "arcane",
+  uniqueName: string,
+) => GuideRefTarget | null
+
+/** Parse a `mod:<uniqueName>` / `arcane:<uniqueName>` href. uniqueNames are
+ *  DE paths and always start with "/", which conveniently keeps the scheme
+ *  unambiguous against real-world URLs. */
+export function parseGuideRefHref(
+  href: string,
+): { kind: "mod" | "arcane"; uniqueName: string } | null {
+  const m = /^(mod|arcane):(\/\S+)$/.exec(href)
+  if (!m) return null
+  return { kind: m[1] as "mod" | "arcane", uniqueName: m[2] }
+}
+
+// Matches the href half of a guide-ref markdown link in raw guide text.
+// uniqueNames never contain whitespace or parens, so this can't over-match
+// into surrounding prose.
+const REF_IN_MARKDOWN = /\]\((mod|arcane):(\/[^()\s]+)\)/g
+
+/**
+ * Scan guide markdown sources for references and snapshot the matching
+ * catalog entries. Unknown uniqueNames are skipped (the renderer falls back
+ * to a wiki link), duplicates collapse to one snapshot. Returns undefined
+ * when nothing matched so `buildData` doesn't grow an empty key.
+ */
+export function collectGuideRefs(
+  sources: (string | undefined)[],
+  mods: Mod[],
+  arcanes: Arcane[],
+): GuideRefs | undefined {
+  const modNames = new Set<string>()
+  const arcaneNames = new Set<string>()
+  for (const source of sources) {
+    if (!source) continue
+    for (const m of source.matchAll(REF_IN_MARKDOWN)) {
+      ;(m[1] === "mod" ? modNames : arcaneNames).add(m[2])
+    }
+  }
+  const refMods = mods.filter((m) => modNames.has(m.uniqueName))
+  const refArcanes = arcanes.filter((a) => arcaneNames.has(a.uniqueName))
+  if (refMods.length === 0 && refArcanes.length === 0) return undefined
+  return {
+    ...(refMods.length > 0 && { mods: refMods }),
+    ...(refArcanes.length > 0 && { arcanes: refArcanes }),
+  }
+}
+
+/**
+ * Build a resolver over any mod/arcane source: the build's stored snapshots
+ * (viewer/embed) or the full catalogs (editor live preview — snapshots don't
+ * exist until save). Lookups are prebuilt Maps so resolving inside the
+ * markdown render path stays O(1) even against the ~1600-mod catalog.
+ */
+export function makeRefResolver(
+  mods: Mod[] | undefined,
+  arcanes: Arcane[] | undefined,
+): GuideRefResolver {
+  const modsByName = new Map(mods?.map((m) => [m.uniqueName, m]))
+  const arcanesByName = new Map(arcanes?.map((a) => [a.uniqueName, a]))
+  return (kind, uniqueName) => {
+    if (kind === "mod") {
+      const mod = modsByName.get(uniqueName)
+      return mod ? { kind: "mod", mod } : null
+    }
+    const arcane = arcanesByName.get(uniqueName)
+    return arcane ? { kind: "arcane", arcane } : null
+  }
+}

--- a/apps/web/src/lib/queries/build-query.ts
+++ b/apps/web/src/lib/queries/build-query.ts
@@ -8,6 +8,7 @@ import { queryOptions } from "@tanstack/react-query"
 import { notFound } from "@tanstack/react-router"
 
 import type { PlacedArcane, PlacedMod, SlotId } from "@/components/build-editor"
+import type { GuideRefs } from "@/lib/guide-refs"
 import type { HelminthAbility } from "@/lib/queries/helminth-query"
 import type { PlacedShard } from "@/lib/shards"
 import { apiFetch, ApiError } from "@/lib/util/api-client"
@@ -56,6 +57,11 @@ export type SavedBuildData = {
   // and the top-level mod/arcane fields mirror variants[0] for legacy
   // viewer compatibility.
   variants?: SavedVariant[]
+
+  /** Snapshots of mods/arcanes referenced from guide text via
+   *  `[Name](mod:…)` links — see lib/guide-refs.ts. Build-wide (covers the
+   *  build guide and every per-variant guide), recomputed on each save. */
+  guideRefs?: GuideRefs
 }
 
 /**

--- a/apps/web/src/lib/queries/mod-tradable-query.ts
+++ b/apps/web/src/lib/queries/mod-tradable-query.ts
@@ -1,3 +1,9 @@
+import { isRivenMod } from "@arsenyx/shared/warframe/rivens"
+import type { Mod } from "@arsenyx/shared/warframe/types"
+import { useQuery } from "@tanstack/react-query"
+
+import { marketUrl } from "@/lib/util/warframe-links"
+
 import { staticDataQuery } from "./static-data-query"
 
 /**
@@ -12,3 +18,25 @@ export const modTradableQuery = staticDataQuery<string[]>(
   "/data/mod-tradable.json",
   "failed to load mod tradability",
 )
+
+/**
+ * Warframe Market URL for a mod, or undefined while the tradability index
+ * hasn't loaded / the mod isn't tradable. Rivens carry a stub uniqueName with
+ * no Market page, so they never link. Pass `enabled: false` until a detail
+ * surface actually opens — the index is only fetched on demand.
+ */
+export function useModMarketHref(
+  mod: Mod | undefined,
+  enabled: boolean,
+): string | undefined {
+  const { data: nonTradable } = useQuery({
+    ...modTradableQuery,
+    enabled: enabled && !!mod,
+  })
+  return mod &&
+    nonTradable &&
+    !isRivenMod(mod) &&
+    !nonTradable.includes(mod.uniqueName)
+    ? marketUrl(mod.name)
+    : undefined
+}

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
       "name": "arsenyx-web",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language": "^6.12.3",


### PR DESCRIPTION
Ships the implementation of #228, which was closed as completed but whose code never landed on main — the original `feat/guide-mod-refs` branch was orphaned when its sibling commits merged via #231.

## What

- `[[` typeahead in the guide editor inserts a mod/arcane reference as a markdown link with a `mod:`/`arcane:` scheme
- In the published guide and live preview, the reference renders as an interactive link: hover (desktop) or tap (mobile) opens the full detail card — expanded mod card or arcane text card — with Wiki/Market links
- Save-time snapshots in `buildData.guideRefs` let the viewer render cards without downloading the ~1.35 MB `mods-all.json`
- Unresolved refs degrade to plain wiki links

## Changes vs the original branch

- Cherry-picked clean onto current main (the other 4 commits on the old branch already landed via #231)
- **New:** themed the `[[` autocomplete tooltip with the site's popover/accent design tokens — it previously fell back to CodeMirror's default light theme (white box, unreadable in dark mode)

## Verification

- `bun run typecheck`, `just check`, and the 5 `guide-refs.test.ts` tests all pass
- Verified in the browser: `[[corro` opens the styled autocomplete, accepting inserts `[Corrosive Projection](mod:/Lotus/...)`, and the live preview renders it as the interactive popover trigger