### PR TITLE
chore(web): plainer wording for the latest changelog entries

### DIFF
--- a/apps/web/src/data/changelog.ts
+++ b/apps/web/src/data/changelog.ts
@@ -16,12 +16,12 @@ export const CHANGELOG: ChangelogEntry[] = [
       {
         type: "feat",
         description:
-          "Sirius & Orion now carry Archon Shards per form: Sirius and Orion each keep their own shard install, so you can plan a separate shard setup for each half and switching forms no longer overwrites the other's. The shards travel in the share URL too, so a link opens with both forms' shards intact.",
+          "Archon Shards on Sirius & Orion are now per form: each half keeps its own shards, so planning one form no longer wipes the other's. They're saved in the share link too, so it opens with both forms' shards intact.",
       },
       {
         type: "chore",
         description:
-          "Build pages load faster — the public version of a build page is now cached at the edge, so the common case renders without waiting on an extra round-trip.",
+          "Build pages open faster for logged-out visitors — they're now served from a cache instead of being rebuilt on every view.",
       },
     ],
   },


### PR DESCRIPTION
## What

A copy pass over the two most recent changelog entries (2026-06-19). No new entries — the changelog is already current.

- **Caching note** rewritten from dev-speak to what a player actually experiences. Was: "the public version of a build page is now cached at the edge, so the common case renders without waiting on an extra round-trip." Now: "Build pages open faster for logged-out visitors — they're now served from a cache instead of being rebuilt on every view."
- **Sirius & Orion shard entry** tightened — it named the frame twice in a row and used "shard install" jargon. Same meaning, plainer wording.

## Why no new entries

Checked, and the changelog doesn't have a content gap:
- The recent perf work ([#248](https://github.com/Reuzehagel/arsenyx/pull/248)) isn't merged, so adding it would claim unshipped work — and the build-page-caching improvement is already covered by the reworded chore entry.
- The donation/cost-disclaimer copy ([#249](https://github.com/Reuzehagel/arsenyx/pull/249)) is support-copy, not a product change players notice.

## Verification

Typecheck clean. Rendered `/changelog` in the dev preview — both entries show the new wording, no dev-speak remaining.