### PR TITLE
feat(web): bump cost disclaimer to ~$10/mo + more prominent donation nudges

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -1137,9 +1137,11 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
               </a>
             </div>
           </div>,
-          // Explicit close button — dismissal shouldn't rely on the user
-          // knowing they can swipe a toast away.
-          { duration: 15000, closeButton: true },
+          // Persist until manually dismissed (duration: Infinity) so the ask
+          // isn't missed — paired with an explicit close button so dismissal
+          // doesn't rely on the user knowing they can swipe a toast away. Still
+          // fires at most once per browser (markDonationNudgeShown above).
+          { duration: Infinity, closeButton: true },
         )
       }
       navigate({ to: "/builds/$slug", params: { slug } })

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -1122,8 +1122,8 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
             <div>
               <p className="font-medium">Thanks for building with Arsenyx</p>
               <p className="text-muted-foreground text-sm">
-                It&apos;s free and ad-free, running on ~$10/mo of server costs.
-                If it&apos;s useful to you, a small tip keeps it online.
+                It&apos;s free and ad-free, and costs me about $10 a month to
+                run. If it&apos;s useful to you, a small tip keeps it going.
               </p>
             </div>
             <div className="flex text-sm">

--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -1118,20 +1118,20 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
       if (!isUpdate && !hasShownDonationNudge()) {
         markDonationNudgeShown()
         toast(
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-3">
             <div>
               <p className="font-medium">Thanks for building with Arsenyx</p>
               <p className="text-muted-foreground text-sm">
-                It&apos;s free and runs on ~$5/mo of server costs. If it&apos;s
-                useful to you, a small tip keeps it online.
+                It&apos;s free and ad-free, running on ~$10/mo of server costs.
+                If it&apos;s useful to you, a small tip keeps it online.
               </p>
             </div>
-            <div className="flex gap-4 text-sm">
+            <div className="flex text-sm">
               <a
                 href={EXTERNAL_LINKS.koFi}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-medium underline underline-offset-2"
+                className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center rounded-md px-3 py-1.5 font-medium transition-colors"
               >
                 Support on Ko-fi
               </a>
@@ -1139,7 +1139,7 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
           </div>,
           // Explicit close button — dismissal shouldn't rely on the user
           // knowing they can swipe a toast away.
-          { duration: 12000, closeButton: true },
+          { duration: 15000, closeButton: true },
         )
       }
       navigate({ to: "/builds/$slug", params: { slug } })

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -74,8 +74,8 @@ export function Footer() {
                 Arsenyx is free and ad-free
               </span>
               <span className="text-muted-foreground">
-                , running on ~$10/mo of server costs. If it&apos;s useful to
-                you, a small tip keeps it online.
+                , and costs me about $10 a month to keep online. If it&apos;s
+                useful to you, a small tip helps cover it.
               </span>
             </p>
             <Button

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,6 +1,7 @@
 import { Icons } from "@/components/icons"
 import { Link } from "@/components/link"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import type { NavLink } from "@/lib/types"
 import { SITE_CONFIG, FOOTER_LINKS, EXTERNAL_LINKS } from "@/lib/util/constants"
@@ -66,19 +67,33 @@ export function Footer() {
 
         <Separator className="my-8" />
 
-        <p className="text-muted-foreground mb-6 text-center text-sm">
-          Arsenyx is free and runs on ~$5/mo of server costs. If it&apos;s
-          useful to you, a small tip keeps it online —{" "}
-          <a
-            href={EXTERNAL_LINKS.koFi}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-foreground/80 hover:text-foreground font-medium underline underline-offset-2"
-          >
-            Ko-fi
-          </a>
-          .
-        </p>
+        <div className="mb-8 flex justify-center">
+          <div className="bg-muted/30 flex max-w-xl flex-col items-center gap-3 rounded-xl border px-6 py-5 text-center">
+            <p className="text-sm leading-relaxed">
+              <span className="text-foreground font-semibold">
+                Arsenyx is free and ad-free
+              </span>
+              <span className="text-muted-foreground">
+                , running on ~$10/mo of server costs. If it&apos;s useful to
+                you, a small tip keeps it online.
+              </span>
+            </p>
+            <Button
+              size="sm"
+              render={
+                <Link
+                  href={EXTERNAL_LINKS.koFi}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+              nativeButton={false}
+            >
+              <Icons.heart data-icon="inline-start" />
+              Support on Ko-fi
+            </Button>
+          </div>
+        </div>
 
         <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <p className="text-muted-foreground text-sm">

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -49,9 +49,9 @@ function AboutPage() {
             <p>
               It&apos;s just me. No team, no company, no roadmap meetings
               &mdash; just one Tenno building the tool I wished existed, for the
-              love of the game. Arsenyx is free and ad-free, running on ~$10/mo
-              of server costs out of my own pocket. If it&apos;s useful to you,
-              a small tip keeps it online &mdash; it genuinely helps.
+              love of the game. Arsenyx is free and ad-free, and the hosting
+              runs me about $10 a month out of pocket. If it&apos;s useful to
+              you, a tip genuinely helps keep it online.
             </p>
             <div className="not-prose">
               <Button

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -49,13 +49,12 @@ function AboutPage() {
             <p>
               It&apos;s just me. No team, no company, no roadmap meetings
               &mdash; just one Tenno building the tool I wished existed, for the
-              love of the game. Arsenyx is free and ad-free; if it&apos;s useful
-              to you, a small tip helps cover the server costs.
+              love of the game. Arsenyx is free and ad-free, running on ~$10/mo
+              of server costs out of my own pocket. If it&apos;s useful to you,
+              a small tip keeps it online &mdash; it genuinely helps.
             </p>
             <div className="not-prose">
               <Button
-                variant="outline"
-                size="sm"
                 render={
                   <Link
                     href={EXTERNAL_LINKS.koFi}


### PR DESCRIPTION
## Why

Server costs rose to **~\$10/mo** after upgrading to the Workers **Paid** plan — the Free-tier Hyperdrive daily query cap (100k/day) started failing requests under a recent ~750% traffic surge, so the upgrade was needed to keep DB-backed features online. This updates the public cost figure everywhere it's stated and gives the Ko-fi asks a bit more visual weight now that the site runs at a real, non-trivial cost.

## What changed

- **Footer** ([footer.tsx](apps/web/src/components/footer.tsx)) — the muted one-line tip becomes a bordered callout box with a proper "Support on Ko-fi" button; figure updated `~\$5/mo → ~\$10/mo`.
- **Post-publish toast** ([editor-shell.tsx](apps/web/src/components/build-editor/editor-shell.tsx)) — `~\$10/mo`; the Ko-fi link is now a filled button and the toast shows ~3s longer (12s → 15s). Still a dismissible toast, never a modal/banner — stays gentle, fires once per browser after a *new* publish.
- **About** ([about.tsx](apps/web/src/routes/about.tsx)) — Ko-fi button promoted from outline to filled, names the `~\$10/mo` out-of-pocket cost, and the copy is warmed up slightly.

## Notes for reviewer

- "A little more prominent" was the brief — kept it tasteful: a callout box + filled buttons, no popups or aggressive banners.
- No new dependencies; Ko-fi destination unchanged (`EXTERNAL_LINKS.koFi`). The once-per-browser gate on the publish nudge is untouched.

## Verification

`just check` (typecheck + oxlint + oxfmt) clean. Verified live in the dev preview: `/about` renders both the filled support button and the footer callout, `\$10/mo` figure present, no console errors.