### PR TITLE
docs(web): changelog for twin-frame per-form shards + edge-cached build pages

### DIFF
--- a/apps/web/src/data/changelog.ts
+++ b/apps/web/src/data/changelog.ts
@@ -11,6 +11,21 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-06-19",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Sirius & Orion now carry Archon Shards per form: Sirius and Orion each keep their own shard install, so you can plan a separate shard setup for each half and switching forms no longer overwrites the other's. The shards travel in the share URL too, so a link opens with both forms' shards intact.",
+      },
+      {
+        type: "chore",
+        description:
+          "Build pages load faster — the public version of a build page is now cached at the edge, so the common case renders without waiting on an extra round-trip.",
+      },
+    ],
+  },
+  {
     date: "2026-06-18",
     changes: [
       {


### PR DESCRIPTION
Adds a `2026-06-19` changelog entry covering the user-visible parts of the twin-frame per-form work (PR #244):

- **feat** — per-form Archon Shards on Sirius & Orion (each form keeps its own shard install; rides along in the share URL).
- **chore** — faster build pages via the edge-cached public build shell.

### Deliberately excluded
- **Per-form innate polarities** are *not* announced. The code is correct, but the feature is dormant until `apps/web/public/data/` is regenerated through the full image pipeline (`just build-items-index`, needs R2 creds) — until then both forms render a blank aura. Announcing it now would be inaccurate. Add a follow-up changelog line once the data is rebuilt.

### Notes
- Separate PR off `main`, as requested. `changelog.ts` is identical on `main` and the #244 branch, so no conflict either way.
- **Merge ordering:** this only describes features that go live with #244. Ideally merge/deploy #244 first (or together) so the changelog doesn't claim shards that aren't in prod yet.

### Checks
- `oxlint` — 0 warnings · `oxfmt --check` — clean · web `tsc --noEmit` — passes
- Verified live on the `/changelog` route: new entry renders at top with correct text/badges, no console errors.