### PR TITLE
feat: per-form innate polarities for Sirius & Orion twin-frame

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -403,15 +403,35 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   // strip and tabs immediately. Shared with the viewer via `deriveFormAxis`;
   // no-op for normal frames (activeFormIndex 0, formVariants = all variants).
   const {
+    isTwin,
     activeFormIndex,
     formAbilities,
     helminthAllowed,
     formNames,
     formVariants,
     formActiveLocalIndex,
+    formPolarities,
+    formAuraPolarity,
+    formExilusPolarity,
   } = useMemo(
     () => deriveFormAxis(item, variants, clampedActiveIndex),
     [item, variants, clampedActiveIndex],
+  )
+  // The active form's innate polarities differ per form (Sirius aura Vazarin,
+  // Orion aura Naramon), so the layout, slot grid, and forma/capacity maths use
+  // a polarity-overridden view of the item. Identical reference to `item` for
+  // normal frames — they pay nothing.
+  const effectiveItem = useMemo(
+    () =>
+      isTwin
+        ? {
+            ...item,
+            polarities: formPolarities ?? [],
+            auraPolarity: formAuraPolarity ?? null,
+            exilusPolarity: formExilusPolarity ?? null,
+          }
+        : item,
+    [isTwin, item, formPolarities, formAuraPolarity, formExilusPolarity],
   )
 
   // Slice projected for this variant — feeds the existing slot/arcane
@@ -468,7 +488,10 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
 
   const categoryLabel = getCategoryLabel(category)
 
-  const layout = useMemo(() => getBuildLayout(item, category), [item, category])
+  const layout = useMemo(
+    () => getBuildLayout(effectiveItem, category),
+    [effectiveItem, category],
+  )
   const {
     isCompanion,
     normalSlotCount,
@@ -870,7 +893,14 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     formaCount,
     capacity,
     capacitySharedInputs,
-  } = useBuildDerived({ item, category, layout, slots, allArcanes, hasReactor })
+  } = useBuildDerived({
+    item: effectiveItem,
+    category,
+    layout,
+    slots,
+    allArcanes,
+    hasReactor,
+  })
 
   // Auto-forma planning (cheap reactive plan + heavy preview cascade). Forma is
   // build-wide in Warframe, so the planner considers every variant's slots
@@ -1366,7 +1396,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
           <KeyboardHintBanner />
           <BuildSurface
             mode="edit"
-            item={item}
+            item={effectiveItem}
             category={category}
             isCompanion={isCompanion}
             normalSlotCount={normalSlotCount}

--- a/apps/web/src/components/build-viewer/build-viewer-body.tsx
+++ b/apps/web/src/components/build-viewer/build-viewer-body.tsx
@@ -188,9 +188,27 @@ function BuildViewerBodyInner({
     formNames,
     formVariants,
     formActiveLocalIndex,
+    formPolarities,
+    formAuraPolarity,
+    formExilusPolarity,
   } = useMemo(
     () => deriveFormAxis(item, variants, activeIndex),
     [item, variants, activeIndex],
+  )
+  // Active form's innate polarities differ per form (Sirius aura Vazarin, Orion
+  // aura Naramon); feed a polarity-overridden item to the layout, slot grid,
+  // and forma/capacity maths. Same reference as `item` for normal frames.
+  const effectiveItem = useMemo(
+    () =>
+      isTwin
+        ? {
+            ...item,
+            polarities: formPolarities ?? [],
+            auraPolarity: formAuraPolarity ?? null,
+            exilusPolarity: formExilusPolarity ?? null,
+          }
+        : item,
+    [isTwin, item, formPolarities, formAuraPolarity, formExilusPolarity],
   )
   const selectForm = (formIndex: number) => {
     const target = variants.findIndex((v) => (v.formIndex ?? 0) === formIndex)
@@ -198,7 +216,10 @@ function BuildViewerBodyInner({
   }
 
   const categoryLabel = getCategoryLabel(category)
-  const layout = useMemo(() => getBuildLayout(item, category), [item, category])
+  const layout = useMemo(
+    () => getBuildLayout(effectiveItem, category),
+    [effectiveItem, category],
+  )
   const { isCompanion, normalSlotCount, auraSlotCount, arcaneCount } = layout
 
   const slots = useBuildSlots(normalSlotCount, {
@@ -226,7 +247,7 @@ function BuildViewerBodyInner({
     saved.deploymentContext ?? DEFAULT_DEPLOYMENT_CONTEXT
 
   const { arcaneConfig, totalEndoCost, formaCount, capacity } = useBuildDerived(
-    { item, category, layout, slots, allArcanes, hasReactor },
+    { item: effectiveItem, category, layout, slots, allArcanes, hasReactor },
   )
 
   const sidebarProps = {
@@ -297,7 +318,7 @@ function BuildViewerBodyInner({
         <BuildSurface
           mode="view"
           embed={embed}
-          item={item}
+          item={effectiveItem}
           category={category}
           isCompanion={isCompanion}
           normalSlotCount={normalSlotCount}

--- a/apps/web/src/lib/form-axis.ts
+++ b/apps/web/src/lib/form-axis.ts
@@ -33,6 +33,12 @@ export interface FormAxis {
   formVariants: { v: SavedVariant; globalIndex: number }[]
   /** The active variant's index within `formVariants` (local space). */
   formActiveLocalIndex: number
+  /** The active form's innate polarities, overriding the item's. Forms have
+   *  separate upgrade menus, so each has its own (Sirius aura = Vazarin, Orion
+   *  aura = Naramon). Undefined for normal frames (use the item's directly). */
+  formPolarities: string[] | undefined
+  formAuraPolarity: string | string[] | null | undefined
+  formExilusPolarity: string | null | undefined
 }
 
 export function deriveFormAxis(
@@ -42,13 +48,14 @@ export function deriveFormAxis(
 ): FormAxis {
   const forms = item.forms
   const activeFormIndex = variants[activeIndex]?.formIndex ?? 0
+  const activeForm = forms?.[activeFormIndex]
   const formVariants = variants
     .map((v, globalIndex) => ({ v, globalIndex }))
     .filter(({ v }) => (v.formIndex ?? 0) === activeFormIndex)
   return {
     isTwin: Boolean(forms && forms.length > 1),
     activeFormIndex,
-    formAbilities: forms?.[activeFormIndex]?.abilities,
+    formAbilities: activeForm?.abilities,
     helminthAllowed: activeFormIndex === 0,
     formNames: forms?.map((f) => f.name.split(/\s*&\s*/)[0]),
     formVariants,
@@ -56,5 +63,8 @@ export function deriveFormAxis(
       0,
       formVariants.findIndex((f) => f.globalIndex === activeIndex),
     ),
+    formPolarities: activeForm?.polarities,
+    formAuraPolarity: activeForm?.auraPolarity,
+    formExilusPolarity: activeForm?.exilusPolarity,
   }
 }

--- a/apps/web/src/lib/warframe.ts
+++ b/apps/web/src/lib/warframe.ts
@@ -134,6 +134,12 @@ export interface FrameForm {
   abilities: ItemAbility[]
   passiveDescription?: string
   exalted?: string[]
+  /** Forms have separate upgrade menus, so each has its own innate polarities
+   *  (e.g. Sirius aura = Vazarin, Orion aura = Naramon). Same shape as the
+   *  top-level `DetailItem` polarity fields. */
+  polarities?: string[]
+  auraPolarity?: string | string[] | null
+  exilusPolarity?: string | null
 }
 
 export const CATEGORIES: { id: BrowseCategory; label: string }[] = [

--- a/data/curated/frame-polarities.ts
+++ b/data/curated/frame-polarities.ts
@@ -1,0 +1,34 @@
+/**
+ * Curated per-frame polarity overrides — a stopgap for frames whose wiki
+ * `Module:Warframes/data` entry is missing or incomplete, so our build can't
+ * source polarities from the wiki yet. Values are wiki-verified and keyed by
+ * the cleaned frame name. The wiki always wins when it has data; these only
+ * fill the gaps (see `mergeFrame`).
+ *
+ * Polarity names are lowercase, matching `normalizePolarity` output
+ * ("madurai", "vazarin", "naramon", "zenurik", "unairu", "penjaga", "umbra").
+ *
+ * Sirius & Orion (Update 43) ships as a twin-frame with two switchable forms
+ * that have SEPARATE upgrade menus — including different aura polarities
+ * (verified on wiki.warframe.com/w/Sirius_and_Orion: Sirius aura = Vazarin,
+ * Orion aura = Naramon). The wiki data module hasn't catalogued it yet, so
+ * both DE rows come through unmatched with empty polarities. We curate the
+ * (high-confidence) aura polarities here; the 8 mod-slot polarity positions
+ * aren't curated — they fill in automatically once the wiki module lists them.
+ */
+
+export interface FramePolarityOverride {
+  /** Aura slot polarity (single value, or array for multi-aura frames). */
+  auraPolarity?: string | string[]
+  /** 8 mod-slot polarities, positional. Omit when unknown (don't guess). */
+  polarities?: readonly string[]
+  /** Exilus slot polarity. */
+  exilusPolarity?: string
+}
+
+export const FRAME_POLARITY_OVERRIDES: Record<string, FramePolarityOverride> = {
+  // Sirius controls the primary form (uniqueName .../SiriusSuit).
+  "Sirius & Orion": { auraPolarity: "vazarin" },
+  // Orion is the secondary form (.../OrionSuit), named "Orion & Sirius".
+  "Orion & Sirius": { auraPolarity: "naramon" },
+}

--- a/packages/shared/src/warframe/types.ts
+++ b/packages/shared/src/warframe/types.ts
@@ -58,12 +58,17 @@ export interface Ability {
 }
 
 /** One switchable form of a twin-frame. Mods/auras/arcanes are tracked on the
- *  build (per-variant); only ability-set, passive, and exalted differ here. */
+ *  build (per-variant). Forms have separate upgrade menus in game, so the
+ *  ability-set, passive, exalted, AND polarities differ per form (Sirius aura
+ *  = Vazarin, Orion aura = Naramon). */
 export interface FrameForm {
   name: string
   abilities: Ability[]
   passiveDescription?: string
   exalted?: string[]
+  polarities?: string[]
+  auraPolarity?: string | string[] | null
+  exilusPolarity?: string | null
 }
 
 // Weapon base interface

--- a/scripts/build-items-index.ts
+++ b/scripts/build-items-index.ts
@@ -225,7 +225,11 @@ async function main() {
   const rawFrames: MergedFrame[] = []
   for (const de of deFramesBlob.ExportWarframes) {
     rawFrames.push(
-      mergeFrame(de, { wiki: wikiFramesBlob, unmatched: frameUnmatched }),
+      mergeFrame(de, {
+        wiki: wikiFramesBlob,
+        unmatched: frameUnmatched,
+        polarityOverrides: curated.framePolarities,
+      }),
     )
   }
   // Collapse twin-frames (e.g. Sirius & Orion ships as two DE rows) into one

--- a/scripts/build/merge-frames.ts
+++ b/scripts/build/merge-frames.ts
@@ -14,6 +14,7 @@
  * on each frame entry.
  */
 
+import type { FramePolarityOverride } from "../../data/curated/frame-polarities"
 import { cleanDeName } from "./names"
 import { normalizePolarity, normalizePolarities } from "./polarity"
 import type { DeFrame } from "./read-de"
@@ -27,12 +28,17 @@ interface FrameAbility {
   imageName?: string
 }
 
-/** One switchable form of a twin-frame (e.g. Sirius & Orion). */
+/** One switchable form of a twin-frame (e.g. Sirius & Orion). Forms have
+ *  SEPARATE upgrade menus in game, so each carries its own polarities (Sirius
+ *  aura = Vazarin, Orion aura = Naramon). */
 export interface MergedFrameForm {
   name: string
   abilities: readonly FrameAbility[]
   passiveDescription?: string
   exalted: readonly string[]
+  polarities: readonly string[]
+  auraPolarity: string | string[] | null
+  exilusPolarity: string | null
 }
 
 export interface MergedFrame {
@@ -131,6 +137,9 @@ function findWikiFrame(
 export interface MergeFramesOpts {
   wiki: FrameWikiTable
   unmatched: Set<string>
+  /** Frame name → wiki-verified polarity fallback for frames the wiki data
+   *  module hasn't catalogued yet (e.g. the Sirius & Orion twin-frame). */
+  polarityOverrides?: Record<string, FramePolarityOverride>
 }
 
 /** Build the mod-pool list for a frame.
@@ -167,7 +176,22 @@ export function mergeFrame(de: DeFrame, opts: MergeFramesOpts): MergedFrame {
   const wiki = findWikiFrame(cleanName, opts.wiki)
   if (!wiki) opts.unmatched.add(cleanName)
 
-  const polarities = normalizePolarities(wiki?.Polarities ?? [])
+  // Wiki is authoritative; the curated override only fills gaps for frames the
+  // wiki data module hasn't catalogued yet (e.g. the Sirius & Orion twin-frame,
+  // whose two forms have different aura polarities).
+  const override = opts.polarityOverrides?.[cleanName]
+  const wikiPolarities = normalizePolarities(wiki?.Polarities ?? [])
+  const polarities = wikiPolarities.length
+    ? wikiPolarities
+    : (override?.polarities ?? [])
+  const auraPolarity =
+    normalizeAuraPolarity(wiki?.AuraPolarity) ??
+    (override?.auraPolarity
+      ? normalizeAuraPolarity(override.auraPolarity)
+      : null)
+  const exilusPolarity =
+    normalizePolarity(wiki?.ExilusPolarity) ??
+    normalizePolarity(override?.exilusPolarity)
   const category = categoryOf(de.productCategory)
 
   return {
@@ -194,8 +218,8 @@ export function mergeFrame(de: DeFrame, opts: MergeFramesOpts): MergedFrame {
       imageName: a.imageName,
     })),
     polarities,
-    auraPolarity: normalizeAuraPolarity(wiki?.AuraPolarity),
-    exilusPolarity: normalizePolarity(wiki?.ExilusPolarity),
+    auraPolarity,
+    exilusPolarity,
     isPrime: cleanName.includes(" Prime"),
   }
 }
@@ -219,6 +243,9 @@ function toForm(f: MergedFrame): MergedFrameForm {
     abilities: f.abilities,
     passiveDescription: f.passiveDescription,
     exalted: f.exalted,
+    polarities: f.polarities,
+    auraPolarity: f.auraPolarity,
+    exilusPolarity: f.exilusPolarity,
   }
 }
 

--- a/scripts/build/read-curated.ts
+++ b/scripts/build/read-curated.ts
@@ -7,11 +7,18 @@
  * to know which file each curated table lives in.
  */
 
-import { CLASS_DEFAULT_POOLS, ALL_MENTIONED_POOLS } from "../../data/curated/class-pools"
+import {
+  CLASS_DEFAULT_POOLS,
+  ALL_MENTIONED_POOLS,
+} from "../../data/curated/class-pools"
 import {
   EXALTED_STANCES,
   type ExaltedStance,
 } from "../../data/curated/exalted-stances"
+import {
+  FRAME_POLARITY_OVERRIDES,
+  type FramePolarityOverride,
+} from "../../data/curated/frame-polarities"
 import { MOD_POOL_OVERRIDES } from "../../data/curated/mod-pools"
 import { PLEXUS_BROWSE_ITEM, PLEXUS_DETAIL } from "../../data/curated/plexus"
 import {
@@ -34,6 +41,9 @@ export interface CuratedData {
   releaseHistory: Record<string, ReleaseHistoryEntry>
   /** Weapon name → permanently-installed exalted stance (locked slot). */
   exaltedStances: Record<string, ExaltedStance>
+  /** Frame name → wiki-verified polarity fallback (for frames the wiki data
+   *  module hasn't catalogued yet). The wiki wins when it has data. */
+  framePolarities: Record<string, FramePolarityOverride>
 }
 
 export function readCurated(): CuratedData {
@@ -47,5 +57,6 @@ export function readCurated(): CuratedData {
     plexusDetail: PLEXUS_DETAIL,
     releaseHistory: RELEASE_HISTORY,
     exaltedStances: EXALTED_STANCES,
+    framePolarities: FRAME_POLARITY_OVERRIDES,
   }
 }


### PR DESCRIPTION
## Summary

You flagged that Sirius & Orion's polarities don't behave right. I checked the wiki (twice) and the answer flips the framing: the two forms have **separate upgrade menus** and **different aura polarities** — **Sirius = Vazarin, Orion = Naramon** — so polarities are genuinely *per-form*, not shared. (Only Archon Shards & Decrees are shared between the forms.) You picked the **per-form (wiki-correct)** direction.

The underlying bug: the frame is currently **wiki-unmatched** (the wiki *data module* hasn't catalogued it, even though the web page exists), so it shipped with **no polarity data at all** — and `collapseTwinFrames` was giving both forms the primary's polarities anyway. This PR fixes that.

## What changed

**Data**
- `MergedFrameForm` now carries its own `polarities` / `auraPolarity` / `exilusPolarity`; `collapseTwinFrames` preserves each form's via `toForm`.
- New curated fallback [`data/curated/frame-polarities.ts`](data/curated/frame-polarities.ts) supplies the **aura polarities** (Sirius Vazarin, Orion Naramon) until the wiki module catalogues the frame. **Wiki always wins** when it has data. The 8 mod-slot polarity *positions* are **not** curated — I won't guess them; they fill in automatically from the wiki later.

**Web**
- `FrameForm` (shared + web types) gains the polarity fields.
- `deriveFormAxis` exposes the active form's polarities; the editor and viewer build a polarity-overridden `effectiveItem` fed to `getBuildLayout`, `useBuildDerived`, and `BuildSurface`, so the slot grid, aura slot, and forma/capacity maths use the **active form's** polarities. **Identical reference to `item` for normal frames** → zero impact off the twin-frame path. Degrades gracefully (no aura shown) until the data carries per-form polarities.

## Scope / follow-up
This makes the **innate** polarities per-form (Orion now shows its Naramon aura). Independent per-form **forma editing** — where user-applied forma on Sirius doesn't leak to Orion — is a separate, larger change (it touches the persisted build schema + codec golden tests), so it's a tracked **follow-up PR**, ideally with runtime verification.

## Verification
- `bun run typecheck` clean (web / api / shared / scripts)
- `bun run build:items` emits per-form aura polarities (Sirius `vazarin`, Orion `naramon`); top-level mirrors the primary
- Tests: web (120), shared (103), build-pipeline (41) all pass
- `bun run check:images` ✓ — **no catalog changes in this PR**

## 🚀 Rollout
Same two-step as the twin-frame PR: **merge this**, then run the **Update Warframe Data** workflow so the catalog regenerates with the per-form polarities (and synced images). The web code reads the new per-form fields the moment the data carries them.