### PR TITLE
fix(web): bust immutable /data cache after #256 (bump data-version)

### DIFF
--- a/apps/web/public/data/meta.json
+++ b/apps/web/public/data/meta.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T06:57:15.661Z",
+  "generatedAt": "2026-06-21T19:21:15.616Z",
   "source": "DE PublicExport + wiki Lua (v2 pipeline)",
   "pipelineVersion": 2,
   "itemCount": 863,


### PR DESCRIPTION
## Symptom
After #256 merged and deployed, old build pages still showed the broken data (missing Arcane Crepuscular, Sirius & Orion with two aura slots) for users who'd already loaded the site.

## Cause
`/data/*` is served `Cache-Control: immutable, max-age=31536000` under **stable** URLs. The app cache-busts by appending `?v=<data-version>`, and `dataVersion()` ([vite.config.ts](apps/web/vite.config.ts)) derives that stamp **solely from `meta.json`'s `generatedAt`**.

#256 hand-corrected the catalog bytes but left `generatedAt` untouched (`2026-06-21T06:57:15.661Z`), so `?v=` stayed identical to the broken #255 build (`1782025035661`). Browsers that fetched the broken catalog cached it immutably under that exact URL and never revalidate — so the corrected bytes (already live at the edge) are masked client-side.

Verified: `GET /data/arcanes-all.json?v=1782025035661` at the edge now returns the *correct* data, but any browser holding the immutable copy under that URL won't refetch it.

## Fix
Bump `generatedAt` → new `?v=` (`1782069675616`). On deploy, the new JS bundle requests `/data/...?v=<new>`, a fresh never-cached URL, so every client gets the corrected catalog. Returning tabs pick up the new bundle via `index.html` (`must-revalidate`) + the existing app-update prompt.

## Note / follow-up
A manual edit to `public/data/` must bump `generatedAt` (a real pipeline regen does this automatically). Worth considering a guard — e.g. derive the version from a content hash of the catalog rather than the timestamp — so hand-edits can't silently skip cache-busting. Out of scope here.