### PR TITLE
perf(api): edge-cache partners route + raise list TTL to cut Hyperdrive queries

### DIFF
--- a/apps/api/src/lib/edge-cache.test.ts
+++ b/apps/api/src/lib/edge-cache.test.ts
@@ -1,0 +1,177 @@
+import { Hono } from "hono"
+import { setCookie } from "hono/cookie"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { edgeCache, purgeEdge } from "./edge-cache"
+
+// Map-backed stand-in for `caches.default`. The real Cloudflare Cache API isn't
+// present under vitest's node environment, so without this the middleware's
+// `defaultCache()` returns null and every request falls through uncached —
+// which would make these tests assert nothing. Keyed by request URL (the
+// middleware already normalizes query-param order via cacheKey()).
+class FakeCache {
+  store = new Map<string, Response>()
+  match(req: Request): Promise<Response | undefined> {
+    const hit = this.store.get(req.url)
+    // Clone on read: a Response body is a one-shot stream, and the same entry
+    // may be served to multiple hits.
+    return Promise.resolve(hit ? hit.clone() : undefined)
+  }
+  put(req: Request, res: Response): Promise<void> {
+    this.store.set(req.url, res)
+    return Promise.resolve()
+  }
+  delete(req: Request): Promise<boolean> {
+    return Promise.resolve(this.store.delete(req.url))
+  }
+}
+
+let fake: FakeCache
+
+beforeEach(() => {
+  fake = new FakeCache()
+  ;(globalThis as unknown as { caches: unknown }).caches = { default: fake }
+})
+
+afterEach(() => {
+  delete (globalThis as unknown as { caches?: unknown }).caches
+})
+
+// Drive a request through app.fetch with a real ExecutionContext so the
+// middleware's waitUntil-backed cache.put() (runInBackground) is captured and
+// awaited — otherwise the store would race the assertions.
+async function run(
+  app: Hono,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const waits: Promise<unknown>[] = []
+  const ctx = {
+    waitUntil: (p: Promise<unknown>) => {
+      waits.push(p)
+    },
+    passThroughOnException: () => {},
+  } as unknown as ExecutionContext
+  const res = await app.fetch(new Request(url, init), {}, ctx)
+  await Promise.all(waits)
+  return res
+}
+
+const AUTHED = { headers: { Cookie: "better-auth.session_token=abc" } }
+const BASE = "http://api.test/builds/x/partners"
+
+describe("edgeCache", () => {
+  it("serves a second anonymous request from cache without re-running the handler", async () => {
+    let calls = 0
+    const app = new Hono()
+    app.get("*", edgeCache({ maxAge: 300 }), (c) => {
+      calls++
+      return c.json({ n: calls })
+    })
+
+    const first = await run(app, BASE)
+    expect(await first.json()).toEqual({ n: 1 })
+
+    const second = await run(app, BASE)
+    // Handler did NOT run again; the cached body is replayed verbatim.
+    expect(calls).toBe(1)
+    expect(await second.json()).toEqual({ n: 1 })
+  })
+
+  it("bypasses the cache entirely for requests carrying a session cookie", async () => {
+    let calls = 0
+    const app = new Hono()
+    app.get("*", edgeCache({ maxAge: 300 }), (c) => {
+      calls++
+      return c.json({ n: calls })
+    })
+
+    await run(app, BASE, AUTHED)
+    await run(app, BASE, AUTHED)
+    // Personalized responses must never be cached or served from cache.
+    expect(calls).toBe(2)
+    expect(fake.store.size).toBe(0)
+  })
+
+  it("never serves an anonymous cache entry to an authenticated request", async () => {
+    let calls = 0
+    const app = new Hono()
+    app.get("*", edgeCache({ maxAge: 300 }), (c) => {
+      calls++
+      return c.json({ who: calls === 1 ? "anon" : "authed" })
+    })
+
+    await run(app, BASE) // anon populates the cache
+    const authed = await run(app, BASE, AUTHED)
+    // The authed request runs the handler instead of replaying the anon body.
+    expect(calls).toBe(2)
+    expect(await authed.json()).toEqual({ who: "authed" })
+  })
+
+  it("strips Set-Cookie and stamps Cache-Control + Vary on the stored entry", async () => {
+    const app = new Hono()
+    app.get("*", edgeCache({ maxAge: 300 }), (c) => {
+      // A per-viewer cookie (e.g. the view-dedupe cookie) must not be shared
+      // across viewers via the cache.
+      setCookie(c, "vw_x", "1")
+      return c.json({ ok: true })
+    })
+
+    await run(app, BASE) // miss: stores a cleaned clone
+    const hit = await run(app, BASE) // hit: returns the stored clone
+    expect(hit.headers.get("Set-Cookie")).toBeNull()
+    expect(hit.headers.get("Cache-Control")).toBe("public, max-age=300")
+    expect(hit.headers.get("Vary")).toBe("Cookie")
+  })
+
+  it("does not cache non-200 responses", async () => {
+    let calls = 0
+    const app = new Hono()
+    app.get("*", edgeCache({ maxAge: 300 }), (c) => {
+      calls++
+      return c.json({ error: "not_found" }, 404)
+    })
+
+    await run(app, BASE)
+    await run(app, BASE)
+    expect(calls).toBe(2)
+    expect(fake.store.size).toBe(0)
+  })
+
+  it("normalizes query-param order to a single cache entry", async () => {
+    let calls = 0
+    const app = new Hono()
+    app.get("*", edgeCache({ maxAge: 300 }), (c) => {
+      calls++
+      return c.json({ n: calls })
+    })
+
+    await run(app, `${BASE}?a=1&b=2`)
+    const reordered = await run(app, `${BASE}?b=2&a=1`)
+    expect(calls).toBe(1)
+    expect(await reordered.json()).toEqual({ n: 1 })
+  })
+
+  it("purgeEdge evicts the detail path and its embed/view variants", async () => {
+    let calls = 0
+    const app = new Hono()
+    app.get("/builds/:slug", edgeCache({ maxAge: 300 }), (c) => {
+      calls++
+      return c.json({ n: calls })
+    })
+    // Mounted so purgeEdge (which mutates the request URL's pathname) can run
+    // against a real context.
+    app.get("/purge/:slug", (c) => {
+      purgeEdge(c, `/builds/${c.req.param("slug")}`)
+      return c.body(null, 204)
+    })
+
+    await run(app, "http://api.test/builds/x") // populate
+    await run(app, "http://api.test/builds/x") // hit
+    expect(calls).toBe(1)
+
+    await run(app, "http://api.test/purge/x")
+    await run(app, "http://api.test/builds/x") // miss again post-purge
+    expect(calls).toBe(2)
+  })
+})

--- a/apps/api/src/lib/edge-cache.ts
+++ b/apps/api/src/lib/edge-cache.ts
@@ -1,11 +1,10 @@
 import type { Context, MiddlewareHandler } from "hono"
 
 // Best-effort edge caching for anonymous public reads, using the Cloudflare
-// Cache API (`caches.default`). The point is purely to let Neon's autosuspend
-// fire: every cache HIT is a request that never touches Postgres, so the DB
-// can actually sleep during quiet periods instead of being kept awake by a
-// constant trickle of reads. (Neon Free bills compute-hours and its 5-minute
-// autosuspend is non-configurable, so "fewer wakeups" is the only lever.)
+// Cache API (`caches.default`). Every cache HIT is a request that never touches
+// Postgres (nor Hyperdrive), so this directly cuts query volume against the
+// Hyperdrive Free-plan daily query cap — the dominant lever now that anonymous
+// reads (site browsing + Discord/embed traffic) make up most of the load.
 //
 // Correctness invariant — we ONLY cache responses for requests with no session
 // cookie. Authenticated detail/list responses are personalized (isOwner /
@@ -105,12 +104,13 @@ export function edgeCache(opts: { maxAge: number }): MiddlewareHandler {
 // always see their own writes immediately regardless of this.
 //
 // Scope note: callers purge the build DETAIL path only. The `GET /builds` LIST
-// is also edge-cached (maxAge 120s) but is NOT purged here — its entries are
-// keyed by every filter/sort/page param combination, and the Cache API has no
-// wildcard delete, so there's no tractable key to evict. Consequence: when a
-// build flips PUBLIC->PRIVATE or is deleted, its title/summary can linger in
-// cached listings for up to that 120s TTL. Accepted as a bounded, best-effort
-// window (the detail payload — the sensitive surface — is purged precisely).
+// (and the `/:slug/partners` strip) are also edge-cached (maxAge 300s) but are
+// NOT purged here — their entries are keyed by every filter/sort/page param
+// combination, and the Cache API has no wildcard delete, so there's no
+// tractable key to evict. Consequence: when a build flips PUBLIC->PRIVATE or is
+// deleted, its title/summary can linger in cached listings for up to that 300s
+// TTL. Accepted as a bounded, best-effort window (the detail payload — the
+// sensitive surface — is purged precisely).
 export function purgeEdge(c: Context, path: string): void {
   const cache = defaultCache()
   if (!cache) return

--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -442,7 +442,7 @@ builds.post("/:slug/fork", rateLimitUser("mutate"), async (c) => {
   return c.json({ error: "slug_collision" }, 500)
 })
 
-builds.get("/", edgeCache({ maxAge: 120 }), async (c) => {
+builds.get("/", edgeCache({ maxAge: 300 }), async (c) => {
   const result = await runList({
     filters: parseListQuery(c),
     ...publicScope(),
@@ -550,7 +550,16 @@ async function loadPartnerContext(slug: string, partnerSlug: string) {
   return { own, partner }
 }
 
-builds.get("/:slug/partners", async (c) => {
+// Edge-cached like the detail route: this fires on every full build-detail
+// page view (the "Related builds" strip), so an uncached query here doubles
+// the DB hits per anonymous view. Session-cookie requests bypass the cache
+// (edgeCache checks the Cookie header), so authenticated viewers still get
+// their viewer-specific partner visibility. Accepted staleness, same class as
+// the GET /builds list: if a partner flips PUBLIC->PRIVATE or is unlinked, it
+// can linger in an anon cache entry for up to maxAge — the partner mutations
+// don't purge this path (no tractable per-key eviction). Bounded and low-risk:
+// the strip only shows a title/thumbnail, never the loadout.
+builds.get("/:slug/partners", edgeCache({ maxAge: 300 }), async (c) => {
   const slug = c.req.param("slug")
   const session = await getSession(c)
   const viewerId = session?.user.id


### PR DESCRIPTION
## Why

A traffic surge (~750% visits, ~450% page views) pushed the Hyperdrive **Free-plan daily query count** toward its cap. On the Free plan, queries past the cap **fail with an error** (they aren't billed), so hitting it would take down every DB-backed feature (builds, likes, bookmarks, auth) until the 00:00 UTC reset.

Most of the load is **anonymous** (site browsing + Discord/embed traffic), so the highest-leverage fix is the anonymous edge cache (Cloudflare Cache API) — every hit is a request that never reaches Postgres/Hyperdrive.

> The structural ceiling-remover is still upgrading to the **Workers Paid plan** (~$5/mo → unlimited Hyperdrive queries). This PR is the code-side headroom on top of that, and a genuine inefficiency fix regardless.

## What changed

- **Edge-cache `GET /builds/:slug/partners`** (`maxAge: 300`). The "Related builds" strip fires this on **every full build-detail page view**, but the route had no `edgeCache` middleware and hit Postgres uncached every time — even for anonymous viewers — roughly **doubling** the DB queries per anon detail view (cached detail + uncached partners). This is the main win.
- **Raise `GET /builds` list cache TTL 120s → 300s.** Helps the hot keys (default browse / page 1).
- **Refresh `edge-cache.ts` comments**: drop the stale Neon-autosuspend rationale (we're on PlanetScale now), reframe around the Hyperdrive query cap, and fix the 120s → 300s reference.

## Reviewer notes

- **Cache safety is unchanged from the detail route's model.** `edgeCache` bypasses the cache whenever a session cookie is present, so authenticated viewers still get their viewer-specific partner visibility. Only cookieless (anonymous) responses — which see a stable PUBLIC/UNLISTED partner set — are stored.
- **Accepted staleness on partners**, same class as the existing list cache: partner mutations don't purge this path (no tractable per-key eviction in the Cache API), so an unlinked or newly-private partner can linger in an anon entry for up to 300s. Bounded and low-risk — the strip only renders a title/thumbnail, never the loadout. Documented inline.
- **List TTL tradeoff:** a new/edited build now takes up to 5 min (was 2) to surface in listings.
- **Detail TTL left at 300s on purpose.** Anonymous view-counting only runs on a cache *miss*, so raising the detail TTL would suppress view-count accrual on popular builds. Not worth trading view-count fidelity for during an active traffic spike.

## Verification

`just check` (typecheck + oxlint + oxfmt) passes across web + api + shared; scripts typecheck clean.