### PR TITLE
feat: twin-frame per-form shards + polarities (+ edge-cache build pages)

### DIFF
--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -83,8 +83,17 @@ export function variantsOverCap(buildData: unknown): boolean {
 
 function hasShardsInBuildData(buildData: unknown): boolean {
   if (!buildData || typeof buildData !== "object") return false
-  const shards = (buildData as Record<string, unknown>).shards
-  return Array.isArray(shards) && shards.some((s) => s != null)
+  const data = buildData as Record<string, unknown>
+  const anyPlaced = (v: unknown): boolean =>
+    Array.isArray(v) && v.some((s) => s != null)
+  if (anyPlaced(data.shards)) return true
+  // Twin-frames (Sirius & Orion) store each form's shards in `formShards`
+  // (keyed by form index); a half can carry shards while form 0 is empty.
+  const formShards = data.formShards
+  if (formShards && typeof formShards === "object") {
+    return Object.values(formShards as Record<string, unknown>).some(anyPlaced)
+  }
+  return false
 }
 
 const MAX_CATALOG_VERSION = 64

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -414,15 +414,35 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   // strip and tabs immediately. Shared with the viewer via `deriveFormAxis`;
   // no-op for normal frames (activeFormIndex 0, formVariants = all variants).
   const {
+    isTwin,
     activeFormIndex,
     formAbilities,
     helminthAllowed,
     formNames,
     formVariants,
     formActiveLocalIndex,
+    formPolarities,
+    formAuraPolarity,
+    formExilusPolarity,
   } = useMemo(
     () => deriveFormAxis(item, variants, clampedActiveIndex),
     [item, variants, clampedActiveIndex],
+  )
+  // The active form's innate polarities differ per form (Sirius aura Vazarin,
+  // Orion aura Naramon), so the layout, slot grid, and forma/capacity maths use
+  // a polarity-overridden view of the item. Identical reference to `item` for
+  // normal frames — they pay nothing.
+  const effectiveItem = useMemo(
+    () =>
+      isTwin
+        ? {
+            ...item,
+            polarities: formPolarities ?? [],
+            auraPolarity: formAuraPolarity ?? null,
+            exilusPolarity: formExilusPolarity ?? null,
+          }
+        : item,
+    [isTwin, item, formPolarities, formAuraPolarity, formExilusPolarity],
   )
 
   // Slice projected for this variant — feeds the existing slot/arcane
@@ -479,7 +499,10 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
 
   const categoryLabel = getCategoryLabel(category)
 
-  const layout = useMemo(() => getBuildLayout(item, category), [item, category])
+  const layout = useMemo(
+    () => getBuildLayout(effectiveItem, category),
+    [effectiveItem, category],
+  )
   const {
     isCompanion,
     normalSlotCount,
@@ -931,7 +954,14 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     formaCount,
     capacity,
     capacitySharedInputs,
-  } = useBuildDerived({ item, category, layout, slots, allArcanes, hasReactor })
+  } = useBuildDerived({
+    item: effectiveItem,
+    category,
+    layout,
+    slots,
+    allArcanes,
+    hasReactor,
+  })
 
   // Auto-forma planning (cheap reactive plan + heavy preview cascade). Forma is
   // build-wide in Warframe, so the planner considers every variant's slots
@@ -1433,7 +1463,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
           <KeyboardHintBanner />
           <BuildSurface
             mode="edit"
-            item={item}
+            item={effectiveItem}
             category={category}
             isCompanion={isCompanion}
             normalSlotCount={normalSlotCount}

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -63,7 +63,7 @@ import {
   saveEditorDraft,
   type EditorDraftPayload,
 } from "@/lib/editor-draft"
-import { deriveFormAxis } from "@/lib/form-axis"
+import { applyFormPolarities, deriveFormAxis } from "@/lib/form-axis"
 import { collectGuideRefs } from "@/lib/guide-refs"
 import { useHotkey } from "@/lib/hooks/hotkeys"
 import { consumeDraft } from "@/lib/import-draft"
@@ -428,20 +428,16 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     () => deriveFormAxis(item, variants, clampedActiveIndex),
     [item, variants, clampedActiveIndex],
   )
-  // The active form's innate polarities differ per form (Sirius aura Vazarin,
-  // Orion aura Naramon), so the layout, slot grid, and forma/capacity maths use
-  // a polarity-overridden view of the item. Identical reference to `item` for
-  // normal frames — they pay nothing.
+  // Polarity-overridden view of the item (active form's innate polarities) for
+  // the layout, slot grid, and forma/capacity maths — see `applyFormPolarities`.
   const effectiveItem = useMemo(
     () =>
-      isTwin
-        ? {
-            ...item,
-            polarities: formPolarities ?? [],
-            auraPolarity: formAuraPolarity ?? null,
-            exilusPolarity: formExilusPolarity ?? null,
-          }
-        : item,
+      applyFormPolarities(item, {
+        isTwin,
+        formPolarities,
+        formAuraPolarity,
+        formExilusPolarity,
+      }),
     [isTwin, item, formPolarities, formAuraPolarity, formExilusPolarity],
   )
 

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -52,6 +52,7 @@ import {
   pickPerVariantData,
   savedDataToBuildState,
   selectVariant,
+  shardsForFormSaved,
   stripPersistedImages,
   SYNTHETIC_VARIANT_ID,
   SYNTHETIC_VARIANT_LABEL,
@@ -132,7 +133,11 @@ import { useVariantActions } from "./use-variant-actions"
 
 type SharedEditorOverrides = {
   hasReactor?: boolean
-  shards?: (PlacedShard | null)[]
+  /** Per-form Archon Shards, keyed by form index. Twin-frames (Sirius & Orion)
+   *  give each form ("half") its own set; normal frames only ever use index 0.
+   *  Holds every form so the inactive half's shards survive the remount that a
+   *  form switch triggers (the live `shards` state only edits the active one). */
+  formShards?: Record<number, (PlacedShard | null)[]>
   zawComponents?: { grip: string; link: string } | undefined
   kitgunComponents?: KitgunComponents | undefined
   lichBonusElement?: LichBonusElement | null
@@ -257,9 +262,15 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       )
       // `formIndex` isn't carried through BuildState, so lift it off the
       // decoded variant directly onto the top-level mirror (and each variant).
+      // Shards/formShards come straight off the doc (canonical: form 0 in
+      // `shards`, twin-frame halves in `formShards`) rather than from the
+      // active variant's projection, so a share link opened on Orion still
+      // hydrates Sirius's shards too.
       const withForm = {
         ...activeData,
         formIndex: doc.variants[activeIdx].formIndex,
+        shards: doc.shardSlots,
+        formShards: doc.formShardSlots,
       }
       if (doc.variants.length === 1) return { data: withForm }
       const savedVariants: SavedVariant[] = doc.variants.map((v, i) => {
@@ -610,8 +621,30 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   const [hasReactor, setHasReactor] = useState(
     () => cachedShared?.hasReactor ?? savedData.hasReactor ?? true,
   )
+
+  // Shards are per-form ("half") on twin-frames. The base map seeds every
+  // form's shards from the saved build once at mount; the live `shards` state
+  // below edits only the active form, and the cache holds the rest so they
+  // survive the remount a form switch triggers. Mount-frozen like `savedData`
+  // (EditorShell re-keys on variant/form switch — see savedData's note).
+  const initialFormShards = useMemo<Record<number, (PlacedShard | null)[]>>(
+    () => {
+      const forms = item.forms
+      const formCount = forms && forms.length > 1 ? forms.length : 1
+      const map: Record<number, (PlacedShard | null)[]> = {}
+      for (let i = 0; i < formCount; i++) {
+        map[i] = padShards(shardsForFormSaved(savedDataAll, i))
+      }
+      return map
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
   const [shards, setShards] = useState<(PlacedShard | null)[]>(
-    () => cachedShared?.shards ?? padShards(savedData.shards),
+    () =>
+      cachedShared?.formShards?.[activeFormIndex] ??
+      initialFormShards[activeFormIndex] ??
+      padShards(undefined),
   )
   const setShard = (i: number, s: PlacedShard | null) => {
     setShards((prev) => {
@@ -619,6 +652,32 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       next[i] = s
       return next
     })
+  }
+  // The active form's live edits overlaid on every other form's set — the
+  // single source for persisting/sharing shards. Always overlays the live
+  // `shards` so a capture that races ahead of the sync effect still sees it.
+  const collectFormShards = (): Record<number, (PlacedShard | null)[]> => ({
+    ...initialFormShards,
+    ...(cachedShared?.formShards ?? {}),
+    [activeFormIndex]: shards,
+  })
+  // Split the per-form map into the wire/DB shape: form 0 in `shards`,
+  // twin-frame halves (non-empty only) in `formShards`.
+  const splitFormShards = (): {
+    shards: (PlacedShard | null)[]
+    formShards?: Record<number, (PlacedShard | null)[]>
+  } => {
+    const all = collectFormShards()
+    const formShards: Record<number, (PlacedShard | null)[]> = {}
+    for (const [key, slots] of Object.entries(all)) {
+      const idx = Number(key)
+      if (idx === 0) continue
+      if (slots.some((s) => s !== null)) formShards[idx] = slots
+    }
+    return {
+      shards: all[0] ?? [],
+      ...(Object.keys(formShards).length > 0 && { formShards }),
+    }
   }
 
   const riven = useRivenDialog({ slots, normalSlotCount, category })
@@ -730,7 +789,9 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   useEffect(() => {
     writeShared({
       hasReactor,
-      shards,
+      // Persist every form's shards so switching halves doesn't drop the
+      // inactive one; the active form mirrors the live `shards` state.
+      formShards: collectFormShards(),
       zawComponents,
       kitgunComponents,
       lichBonusElement,
@@ -926,13 +987,18 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       // fields from `state`, per-variant data from the in-memory variants
       // array (with the active variant's slice replaced by the live
       // editor state so unsaved tweaks make it into the share URL).
+      // Per-form shards: form 0 is canonical (`shardSlots`); twin-frame halves
+      // ride along in `formShardSlots`. `state.shardSlots` is only the active
+      // form, so derive both from the full per-form map instead.
+      const sharded = splitFormShards()
       const doc: BuildDoc = {
         itemUniqueName: state.itemUniqueName,
         itemName: state.itemName,
         itemCategory: state.itemCategory,
         itemImageName: state.itemImageName,
         hasReactor: state.hasReactor,
-        shardSlots: state.shardSlots,
+        shardSlots: sharded.shards,
+        formShardSlots: sharded.formShards,
         helminthAbility: state.helminthAbility,
         zawComponents: state.zawComponents,
         kitgunComponents: state.kitgunComponents,
@@ -1204,7 +1270,8 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       slots: slots.placed,
       formaPolarities: slots.formaPolarities,
       arcanes: arcanes.placed,
-      shards,
+      // Per-form: form 0 in `shards`, twin-frame halves in `formShards`.
+      ...splitFormShards(),
       hasReactor,
       helminth,
       zawComponents,

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -648,8 +648,8 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
   // (EditorShell re-keys on variant/form switch — see savedData's note).
   const initialFormShards = useMemo<Record<number, (PlacedShard | null)[]>>(
     () => {
-      const forms = item.forms
-      const formCount = forms && forms.length > 1 ? forms.length : 1
+      // Reuse the twin signal from deriveFormAxis rather than re-deriving it.
+      const formCount = isTwin && item.forms ? item.forms.length : 1
       const map: Record<number, (PlacedShard | null)[]> = {}
       for (let i = 0; i < formCount; i++) {
         map[i] = padShards(shardsForFormSaved(savedDataAll, i))

--- a/apps/web/src/components/build-viewer/build-viewer-body.tsx
+++ b/apps/web/src/components/build-viewer/build-viewer-body.tsx
@@ -25,7 +25,7 @@ import {
   refreshImagesFromMap,
   selectVariant,
 } from "@/lib/codec/build-codec-adapter"
-import { deriveFormAxis } from "@/lib/form-axis"
+import { applyFormPolarities, deriveFormAxis } from "@/lib/form-axis"
 import { makeRefResolver } from "@/lib/guide-refs"
 import { arcanesQuery } from "@/lib/queries/arcanes-query"
 import { type BuildDetail, hasGuideContent } from "@/lib/queries/build-query"
@@ -195,19 +195,16 @@ function BuildViewerBodyInner({
     () => deriveFormAxis(item, variants, activeIndex),
     [item, variants, activeIndex],
   )
-  // Active form's innate polarities differ per form (Sirius aura Vazarin, Orion
-  // aura Naramon); feed a polarity-overridden item to the layout, slot grid,
-  // and forma/capacity maths. Same reference as `item` for normal frames.
+  // Polarity-overridden view of the item (active form's innate polarities) for
+  // the layout, slot grid, and forma/capacity maths — see `applyFormPolarities`.
   const effectiveItem = useMemo(
     () =>
-      isTwin
-        ? {
-            ...item,
-            polarities: formPolarities ?? [],
-            auraPolarity: formAuraPolarity ?? null,
-            exilusPolarity: formExilusPolarity ?? null,
-          }
-        : item,
+      applyFormPolarities(item, {
+        isTwin,
+        formPolarities,
+        formAuraPolarity,
+        formExilusPolarity,
+      }),
     [isTwin, item, formPolarities, formAuraPolarity, formExilusPolarity],
   )
   const selectForm = (formIndex: number) => {

--- a/apps/web/src/components/build-viewer/build-viewer-body.tsx
+++ b/apps/web/src/components/build-viewer/build-viewer-body.tsx
@@ -188,9 +188,27 @@ function BuildViewerBodyInner({
     formNames,
     formVariants,
     formActiveLocalIndex,
+    formPolarities,
+    formAuraPolarity,
+    formExilusPolarity,
   } = useMemo(
     () => deriveFormAxis(item, variants, activeIndex),
     [item, variants, activeIndex],
+  )
+  // Active form's innate polarities differ per form (Sirius aura Vazarin, Orion
+  // aura Naramon); feed a polarity-overridden item to the layout, slot grid,
+  // and forma/capacity maths. Same reference as `item` for normal frames.
+  const effectiveItem = useMemo(
+    () =>
+      isTwin
+        ? {
+            ...item,
+            polarities: formPolarities ?? [],
+            auraPolarity: formAuraPolarity ?? null,
+            exilusPolarity: formExilusPolarity ?? null,
+          }
+        : item,
+    [isTwin, item, formPolarities, formAuraPolarity, formExilusPolarity],
   )
   const selectForm = (formIndex: number) => {
     const target = variants.findIndex((v) => (v.formIndex ?? 0) === formIndex)
@@ -198,7 +216,10 @@ function BuildViewerBodyInner({
   }
 
   const categoryLabel = getCategoryLabel(category)
-  const layout = useMemo(() => getBuildLayout(item, category), [item, category])
+  const layout = useMemo(
+    () => getBuildLayout(effectiveItem, category),
+    [effectiveItem, category],
+  )
   const { isCompanion, normalSlotCount, auraSlotCount, arcaneCount } = layout
 
   const slots = useBuildSlots(normalSlotCount, {
@@ -226,7 +247,7 @@ function BuildViewerBodyInner({
     saved.deploymentContext ?? DEFAULT_DEPLOYMENT_CONTEXT
 
   const { arcaneConfig, totalEndoCost, formaCount, capacity } = useBuildDerived(
-    { item, category, layout, slots, allArcanes, hasReactor },
+    { item: effectiveItem, category, layout, slots, allArcanes, hasReactor },
   )
 
   const sidebarProps = {
@@ -297,7 +318,7 @@ function BuildViewerBodyInner({
         <BuildSurface
           mode="view"
           embed={embed}
-          item={item}
+          item={effectiveItem}
           category={category}
           isCompanion={isCompanion}
           normalSlotCount={normalSlotCount}

--- a/apps/web/src/lib/codec/build-codec-adapter.ts
+++ b/apps/web/src/lib/codec/build-codec-adapter.ts
@@ -543,10 +543,26 @@ export function getVariants(data: SavedBuildData): SavedVariant[] {
 }
 
 /**
+ * Resolve a form's Archon Shard set from saved build data. Form 0 (and every
+ * normal frame) reads the canonical `shards`; twin-frame forms ≥ 1 read their
+ * own slice of `formShards`, defaulting to empty so each "half" is independent.
+ * Mirrors `shardsForForm` (build-doc.ts) for the SavedBuildData shape.
+ */
+export function shardsForFormSaved(
+  data: Pick<SavedBuildData, "shards" | "formShards">,
+  formIndex: number,
+): (PlacedShard | null)[] {
+  if (formIndex === 0) return data.shards ?? []
+  return data.formShards?.[formIndex] ?? []
+}
+
+/**
  * Project a single variant back into a `SavedBuildData` shape that the
- * existing viewer/editor pipelines consume unchanged. Shared fields
- * (shards, forma, reactor, helminth, lich, zaw, name) come from the
- * top-level doc; per-variant fields override.
+ * existing viewer/editor pipelines consume unchanged. Build-wide fields
+ * (forma, reactor, helminth, lich, zaw, name) come from the top-level doc;
+ * per-variant fields override. Shards follow the variant's form ("half"):
+ * `.shards` is resolved to that form's set so the viewer renders the right
+ * shards on a twin-frame, and is a no-op for normal frames.
  */
 export function selectVariant(
   data: SavedBuildData,
@@ -570,8 +586,9 @@ export function selectVariant(
     slots: v.slots,
     arcanes: v.arcanes,
     ...pickPerVariantData(v),
-    // formaPolarities, shards, hasReactor, zaw, kitgun, lich, buildName are
-    // shared across variants and stay as-is.
+    // Resolve shards to the variant's form. formaPolarities, hasReactor, zaw,
+    // kitgun, lich, buildName are shared across variants and stay as-is.
+    shards: shardsForFormSaved(data, v.formIndex ?? 0),
   }
 }
 

--- a/apps/web/src/lib/form-axis.ts
+++ b/apps/web/src/lib/form-axis.ts
@@ -33,6 +33,12 @@ export interface FormAxis {
   formVariants: { v: SavedVariant; globalIndex: number }[]
   /** The active variant's index within `formVariants` (local space). */
   formActiveLocalIndex: number
+  /** The active form's innate polarities, overriding the item's. Forms have
+   *  separate upgrade menus, so each has its own (Sirius aura = Vazarin, Orion
+   *  aura = Naramon). Undefined for normal frames (use the item's directly). */
+  formPolarities: string[] | undefined
+  formAuraPolarity: string | string[] | null | undefined
+  formExilusPolarity: string | null | undefined
 }
 
 export function deriveFormAxis(
@@ -42,13 +48,14 @@ export function deriveFormAxis(
 ): FormAxis {
   const forms = item.forms
   const activeFormIndex = variants[activeIndex]?.formIndex ?? 0
+  const activeForm = forms?.[activeFormIndex]
   const formVariants = variants
     .map((v, globalIndex) => ({ v, globalIndex }))
     .filter(({ v }) => (v.formIndex ?? 0) === activeFormIndex)
   return {
     isTwin: Boolean(forms && forms.length > 1),
     activeFormIndex,
-    formAbilities: forms?.[activeFormIndex]?.abilities,
+    formAbilities: activeForm?.abilities,
     helminthAllowed: activeFormIndex === 0,
     formNames: forms?.map((f) => f.name.split(/\s*&\s*/)[0]),
     formVariants,
@@ -56,5 +63,8 @@ export function deriveFormAxis(
       0,
       formVariants.findIndex((f) => f.globalIndex === activeIndex),
     ),
+    formPolarities: activeForm?.polarities,
+    formAuraPolarity: activeForm?.auraPolarity,
+    formExilusPolarity: activeForm?.exilusPolarity,
   }
 }

--- a/apps/web/src/lib/form-axis.ts
+++ b/apps/web/src/lib/form-axis.ts
@@ -41,6 +41,37 @@ export interface FormAxis {
   formExilusPolarity: string | null | undefined
 }
 
+/** Item fields a form's innate polarities override. */
+type ItemPolarityFields = {
+  polarities?: string[]
+  auraPolarity?: string | string[] | null
+  exilusPolarity?: string | null
+}
+
+/**
+ * Overlay the active form's innate polarities onto an item so the layout, slot
+ * grid, and forma/capacity maths use the right ones. Twin-frame forms have
+ * separate upgrade menus (Sirius aura = Vazarin, Orion aura = Naramon), so each
+ * renders its own; a half with none falls back to empty (never the other
+ * half's). Returns the same `item` reference for normal frames — they pay
+ * nothing. Single source for the overlay shared by the editor and the viewer.
+ */
+export function applyFormPolarities<T extends ItemPolarityFields>(
+  item: T,
+  axis: Pick<
+    FormAxis,
+    "isTwin" | "formPolarities" | "formAuraPolarity" | "formExilusPolarity"
+  >,
+): T {
+  if (!axis.isTwin) return item
+  return {
+    ...item,
+    polarities: axis.formPolarities ?? [],
+    auraPolarity: axis.formAuraPolarity ?? null,
+    exilusPolarity: axis.formExilusPolarity ?? null,
+  } as T
+}
+
 export function deriveFormAxis(
   item: { forms?: FrameForm[] },
   variants: SavedVariant[],

--- a/apps/web/src/lib/queries/build-query.ts
+++ b/apps/web/src/lib/queries/build-query.ts
@@ -46,7 +46,13 @@ export type SavedBuildData = {
   slots?: Partial<Record<SlotId, PlacedMod>>
   formaPolarities?: Partial<Record<SlotId, Polarity>>
   arcanes?: (PlacedArcane | null)[]
+  /** Primary form's (form 0) Archon Shards — the only shard set for normal
+   *  frames. Twin-frame forms ≥ 1 store theirs in `formShards`. */
   shards?: (PlacedShard | null)[]
+  /** Twin-frames (Sirius & Orion): per-form shards for forms ≥ 1, keyed by
+   *  form index. Build-wide like `shards` (not per-variant), so it lives at the
+   *  top level — not in `SavedVariant`/`PerVariantDataField`. */
+  formShards?: Record<number, (PlacedShard | null)[]>
   hasReactor?: boolean
   helminth?: Record<number, HelminthAbility>
   zawComponents?: { grip: string; link: string }

--- a/apps/web/src/lib/warframe.ts
+++ b/apps/web/src/lib/warframe.ts
@@ -134,6 +134,12 @@ export interface FrameForm {
   abilities: ItemAbility[]
   passiveDescription?: string
   exalted?: string[]
+  /** Forms have separate upgrade menus, so each has its own innate polarities
+   *  (e.g. Sirius aura = Vazarin, Orion aura = Naramon). Same shape as the
+   *  top-level `DetailItem` polarity fields. */
+  polarities?: string[]
+  auraPolarity?: string | string[] | null
+  exilusPolarity?: string | null
 }
 
 export const CATEGORIES: { id: BrowseCategory; label: string }[] = [

--- a/apps/web/worker/index.test.ts
+++ b/apps/web/worker/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { buildPageCacheKeyUrl } from "./index"
+
+// The worker itself is bundled by wrangler (not Vite) and lives outside the
+// typecheck/lint graph, so this covers only the pure cache-key logic — the two
+// invariants whose regression would be expensive: a deploy serving a stale
+// asset shell (white screen), or one hot slug fragmenting across tracking-param
+// variants. The actual cache hit/miss/store path needs a Workers runtime and is
+// intentionally not exercised here.
+describe("buildPageCacheKeyUrl", () => {
+  const url = new URL("https://www.arsenyx.com/builds/wPDrEvV3Wf")
+
+  it("namespaces the key by the deploy version so a deploy starts fresh", () => {
+    const a = buildPageCacheKeyUrl(url, "v1")
+    const b = buildPageCacheKeyUrl(url, "v2")
+    expect(a).not.toBe(b)
+    expect(a).toContain("__v=v1")
+  })
+
+  it("drops the query string so tracking params don't fragment the hot slug", () => {
+    const tracked = new URL(
+      "https://www.arsenyx.com/builds/wPDrEvV3Wf?utm_source=x&fbclid=y",
+    )
+    expect(buildPageCacheKeyUrl(tracked, "v1")).toBe(
+      buildPageCacheKeyUrl(url, "v1"),
+    )
+  })
+
+  it("falls back to a 'dev' namespace when no version is bound", () => {
+    expect(buildPageCacheKeyUrl(url, undefined)).toContain("__v=dev")
+  })
+
+  it("URL-encodes the version so an odd id can't corrupt the key", () => {
+    expect(buildPageCacheKeyUrl(url, "a b/c")).toContain("__v=a%20b%2Fc")
+  })
+})

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -21,6 +21,11 @@ import { buildMetaTitle, buildOgType } from "@arsenyx/shared/seo/build-meta"
 
 interface Env {
   ASSETS: { fetch: (request: Request) => Promise<Response> }
+  // Per-deploy version metadata (wrangler [version_metadata] binding). Its `id`
+  // changes on every deploy; we mix it into the build-page cache key so a deploy
+  // starts a fresh cache namespace (see handleBuildPage). Optional so local /
+  // dry-run runs without the binding still type-check.
+  CF_VERSION_METADATA?: { id: string }
 }
 
 // Minimal shape of the Workers ExecutionContext — we only use waitUntil, to let
@@ -216,8 +221,18 @@ async function handleBuildPage(
   // visitor — safe to share across users. The key drops the query string so
   // tracking params (utm_*, fbclid, …) don't fragment the one hot slug; the
   // ?embed=1 variant already returned above, so it never reaches this key.
+  //
+  // The key is namespaced by the deploy version: the cached shell embeds this
+  // deploy's hashed /assets/*.js tags, which rotate on the next deploy and then
+  // 404 → SPA-fallback HTML (white screen). The per-colo Cache API survives
+  // deploys, so without this a warm colo would serve the pre-deploy shell for
+  // the whole TTL; a new version id orphans old entries (never matched again)
+  // and they age out by TTL.
   const cache = edgeCache()
-  const cacheKey = new Request(url.origin + url.pathname)
+  const version = env.CF_VERSION_METADATA?.id ?? "dev"
+  const cacheKey = new Request(
+    `${url.origin}${url.pathname}?__v=${encodeURIComponent(version)}`,
+  )
   if (cache) {
     const hit = await cache.match(cacheKey)
     if (hit) return hit

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -51,6 +51,13 @@ const MAX_SLUG_LENGTH = 64
 // refetches client-side). Lower this if meta freshness matters more than hit rate.
 const BUILD_HTML_TTL = 300
 
+// TTL for the anonymous API meta subrequest — the cold-miss shield behind the
+// HTML cache above. Kept short and decoupled from BUILD_HTML_TTL so the two
+// caches don't compound: a freshly-written HTML entry carries meta at most this
+// stale, bounding worst-case staleness to ~BUILD_HTML_TTL + BUILD_META_TTL
+// rather than 2×BUILD_HTML_TTL.
+const BUILD_META_TTL = 60
+
 // Sync with CATEGORIES in src/lib/warframe.ts.
 const CATEGORY_LABELS: Record<string, string> = {
   warframes: "Warframes",
@@ -297,11 +304,12 @@ async function fetchBuild(
         // Per-status TTL rather than a blanket cacheTtl: never cache a 5xx (a
         // transient API blip would otherwise pin a degraded shell for the whole
         // window), briefly cache 404s to blunt dead-link hammering, and cache
-        // good meta for the same window as the rendered HTML.
+        // good meta only briefly — this is the cold-miss shield behind the HTML
+        // cache, kept short (BUILD_META_TTL) so the two TTLs don't compound.
         cf: {
           cacheEverything: true,
           cacheTtlByStatus: {
-            "200-299": BUILD_HTML_TTL,
+            "200-299": BUILD_META_TTL,
             "404": 10,
             "500-599": 0,
           },
@@ -519,7 +527,14 @@ function cacheStore(
 ): Response {
   const out = new Response(res.body, res)
   out.headers.delete("set-cookie")
-  out.headers.set("cache-control", `public, s-maxage=${BUILD_HTML_TTL}`)
+  // max-age=0 + must-revalidate keeps browsers revalidating every navigation
+  // (so a fresh Worker run picks up updated meta), while s-maxage lets the
+  // shared per-colo Cache API serve the entry for the TTL. Without max-age a
+  // browser could heuristically cache the shell and pin stale <head> meta.
+  out.headers.set(
+    "cache-control",
+    `public, max-age=0, s-maxage=${BUILD_HTML_TTL}, must-revalidate`,
+  )
   ctx.waitUntil(cache.put(key, out.clone()))
   return out
 }

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -223,6 +223,12 @@ async function handleBuildPage(
     if (hit) return hit
   }
 
+  // Kick off the OG image-map fetch up front so it overlaps the asset + API
+  // fetches below; only the PUBLIC branch awaits it. fetchImageMap never
+  // rejects (returns null on error), so the not-found / non-public early
+  // returns can leave it unawaited safely.
+  const imageMapPromise = fetchImageMap(env, url)
+
   // Workers Static Assets redirects `/index.html` → `/` by default
   // (html_handling), so we ask for the original path and let the SPA
   // fallback (`not_found_handling = "single-page-application"`) serve
@@ -257,12 +263,13 @@ async function handleBuildPage(
     return rewriteMeta(shellRes, { noindex: true })
   }
 
-  // Builds persist a denormalized item imageName that rots across
-  // image-scheme changes (see scripts/sync-images.ts). Re-resolve the OG
-  // image by the item's stable uniqueName against the same image-map.json the
-  // SPA uses, falling back to the stored value on a miss.
-  const imageMap = await fetchImageMap(env, url)
-  const res = rewriteMeta(shellRes, buildMeta(build, slug, imageMap))
+  // Re-resolve the OG image by the item's stable uniqueName (the denormalized
+  // build imageName rots across image-scheme changes — see sync-images.ts),
+  // awaiting the map kicked off above; falls back to the stored value on a miss.
+  const res = rewriteMeta(
+    shellRes,
+    buildMeta(build, slug, await imageMapPromise),
+  )
 
   // Only the fully-enriched PUBLIC HTML is cached. 404s, API-error fallbacks,
   // and private/unlisted shells are left uncached so a transient blip or a

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -229,9 +229,8 @@ async function handleBuildPage(
   // the whole TTL; a new version id orphans old entries (never matched again)
   // and they age out by TTL.
   const cache = edgeCache()
-  const version = env.CF_VERSION_METADATA?.id ?? "dev"
   const cacheKey = new Request(
-    `${url.origin}${url.pathname}?__v=${encodeURIComponent(version)}`,
+    buildPageCacheKeyUrl(url, env.CF_VERSION_METADATA?.id),
   )
   if (cache) {
     const hit = await cache.match(cacheKey)
@@ -526,6 +525,21 @@ function stripTrailingSlash(pathname: string): string {
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+// Cache key URL for a build page's rendered shell. Two invariants, both
+// load-bearing (see handleBuildPage's cache comment + tests in index.test.ts):
+//   - drops the query string, so tracking params (utm_*, fbclid, …) can't
+//     fragment the one hot slug across many cache entries;
+//   - namespaces by the deploy version, so a deploy starts a fresh namespace —
+//     the cached shell embeds this deploy's hashed /assets/*.js, which 404 after
+//     the next deploy. Falls back to "dev" when the binding is absent.
+// Exported for unit tests; the synthetic `?__v=` is only ever a cache key.
+export function buildPageCacheKeyUrl(
+  url: URL,
+  version: string | undefined,
+): string {
+  return `${url.origin}${url.pathname}?__v=${encodeURIComponent(version ?? "dev")}`
+}
 
 // Per-colo Cache API handle. `caches.default` is a workerd global; we cast it
 // the same way we cast HTMLRewriter rather than pulling in the full CF types.

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -23,6 +23,13 @@ interface Env {
   ASSETS: { fetch: (request: Request) => Promise<Response> }
 }
 
+// Minimal shape of the Workers ExecutionContext — we only use waitUntil, to let
+// a cache write finish after the response has been returned. (The full
+// @cloudflare types aren't a dep of apps/web; this file is bundled by wrangler.)
+interface ExecutionCtx {
+  waitUntil(promise: Promise<unknown>): void
+}
+
 const API_BASE = "https://api.arsenyx.com"
 const SITE_URL = "https://www.arsenyx.com"
 const SITE_NAME = "Arsenyx"
@@ -34,6 +41,15 @@ const RESERVED_BUILD_SUBPATHS = new Set(["mine", "bookmarks", "new"])
 // upper bound that still cheaply rejects amplification attempts that try to
 // pin Postgres findUnique with megabyte-sized strings.
 const MAX_SLUG_LENGTH = 64
+
+// Per-colo Cache API TTL for fully-rewritten PUBLIC build-page HTML. One hot
+// slug dominates traffic, so caching the rendered shell lets repeat hits in a
+// colo skip the asset fetch, the API round-trip, and the HTMLRewriter pass.
+// Tradeoff: the build name/description/like/view counts baked into the <head>
+// meta — and a just-flipped visibility — can lag by up to this window. Only the
+// crawler-facing meta is affected; the page BODY is always live (the SPA
+// refetches client-side). Lower this if meta freshness matters more than hit rate.
+const BUILD_HTML_TTL = 300
 
 // Sync with CATEGORIES in src/lib/warframe.ts.
 const CATEGORY_LABELS: Record<string, string> = {
@@ -120,7 +136,7 @@ type BuildSummary = {
 }
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionCtx): Promise<Response> {
     const url = new URL(request.url)
 
     if (request.method !== "GET") return env.ASSETS.fetch(request)
@@ -143,7 +159,7 @@ export default {
     }
 
     const buildSlug = extractBuildSlug(url.pathname)
-    if (buildSlug) return handleBuildPage(request, env, url, buildSlug)
+    if (buildSlug) return handleBuildPage(request, env, url, buildSlug, ctx)
 
     const item = extractItemPath(url.pathname)
     if (item) return handleItemPage(request, env, url, item)
@@ -161,6 +177,7 @@ async function handleBuildPage(
   env: Env,
   url: URL,
   slug: string,
+  ctx: ExecutionCtx,
 ): Promise<Response> {
   // Embed iframes (`?embed=1`) get a dedicated lightweight shell instead of
   // the full SPA index.html, so a guide page with many embeds doesn't boot
@@ -185,6 +202,18 @@ async function handleBuildPage(
       }
     }
     return res
+  }
+
+  // Per-colo edge cache for the rendered PUBLIC build shell. The injected meta
+  // is derived from an anonymous API read, so the HTML is identical for every
+  // visitor — safe to share across users. The key drops the query string so
+  // tracking params (utm_*, fbclid, …) don't fragment the one hot slug; the
+  // ?embed=1 variant already returned above, so it never reaches this key.
+  const cache = edgeCache()
+  const cacheKey = new Request(url.origin + url.pathname)
+  if (cache) {
+    const hit = await cache.match(cacheKey)
+    if (hit) return hit
   }
 
   // Workers Static Assets redirects `/index.html` → `/` by default
@@ -226,7 +255,13 @@ async function handleBuildPage(
   // image by the item's stable uniqueName against the same image-map.json the
   // SPA uses, falling back to the stored value on a miss.
   const imageMap = await fetchImageMap(env, url)
-  return rewriteMeta(shellRes, buildMeta(build, slug, imageMap))
+  const res = rewriteMeta(shellRes, buildMeta(build, slug, imageMap))
+
+  // Only the fully-enriched PUBLIC HTML is cached. 404s, API-error fallbacks,
+  // and private/unlisted shells are left uncached so a transient blip or a
+  // just-changed visibility can't pin a wrong response for the whole TTL.
+  if (!cache) return res
+  return cacheStore(res, cacheKey, cache, ctx)
 }
 
 function extractBuildSlug(pathname: string): string | null {
@@ -259,7 +294,18 @@ async function fetchBuild(
       {
         headers: { accept: "application/json" },
         signal: AbortSignal.timeout(2500),
-        cf: { cacheTtl: 60, cacheEverything: true },
+        // Per-status TTL rather than a blanket cacheTtl: never cache a 5xx (a
+        // transient API blip would otherwise pin a degraded shell for the whole
+        // window), briefly cache 404s to blunt dead-link hammering, and cache
+        // good meta for the same window as the rendered HTML.
+        cf: {
+          cacheEverything: true,
+          cacheTtlByStatus: {
+            "200-299": BUILD_HTML_TTL,
+            "404": 10,
+            "500-599": 0,
+          },
+        },
       } as RequestInit,
     )
     if (res.status === 404) return "not-found"
@@ -451,6 +497,33 @@ function stripTrailingSlash(pathname: string): string {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
+// Per-colo Cache API handle. `caches.default` is a workerd global; we cast it
+// the same way we cast HTMLRewriter rather than pulling in the full CF types.
+// Returns null if absent (e.g. a non-workerd test runtime) so callers fall back
+// to the uncached path.
+function edgeCache(): EdgeCache | null {
+  const c = (globalThis as { caches?: { default?: EdgeCache } }).caches
+  return c?.default ?? null
+}
+
+// Store a clone of the streamed rewrite result while the original streams to the
+// user (waitUntil keeps the put alive past the response). We re-wrap to own the
+// headers: the asset shell can carry _headers-derived Cache-Control, and a
+// shared cache must never hold a Set-Cookie — so overwrite the TTL and strip any
+// cookie explicitly. Cloning a streaming body tees it, so no manual buffering.
+function cacheStore(
+  res: Response,
+  key: Request,
+  cache: EdgeCache,
+  ctx: ExecutionCtx,
+): Response {
+  const out = new Response(res.body, res)
+  out.headers.delete("set-cookie")
+  out.headers.set("cache-control", `public, s-maxage=${BUILD_HTML_TTL}`)
+  ctx.waitUntil(cache.put(key, out.clone()))
+  return out
+}
+
 // Compact `uniqueName → current imageName` map emitted by
 // scripts/build-items-index.ts and served from Static Assets. Fetched through
 // the ASSETS binding only on the build-page path.
@@ -591,6 +664,11 @@ function escapeAttr(s: string): string {
 // wrangler at deploy time, not by Vite.
 interface HTMLRewriterCtor {
   new (): HTMLRewriterInst
+}
+// Subset of the workerd Cache API surface we touch (caches.default).
+interface EdgeCache {
+  match(request: Request): Promise<Response | undefined>
+  put(request: Request, response: Response): Promise<void>
 }
 interface HTMLRewriterInst {
   on(selector: string, handlers: ElementHandlers): HTMLRewriterInst

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -44,5 +44,13 @@ run_worker_first = [
   "!/sitemap.xml",
 ]
 
+# Per-deploy version metadata (id/tag/timestamp). The edge Worker mixes the
+# deploy `id` into its build-page HTML cache key so each deploy starts a fresh
+# cache namespace — otherwise the per-colo Cache API (which survives deploys)
+# could serve a pre-deploy shell whose hashed /assets/*.js have rotated away
+# (now 404 → SPA-fallback HTML), white-screening the SPA until the TTL expired.
+[version_metadata]
+binding = "CF_VERSION_METADATA"
+
 [observability]
 enabled = true

--- a/data/curated/frame-polarities.ts
+++ b/data/curated/frame-polarities.ts
@@ -1,0 +1,34 @@
+/**
+ * Curated per-frame polarity overrides — a stopgap for frames whose wiki
+ * `Module:Warframes/data` entry is missing or incomplete, so our build can't
+ * source polarities from the wiki yet. Values are wiki-verified and keyed by
+ * the cleaned frame name. The wiki always wins when it has data; these only
+ * fill the gaps (see `mergeFrame`).
+ *
+ * Polarity names are lowercase, matching `normalizePolarity` output
+ * ("madurai", "vazarin", "naramon", "zenurik", "unairu", "penjaga", "umbra").
+ *
+ * Sirius & Orion (Update 43) ships as a twin-frame with two switchable forms
+ * that have SEPARATE upgrade menus — including different aura polarities
+ * (verified on wiki.warframe.com/w/Sirius_and_Orion: Sirius aura = Vazarin,
+ * Orion aura = Naramon). The wiki data module hasn't catalogued it yet, so
+ * both DE rows come through unmatched with empty polarities. We curate the
+ * (high-confidence) aura polarities here; the 8 mod-slot polarity positions
+ * aren't curated — they fill in automatically once the wiki module lists them.
+ */
+
+export interface FramePolarityOverride {
+  /** Aura slot polarity (single value, or array for multi-aura frames). */
+  auraPolarity?: string | string[]
+  /** 8 mod-slot polarities, positional. Omit when unknown (don't guess). */
+  polarities?: readonly string[]
+  /** Exilus slot polarity. */
+  exilusPolarity?: string
+}
+
+export const FRAME_POLARITY_OVERRIDES: Record<string, FramePolarityOverride> = {
+  // Sirius controls the primary form (uniqueName .../SiriusSuit).
+  "Sirius & Orion": { auraPolarity: "vazarin" },
+  // Orion is the secondary form (.../OrionSuit), named "Orion & Sirius".
+  "Orion & Sirius": { auraPolarity: "naramon" },
+}

--- a/packages/shared/src/warframe/build-codec.test.ts
+++ b/packages/shared/src/warframe/build-codec.test.ts
@@ -110,6 +110,33 @@ describe("encodeBuildDoc / decodeBuildDoc round-trip", () => {
     expect(decodeBuildDoc(encoded)!.variants[0].formIndex).toBe(1)
   })
 
+  it("round-trips per-form shards on a twin-frame doc", () => {
+    const doc: BuildDoc = {
+      ...makeDoc([
+        makeVariant({ id: "sirius", label: "Sirius", formIndex: 0 }),
+        makeVariant({ id: "orion", label: "Orion", formIndex: 1 }),
+      ]),
+      shardSlots: [
+        { color: "crimson", stat: "Ability Strength", tauforged: true },
+      ],
+      formShardSlots: {
+        1: [{ color: "azure", stat: "Health", tauforged: false }],
+      },
+    }
+    const decoded = decodeBuildDoc(encodeBuildDoc(doc))!
+    // Form 0 stays in the canonical `shardSlots`; form 1 keeps its own set.
+    expect(decoded.shardSlots[0]).toEqual({
+      color: "crimson",
+      stat: "Ability Strength",
+      tauforged: true,
+    })
+    expect(decoded.formShardSlots?.[1]?.[0]).toEqual({
+      color: "azure",
+      stat: "Health",
+      tauforged: false,
+    })
+  })
+
   it("rejects unknown lichBonusElement on v2 decode", () => {
     const doc = makeDoc([makeVariant(), makeVariant({ id: "v1", label: "B" })])
     const encoded = encodeBuildDoc({

--- a/packages/shared/src/warframe/build-codec.ts
+++ b/packages/shared/src/warframe/build-codec.ts
@@ -101,6 +101,9 @@ interface EncodedSlotGroup {
  *  v2. */
 interface EncodedSharedMeta {
   sh?: number[]
+  /** Twin-frame per-form shards for forms ≥ 1 (form 0 lives in `sh`). Keyed by
+   *  form index. Omitted for normal frames. */
+  shf?: Record<number, number[]>
   h?: EncodedHelminth
   zc?: { g: string; l: string }
   kc?: { g: string; l: string }
@@ -299,6 +302,7 @@ function decodeSlotGroup(g: EncodedSlotGroup): SlotGroupSource {
 type SharedMetaSource = Pick<
   BuildDoc,
   | "shardSlots"
+  | "formShardSlots"
   | "helminthAbility"
   | "zawComponents"
   | "kitgunComponents"
@@ -316,6 +320,17 @@ function encodeSharedMeta(
     src.shardSlots.some((s) => s !== null)
   )
     target.sh = encodeShards(src.shardSlots)
+  if (src.formShardSlots) {
+    const shf: Record<number, number[]> = {}
+    for (const [formIndex, slots] of Object.entries(src.formShardSlots)) {
+      // Form 0 is always `sh`; skip it here and skip empty sets so a twin
+      // frame with no shards on a half doesn't bloat the link.
+      if (Number(formIndex) === 0) continue
+      if (slots && slots.length > 0 && slots.some((s) => s !== null))
+        shf[Number(formIndex)] = encodeShards(slots)
+    }
+    if (Object.keys(shf).length > 0) target.shf = shf
+  }
   if (src.helminthAbility) {
     target.h = {
       si: src.helminthAbility.slotIndex,
@@ -337,8 +352,16 @@ function encodeSharedMeta(
 function decodeSharedMeta(encoded: EncodedSharedMeta): SharedMetaSource & {
   shardSlots: (PlacedShard | null)[]
 } {
+  let formShardSlots: Record<number, (PlacedShard | null)[]> | undefined
+  if (encoded.shf) {
+    formShardSlots = {}
+    for (const [formIndex, slots] of Object.entries(encoded.shf)) {
+      formShardSlots[Number(formIndex)] = decodeShards(slots)
+    }
+  }
   return {
     shardSlots: encoded.sh ? decodeShards(encoded.sh) : [],
+    formShardSlots,
     helminthAbility: encoded.h
       ? {
           slotIndex: encoded.h.si,

--- a/packages/shared/src/warframe/build-doc.ts
+++ b/packages/shared/src/warframe/build-doc.ts
@@ -52,7 +52,15 @@ export interface BuildDoc {
   itemCategory: BrowseCategory
   itemImageName?: string
   hasReactor: boolean
+  /** The primary form's (form 0) Archon Shards — and the only shard set for
+   *  every normal frame. Kept as the canonical field so existing builds and
+   *  share links (which only ever had one shard set) read as the primary
+   *  form's shards with no migration. */
   shardSlots: (PlacedShard | null)[]
+  /** Twin-frames (Sirius & Orion): each form ("half") owns its own shards.
+   *  Keyed by form index for forms ≥ 1; form 0 lives in `shardSlots` above.
+   *  Absent for normal frames. */
+  formShardSlots?: Record<number, (PlacedShard | null)[]>
   helminthAbility?: BuildState["helminthAbility"]
   zawComponents?: BuildState["zawComponents"]
   kitgunComponents?: BuildState["kitgunComponents"]
@@ -68,6 +76,19 @@ export interface BuildDoc {
 }
 
 /**
+ * Resolve the Archon Shard set for a form. Form 0 (and every normal frame)
+ * reads the canonical `shardSlots`; twin-frame forms ≥ 1 read their own slice
+ * of `formShardSlots`, defaulting to empty so each "half" is independent.
+ */
+export function shardsForForm(
+  doc: Pick<BuildDoc, "shardSlots" | "formShardSlots">,
+  formIndex: number,
+): (PlacedShard | null)[] {
+  if (formIndex === 0) return doc.shardSlots
+  return doc.formShardSlots?.[formIndex] ?? []
+}
+
+/**
  * Project a (doc, index) pair back into a `BuildState` that the existing
  * stat engine, capacity calc, and mod search already understand. Capacity
  * fields are zeroed because every consumer recomputes them downstream.
@@ -80,7 +101,9 @@ export function projectVariant(doc: BuildDoc, index: number): BuildState {
     itemCategory: doc.itemCategory,
     itemImageName: doc.itemImageName,
     hasReactor: doc.hasReactor,
-    shardSlots: doc.shardSlots,
+    // A variant's shards follow its form ("half"): twin-frames give each form
+    // its own set; normal frames always resolve to `shardSlots`.
+    shardSlots: shardsForForm(doc, v?.formIndex ?? 0),
     helminthAbility: doc.helminthAbility,
     zawComponents: doc.zawComponents,
     kitgunComponents: doc.kitgunComponents,

--- a/packages/shared/src/warframe/types.ts
+++ b/packages/shared/src/warframe/types.ts
@@ -58,12 +58,17 @@ export interface Ability {
 }
 
 /** One switchable form of a twin-frame. Mods/auras/arcanes are tracked on the
- *  build (per-variant); only ability-set, passive, and exalted differ here. */
+ *  build (per-variant). Forms have separate upgrade menus in game, so the
+ *  ability-set, passive, exalted, AND polarities differ per form (Sirius aura
+ *  = Vazarin, Orion aura = Naramon). */
 export interface FrameForm {
   name: string
   abilities: Ability[]
   passiveDescription?: string
   exalted?: string[]
+  polarities?: string[]
+  auraPolarity?: string | string[] | null
+  exilusPolarity?: string | null
 }
 
 // Weapon base interface

--- a/scripts/build-items-index.ts
+++ b/scripts/build-items-index.ts
@@ -225,7 +225,11 @@ async function main() {
   const rawFrames: MergedFrame[] = []
   for (const de of deFramesBlob.ExportWarframes) {
     rawFrames.push(
-      mergeFrame(de, { wiki: wikiFramesBlob, unmatched: frameUnmatched }),
+      mergeFrame(de, {
+        wiki: wikiFramesBlob,
+        unmatched: frameUnmatched,
+        polarityOverrides: curated.framePolarities,
+      }),
     )
   }
   // Collapse twin-frames (e.g. Sirius & Orion ships as two DE rows) into one

--- a/scripts/build/merge-frames.ts
+++ b/scripts/build/merge-frames.ts
@@ -186,9 +186,7 @@ export function mergeFrame(de: DeFrame, opts: MergeFramesOpts): MergedFrame {
     : (override?.polarities ?? [])
   const auraPolarity =
     normalizeAuraPolarity(wiki?.AuraPolarity) ??
-    (override?.auraPolarity
-      ? normalizeAuraPolarity(override.auraPolarity)
-      : null)
+    normalizeAuraPolarity(override?.auraPolarity)
   const exilusPolarity =
     normalizePolarity(wiki?.ExilusPolarity) ??
     normalizePolarity(override?.exilusPolarity)

--- a/scripts/build/merge-frames.ts
+++ b/scripts/build/merge-frames.ts
@@ -14,6 +14,7 @@
  * on each frame entry.
  */
 
+import type { FramePolarityOverride } from "../../data/curated/frame-polarities"
 import { cleanDeName } from "./names"
 import { normalizePolarity, normalizePolarities } from "./polarity"
 import type { DeFrame } from "./read-de"
@@ -27,12 +28,17 @@ interface FrameAbility {
   imageName?: string
 }
 
-/** One switchable form of a twin-frame (e.g. Sirius & Orion). */
+/** One switchable form of a twin-frame (e.g. Sirius & Orion). Forms have
+ *  SEPARATE upgrade menus in game, so each carries its own polarities (Sirius
+ *  aura = Vazarin, Orion aura = Naramon). */
 export interface MergedFrameForm {
   name: string
   abilities: readonly FrameAbility[]
   passiveDescription?: string
   exalted: readonly string[]
+  polarities: readonly string[]
+  auraPolarity: string | string[] | null
+  exilusPolarity: string | null
 }
 
 export interface MergedFrame {
@@ -131,6 +137,9 @@ function findWikiFrame(
 export interface MergeFramesOpts {
   wiki: FrameWikiTable
   unmatched: Set<string>
+  /** Frame name → wiki-verified polarity fallback for frames the wiki data
+   *  module hasn't catalogued yet (e.g. the Sirius & Orion twin-frame). */
+  polarityOverrides?: Record<string, FramePolarityOverride>
 }
 
 /** Build the mod-pool list for a frame.
@@ -167,7 +176,22 @@ export function mergeFrame(de: DeFrame, opts: MergeFramesOpts): MergedFrame {
   const wiki = findWikiFrame(cleanName, opts.wiki)
   if (!wiki) opts.unmatched.add(cleanName)
 
-  const polarities = normalizePolarities(wiki?.Polarities ?? [])
+  // Wiki is authoritative; the curated override only fills gaps for frames the
+  // wiki data module hasn't catalogued yet (e.g. the Sirius & Orion twin-frame,
+  // whose two forms have different aura polarities).
+  const override = opts.polarityOverrides?.[cleanName]
+  const wikiPolarities = normalizePolarities(wiki?.Polarities ?? [])
+  const polarities = wikiPolarities.length
+    ? wikiPolarities
+    : (override?.polarities ?? [])
+  const auraPolarity =
+    normalizeAuraPolarity(wiki?.AuraPolarity) ??
+    (override?.auraPolarity
+      ? normalizeAuraPolarity(override.auraPolarity)
+      : null)
+  const exilusPolarity =
+    normalizePolarity(wiki?.ExilusPolarity) ??
+    normalizePolarity(override?.exilusPolarity)
   const category = categoryOf(de.productCategory)
 
   return {
@@ -194,8 +218,8 @@ export function mergeFrame(de: DeFrame, opts: MergeFramesOpts): MergedFrame {
       imageName: a.imageName,
     })),
     polarities,
-    auraPolarity: normalizeAuraPolarity(wiki?.AuraPolarity),
-    exilusPolarity: normalizePolarity(wiki?.ExilusPolarity),
+    auraPolarity,
+    exilusPolarity,
     isPrime: cleanName.includes(" Prime"),
   }
 }
@@ -219,6 +243,9 @@ function toForm(f: MergedFrame): MergedFrameForm {
     abilities: f.abilities,
     passiveDescription: f.passiveDescription,
     exalted: f.exalted,
+    polarities: f.polarities,
+    auraPolarity: f.auraPolarity,
+    exilusPolarity: f.exilusPolarity,
   }
 }
 

--- a/scripts/build/read-curated.ts
+++ b/scripts/build/read-curated.ts
@@ -7,11 +7,18 @@
  * to know which file each curated table lives in.
  */
 
-import { CLASS_DEFAULT_POOLS, ALL_MENTIONED_POOLS } from "../../data/curated/class-pools"
+import {
+  CLASS_DEFAULT_POOLS,
+  ALL_MENTIONED_POOLS,
+} from "../../data/curated/class-pools"
 import {
   EXALTED_STANCES,
   type ExaltedStance,
 } from "../../data/curated/exalted-stances"
+import {
+  FRAME_POLARITY_OVERRIDES,
+  type FramePolarityOverride,
+} from "../../data/curated/frame-polarities"
 import { MOD_POOL_OVERRIDES } from "../../data/curated/mod-pools"
 import { PLEXUS_BROWSE_ITEM, PLEXUS_DETAIL } from "../../data/curated/plexus"
 import {
@@ -34,6 +41,9 @@ export interface CuratedData {
   releaseHistory: Record<string, ReleaseHistoryEntry>
   /** Weapon name → permanently-installed exalted stance (locked slot). */
   exaltedStances: Record<string, ExaltedStance>
+  /** Frame name → wiki-verified polarity fallback (for frames the wiki data
+   *  module hasn't catalogued yet). The wiki wins when it has data. */
+  framePolarities: Record<string, FramePolarityOverride>
 }
 
 export function readCurated(): CuratedData {
@@ -47,5 +57,6 @@ export function readCurated(): CuratedData {
     plexusDetail: PLEXUS_DETAIL,
     releaseHistory: RELEASE_HISTORY,
     exaltedStances: EXALTED_STANCES,
+    framePolarities: FRAME_POLARITY_OVERRIDES,
   }
 }


### PR DESCRIPTION
Bundles three related-but-distinct changes into one PR (per request). Two are twin-frame (Sirius & Orion) per-form follow-ups; the third is an unrelated edge-caching perf win that happened to be in flight.

## 1. Unique Archon Shards per twin-frame form (`8210446f`)
Each form ("half") of a twin-frame carries its own shard set. Forms ≥ 1 store shards in `formShards` / `formShardSlots` (keyed by form index) alongside the primary form's existing `shards`; `projectVariant` resolves a variant's shards by its `formIndex`, and the API's `hasShards` check now counts per-form shards too.
- `packages/shared/warframe/build-doc.ts`, `build-codec.ts` (+ test), `apps/web/.../build-codec-adapter.ts`, `build-query.ts`, `editor-shell.tsx`, `apps/api/.../builds.ts`

## 2. Per-form innate polarities (`a3bab3bb`)
Sirius & Orion each get their own innate polarities, curated and merged through the data pipeline.
- `data/curated/frame-polarities.ts`, `scripts/build/merge-frames.ts`, `read-curated.ts`, `apps/web/.../form-axis.ts`, `build-viewer-body.tsx`, `packages/shared/warframe/types.ts`

## 3. Edge-cache rendered build-page HTML (`9c793c3f`)
Worker-level perf, prompted by Cloudflare Web Analytics showing ~656ms P75 TTFB on build pages (one hot slug = ~70% of traffic).
- Cache the fully-rewritten **PUBLIC** build shell in the per-colo Cache API (keyed by path, query stripped) so repeat hits skip the asset fetch, the API round-trip, **and** the HTMLRewriter pass.
- Only enriched PUBLIC HTML is cached; 404s / API-error fallbacks / private shells stay uncached.
- Subrequest swapped from blanket `cacheTtl` to `cacheTtlByStatus`, so a transient 5xx no longer pins a degraded shell.
- **Tradeoff:** `BUILD_HTML_TTL = 300s` means `<head>` meta (name, like/view counts) and a just-privatized build can lag ≤5 min at the edge; the page body is always live (SPA refetches client-side). One-line knob.

## Verification
- `bun run typecheck` — all packages + scripts pass
- `bunx vitest run build-codec.test.ts` — 14/14 pass
- `just fix` — 0 lint warnings, formatter clean
- `wrangler deploy --dry-run` — worker bundles clean (worker/ is excluded from tsc/oxlint, so the dry-run is its gate)