### PR TITLE
fix(web): allow Helminth subsume on either Sirius & Orion brother

### DIFF
--- a/apps/web/src/components/build-editor/editor-shell.tsx
+++ b/apps/web/src/components/build-editor/editor-shell.tsx
@@ -408,7 +408,6 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
     isTwin,
     activeFormIndex,
     formAbilities,
-    helminthAllowed,
     formNames,
     formVariants,
     formActiveLocalIndex,
@@ -1449,7 +1448,6 @@ export function EditorShell({ search }: { search: EditorShellSearch }) {
               placedMods: slots.placed,
               placedArcanes: arcanes.placed,
               formAbilities,
-              helminthAllowed,
             }}
             topBarLayout="row"
             topBar={

--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -122,10 +122,6 @@ export interface ItemSidebarProps {
   /** Twin-frames (Sirius & Orion): the active form's ability set, overriding
    *  `item.abilities`. Absent for normal frames. */
   formAbilities?: ItemAbility[]
-  /** Twin-frames: Helminth can only be infused on the primary form, so the
-   *  subsume UI (and the helminth replacement display) is suppressed on
-   *  non-primary forms. Defaults to true. */
-  helminthAllowed?: boolean
   readOnly?: boolean
   /**
    * When true, render without the outer card chrome and without the mobile
@@ -165,7 +161,6 @@ export function ItemSidebar({
   placedMods,
   placedArcanes,
   formAbilities,
-  helminthAllowed = true,
   readOnly = false,
   bare = false,
 }: ItemSidebarProps) {
@@ -350,9 +345,9 @@ export function ItemSidebar({
           <>
             <div className="flex justify-around p-3">
               {abilities.slice(0, 4).map((a, i) => {
-                // Helminth lives on the primary form only — on a secondary
-                // twin-frame form, show the raw ability with no replacement.
-                const replaced = helminthAllowed ? helminth[i] : undefined
+                // Helminth is per-variant (and so per-form): each twin-frame
+                // form shows its own subsume, or the raw ability when unset.
+                const replaced = helminth[i]
                 const displayed = replaced
                   ? {
                       uniqueName: replaced.uniqueName,
@@ -366,7 +361,7 @@ export function ItemSidebar({
                     key={i}
                     ability={displayed}
                     isHelminth={Boolean(replaced)}
-                    canSubsume={isPureWarframe && !readOnly && helminthAllowed}
+                    canSubsume={isPureWarframe && !readOnly}
                     onSelectHelminth={(ab) => onSetHelminth(i, ab)}
                   />
                 )

--- a/apps/web/src/components/build-viewer/build-viewer-body.tsx
+++ b/apps/web/src/components/build-viewer/build-viewer-body.tsx
@@ -176,15 +176,14 @@ function BuildViewerBodyInner({
   const hasGuide = hasGuideContent(build, activeVariant)
 
   // Twin-frames (Sirius & Orion): the active variant's form picks the ability
-  // set (Helminth shows only on the primary form), and the variant tabs show
-  // only that form's variants. Shared with the editor via `deriveFormAxis`;
+  // set (each form carries its own per-variant Helminth), and the variant tabs
+  // show only that form's variants. Shared with the editor via `deriveFormAxis`;
   // no-op for normal frames. The form toggle jumps to the target form's first
   // variant.
   const {
     isTwin,
     activeFormIndex,
     formAbilities,
-    helminthAllowed,
     formNames,
     formVariants,
     formActiveLocalIndex,
@@ -267,7 +266,6 @@ function BuildViewerBodyInner({
     placedMods: slots.placed,
     placedArcanes: arcanes.placed,
     formAbilities,
-    helminthAllowed,
     readOnly: true as const,
   }
 
@@ -302,7 +300,7 @@ function BuildViewerBodyInner({
             itemName={item.name}
             itemImageName={item.imageName ?? undefined}
             abilities={formAbilities ?? item.abilities ?? []}
-            helminth={helminthAllowed ? helminth : {}}
+            helminth={helminth}
             shards={shards}
             zawComponents={zawComponents}
             kitgunComponents={kitgunComponents}

--- a/apps/web/src/data/changelog.ts
+++ b/apps/web/src/data/changelog.ts
@@ -11,6 +11,16 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-06-20",
+    changes: [
+      {
+        type: "fix",
+        description:
+          "Sirius & Orion: you can now subsume a Helminth ability on Orion, not just Sirius. Each brother keeps his own subsume, so it lands on whoever's in front.",
+      },
+    ],
+  },
+  {
     date: "2026-06-19",
     changes: [
       {

--- a/apps/web/src/lib/form-axis.ts
+++ b/apps/web/src/lib/form-axis.ts
@@ -9,11 +9,16 @@ import type { FrameForm, ItemAbility } from "@/lib/warframe"
  * form (absent / 0 = primary). Shards are per-variant (not per-form), so each
  * half's variants carry their own.
  *
+ * Either brother can be the "Primary Son" who holds the subsumed ability —
+ * the player picks, and in the planner the active form is that primary — so
+ * Helminth is allowed on whichever form a variant builds (each variant carries
+ * its own per-variant Helminth state).
+ *
  * Both the editor (`EditorShell`) and the read-only viewer (`BuildViewerBody`)
- * need the same derived view — the active form, its ability set, whether
- * Helminth is allowed, the short toggle labels, and the global↔local index
- * mapping for the form-filtered variant tabs. This is the single source so the
- * two can't drift. Pure (no React) so callers wrap it in `useMemo`.
+ * need the same derived view — the active form, its ability set, the short
+ * toggle labels, and the global↔local index mapping for the form-filtered
+ * variant tabs. This is the single source so the two can't drift. Pure (no
+ * React) so callers wrap it in `useMemo`.
  */
 export interface FormAxis {
   /** True when the item has more than one switchable form. */
@@ -23,8 +28,6 @@ export interface FormAxis {
   /** The active form's ability set, overriding `item.abilities`. Undefined for
    *  normal frames (the caller falls back to `item.abilities`). */
   formAbilities: ItemAbility[] | undefined
-  /** Helminth is infused on the primary form only. */
-  helminthAllowed: boolean
   /** Short toggle labels — DE names the controlled form first in the combined
    *  name ("Sirius & Orion" → "Sirius", "Orion & Sirius" → "Orion"). Undefined
    *  for normal frames. */
@@ -88,7 +91,6 @@ export function deriveFormAxis(
     isTwin: Boolean(forms && forms.length > 1),
     activeFormIndex,
     formAbilities: activeForm?.abilities,
-    helminthAllowed: activeFormIndex === 0,
     formNames: forms?.map((f) => f.name.split(/\s*&\s*/)[0]),
     formVariants,
     formActiveLocalIndex: Math.max(


### PR DESCRIPTION
## What

On the Sirius & Orion twin-frame, you could change the Helminth subsume on **Sirius** but not on **Orion**. This lets you subsume on either brother.

## Why it was broken

The planner gated the subsume UI to form 0 (Sirius) in `form-axis.ts`:

```ts
helminthAllowed: activeFormIndex === 0,
```

That assumed Sirius is always the primary. Per the [WARFRAME Wiki](https://wiki.warframe.com/w/Sirius_&_Orion/Abilities), the subsumed ability does go on the **Primary Son** — but the *player* chooses which brother is primary; it's not fixed to Sirius.

## The fix

`helminth` is already a **per-variant** field, and each variant belongs to exactly one form, so allowing the subsume on either form stores it on that form's variant without leaking onto the other brother. That made `helminthAllowed` always-true and vestigial (with comments asserting the opposite of the real rule), so I removed it across:

- `form-axis.ts` — dropped the field + derivation, fixed the doc comment
- `editor-shell.tsx` / `item-sidebar.tsx` — `canSubsume` is now just `isPureWarframe && !readOnly`
- `build-viewer-body.tsx` — viewer/embed show each form's own subsume
- `changelog.ts` — user-facing fix entry

## Verification

`bun run typecheck` + `just check` (lint + format) clean. In-browser on the create editor:

- **Orion**: opened the Helminth picker (previously absent), subsumed Eclipse over Gravitic Slash → strip shows Eclipse
- **Sirius**: unaffected — no leak between brothers
- Toggling forms back and forth preserves each brother's subsume

## Reviewer notes

- No data-format change. Existing builds are unaffected — Orion variants previously couldn't hold a subsume, so there's no legacy data that newly appears.
- Originated from a community bug report (Orion couldn't change subsume).