### PR TITLE
perf(web): cut Worker/API request volume from update-poller + session refetch

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -22,6 +22,13 @@
 /robots.txt
   Cache-Control: public, max-age=3600
 
+# Deploy marker polled by the app-update hook (lib/hooks/use-app-update.ts).
+# must-revalidate so a returning tab learns about a new deploy promptly; tiny
+# body + ETag means each poll is a cheap 304, served by the assets binding with
+# no Worker invocation (excluded in wrangler.toml run_worker_first).
+/version.json
+  Cache-Control: public, max-age=0, must-revalidate
+
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -7,4 +7,14 @@ export const authClient = createAuthClient({
   baseURL: `${API_URL}/auth`,
   fetchOptions: { credentials: "include" },
   plugins: [usernameClient()],
+  // Better Auth refetches /auth/get-session on every tab refocus by default
+  // (refetchOnWindowFocus). For our largely logged-out audience that call
+  // always returns null — pure waste that fans out across the API Worker
+  // whenever a build link is opened in a background tab and later focused.
+  // Cross-tab login/logout still propagates via the broadcast channel (which
+  // is independent of this flag), and the server already caps session
+  // freshness at the 60s cookieCache (see apps/api/src/auth.ts), so on-focus
+  // revalidation bought almost nothing. A long-lived signed-in tab now picks
+  // up session changes on its next request/navigation instead of on refocus.
+  sessionOptions: { refetchOnWindowFocus: false },
 })

--- a/apps/web/src/lib/hooks/use-app-update.ts
+++ b/apps/web/src/lib/hooks/use-app-update.ts
@@ -5,16 +5,27 @@ import { toast } from "sonner"
  * Notifies the user when a newer deploy is available and offers a one-click
  * reload.
  *
- * We have no service worker, so detection piggybacks on `index.html`, which the
- * CDN serves `must-revalidate` (see public/_headers). Vite injects a single
- * content-hashed entry script (`/assets/index-<hash>.js`); any code change ships
- * a new hash, so a fresh `index.html` references a different entry `src` than the
+ * We have no service worker, so detection polls `/version.json` — a tiny static
+ * asset emitted at build time (see the `versionFile()` plugin in vite.config.ts)
+ * holding the SPA's content-hashed entry filename. Vite injects a single
+ * content-hashed entry script (`/assets/main-<hash>.js`); any code change ships
+ * a new hash, so the deployed `version.json` carries a different `entry` than the
  * one this tab loaded with. Mismatch ⇒ a new version is live.
  *
+ * `/version.json` is excluded from the edge Worker and served straight from the
+ * assets binding (wrangler.toml + public/_headers), so each poll is a cheap CDN
+ * 304 with zero Worker invocations — earlier this polled `/index.html`, which
+ * ran the Worker and 307-redirected (two billed hits per poll per open tab).
+ *
  * Polls on an interval and whenever the tab becomes visible again (the moment a
- * returning user is most likely to be on a stale bundle). Fires at most once.
+ * returning user is most likely to be on a stale bundle), throttled so rapid
+ * tab focus changes can't fan out a burst of requests. Fires at most once.
  */
 const POLL_MS = 5 * 60 * 1000
+// Collapse a burst of visibility/interval triggers without throttling the poll
+// cadence itself. Kept well under POLL_MS so the periodic tick never races it
+// and a user returning a few minutes after load still gets a fresh check.
+const MIN_REFETCH_MS = 30 * 1000
 const TOAST_ID = "app-update"
 
 function entryHref(doc: Document): string | null {
@@ -23,18 +34,20 @@ function entryHref(doc: Document): string | null {
 }
 
 async function fetchDeployedEntry(signal: AbortSignal): Promise<string | null> {
-  const res = await fetch(`/index.html?_=${Date.now()}`, {
-    cache: "no-store",
-    signal,
-  })
+  // `no-cache` (revalidate every time), not `no-store`: it sends If-None-Match
+  // so an unchanged file comes back as a cheap 304, while a new deploy still
+  // gets a fresh 200. `no-store` would suppress the conditional request and
+  // force a full 200 every poll.
+  const res = await fetch("/version.json", { cache: "no-cache", signal })
   if (!res.ok) return null
-  const html = await res.text()
-  return entryHref(new DOMParser().parseFromString(html, "text/html"))
+  const { entry } = (await res.json()) as { entry?: string | null }
+  return entry ?? null
 }
 
 export function useAppUpdate() {
   const loadedEntry = useRef<string | null>(null)
   const notified = useRef(false)
+  const lastCheck = useRef(0)
 
   useEffect(() => {
     // Dev serves an unhashed `/src/main.tsx` entry, so there's nothing to diff.
@@ -46,6 +59,10 @@ export function useAppUpdate() {
 
     async function check() {
       if (notified.current || document.visibilityState !== "visible") return
+      // Collapse rapid focus flips into one request; the periodic interval is
+      // far longer than this window so it always passes.
+      if (Date.now() - lastCheck.current < MIN_REFETCH_MS) return
+      lastCheck.current = Date.now()
       try {
         const latest = await fetchDeployedEntry(controller.signal)
         if (latest && latest !== loadedEntry.current) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -108,20 +108,21 @@ function versionFile(): Plugin {
       const main = Object.values(bundle).find(
         (c) => c.type === "chunk" && c.isEntry && c.name === "main",
       )
-      // Fail loud rather than ship {entry:null}: a silent null would disable
-      // update detection for every client with no other signal. Fires if the
-      // `main` rollup input key (build.rollupOptions.input) is ever renamed.
+      // Fail the build rather than ship {entry:null}: a silent null would
+      // disable update detection for every client with no other signal.
+      // `this.error` throws (aborts the build); `this.warn` would only log and
+      // still emit the broken file. Fires if the `main` rollup input key
+      // (build.rollupOptions.input) is ever renamed.
       if (!main) {
-        this.warn(
+        this.error(
           "versionFile: no `main` entry chunk found; /version.json won't detect deploys",
         )
       }
       // `entry` mirrors the `src` Vite injects into index.html (base "/").
-      const entry = main ? `/${main.fileName}` : null
       this.emitFile({
         type: "asset",
         fileName: "version.json",
-        source: `${JSON.stringify({ entry })}\n`,
+        source: `${JSON.stringify({ entry: `/${main.fileName}` })}\n`,
       })
     },
   }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -92,6 +92,41 @@ function sitemap(): Plugin {
   }
 }
 
+/** Emit /version.json holding the SPA's content-hashed entry filename. The
+ * app-update hook (lib/hooks/use-app-update.ts) polls this tiny file to detect
+ * new deploys — a code change ships a new entry hash, so the file's `entry`
+ * differs from the one the running tab loaded with. It's a plain static asset
+ * (excluded from `run_worker_first` in wrangler.toml, short-TTL in
+ * public/_headers), so each poll is a cheap CDN 304 with ZERO Worker
+ * invocations — unlike polling `/index.html`, which ran the edge Worker and
+ * 307-redirected (two hits per poll). */
+function versionFile(): Plugin {
+  return {
+    name: "arsenyx:version-file",
+    apply: "build",
+    generateBundle(_options, bundle) {
+      const main = Object.values(bundle).find(
+        (c) => c.type === "chunk" && c.isEntry && c.name === "main",
+      )
+      // Fail loud rather than ship {entry:null}: a silent null would disable
+      // update detection for every client with no other signal. Fires if the
+      // `main` rollup input key (build.rollupOptions.input) is ever renamed.
+      if (!main) {
+        this.warn(
+          "versionFile: no `main` entry chunk found; /version.json won't detect deploys",
+        )
+      }
+      // `entry` mirrors the `src` Vite injects into index.html (base "/").
+      const entry = main ? `/${main.fileName}` : null
+      this.emitFile({
+        type: "asset",
+        fileName: "version.json",
+        source: `${JSON.stringify({ entry })}\n`,
+      })
+    },
+  }
+}
+
 export default defineConfig({
   define: {
     __DATA_VERSION__: JSON.stringify(dataVersion()),
@@ -101,6 +136,7 @@ export default defineConfig({
     react(),
     tailwindcss(),
     sitemap(),
+    versionFile(),
   ],
   resolve: {
     alias: {

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -42,6 +42,7 @@ run_worker_first = [
   "!/apple-touch-icon.png",
   "!/robots.txt",
   "!/sitemap.xml",
+  "!/version.json",
 ]
 
 # Per-deploy version metadata (id/tag/timestamp). The edge Worker mixes the


### PR DESCRIPTION
## Why

A single viral build page (linked from overframe.gg, many tabs left open) pushed the **arsenyx-web** Worker to ~52k requests/day against the free-plan 100k cap, with observability events tracking ~1:1. Root cause was **not** the recent edge-cache change — it was the client-side update-poller, amplified by a 307 redirect and many open tabs. The same traffic also hammered **arsenyx-api** with redundant `get-session` calls.

## What changed

**1. Update detection polls a static `/version.json` instead of `/index.html`** (`338c0e3a`)

The hook polled `/index.html?_=<ts>` with `no-store`, which ran the edge Worker and 307-redirected (`/index.html` → `/`) — **2 Worker invocations + 2 observability events per poll, per tab**.

- New `versionFile()` Vite plugin emits `/version.json` = `{"entry":"/assets/main-<hash>.js"}` at build.
- Excluded from `run_worker_first` (wrangler.toml) + short-TTL rule (`public/_headers`) → served straight from the assets binding: **0 Worker invocations**, no 307, cheap **304** when unchanged (`cache: "no-cache"`).
- Detection logic unchanged: diff the running tab's `<script>` entry vs the deployed one.

**2. Stop refetching the session on window focus** (`7a7f16b4`)

Better Auth's `refetchOnWindowFocus` (default `true`) fires `/auth/get-session` on every tab refocus — for our mostly logged-out audience that's a `null` every time. Disabled via `sessionOptions`. Cross-tab login/logout still syncs via the broadcast channel (independent of this flag), and the server already caps session freshness at the 60s `cookieCache`.

## Reviewer notes

- Verified the emitted `version.json` `entry` byte-matches the `<script src>` Vite injects into `index.html` (`/assets/main-<hash>.js`).
- The 30s focus-burst throttle (`MIN_REFETCH_MS`) is deliberately decoupled from the 5-min poll cadence so the interval tick never races the throttle and a returning user still gets a prompt check.
- Build fails loud (`this.warn`) if the `main` entry chunk can't be found, rather than silently shipping `{entry:null}`.
- `just check` (typecheck + lint + fmt) and a production build both pass.