### PR TITLE
docs(web): changelog for Sirius & Orion twin-frame + U43 gear

### DIFF
--- a/apps/web/src/data/changelog.ts
+++ b/apps/web/src/data/changelog.ts
@@ -11,6 +11,26 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-06-18",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Sirius & Orion — the new twin Warframe — is in the planner as a single frame with a form toggle above the variant tabs. Each form (Sirius and Orion) keeps its own abilities, Helminth, and set of build variants, so you can plan both loadouts side by side under one build and flip between them. Helminth stays on the primary form, matching how the frame works in game.",
+      },
+      {
+        type: "feat",
+        description:
+          "The latest gear is in the catalog — Sirius & Orion, Styanax Prime, Afentis Prime, and the Pride and Wrath melees, among others. Brand-new weapons the Wiki hasn't documented yet still show up and can be modded; their detailed stats fill in automatically once the Wiki catches up.",
+      },
+      {
+        type: "feat",
+        description:
+          "The home page now leads with the newest Warframe, and the “Recently added” list reliably shows the latest releases.",
+      },
+    ],
+  },
+  {
     date: "2026-06-13",
     changes: [
       {


### PR DESCRIPTION
## Summary

Adds a user-facing changelog entry (dated 2026-06-18) for the work shipped in #240 (twin-frame feature + pipeline) and #241 (data refresh). Data-only edit to [`apps/web/src/data/changelog.ts`](apps/web/src/data/changelog.ts) — rendered by the `/changelog` route.

## Entry (3 `feat` items, in the established benefit-focused voice)
- **Sirius & Orion twin Warframe** — one frame with a form toggle above the variant tabs; each form (Sirius / Orion) keeps its own abilities, Helminth, and build variants. Helminth stays on the primary form, matching the in-game behavior.
- **Latest gear in the catalog** — Sirius & Orion, Styanax Prime, Afentis Prime, Pride/Wrath melees, etc. Brand-new weapons the Wiki hasn't documented yet still appear and can be modded; detailed stats fill in once the Wiki catches up.
- **Front page** — leads with the newest Warframe; "Recently added" list fixed.

## Notes for reviewer
- New entries go at the **top** of the `CHANGELOG` array (per the file's convention).
- Verified: oxlint clean, formatted, `bun --cwd apps/web run typecheck` passes.
- No code/behavior change — pure content.