### PR TITLE
refactor(build): make melee slot-wide pool check symmetric

### DIFF
--- a/scripts/build/merge-weapons.ts
+++ b/scripts/build/merge-weapons.ts
@@ -249,6 +249,7 @@ const PRIMARY_GRANULAR_POOLS = [
   "Assault Rifle",
 ] as const
 const SECONDARY_GRANULAR_POOLS = ["Pistol", "Thrown", "Tome"] as const
+const MELEE_GRANULAR_POOLS = ["Melee"] as const
 
 /**
  * Add the slot-wide DE pool ("PRIMARY"/"SECONDARY"/"MELEE") implied by the
@@ -260,7 +261,7 @@ const SECONDARY_GRANULAR_POOLS = ["Pistol", "Thrown", "Tome"] as const
 export function addSlotWidePools(pools: Set<string>): void {
   if (PRIMARY_GRANULAR_POOLS.some((p) => pools.has(p))) pools.add("PRIMARY")
   if (SECONDARY_GRANULAR_POOLS.some((p) => pools.has(p))) pools.add("SECONDARY")
-  if (pools.has("Melee")) pools.add("MELEE")
+  if (MELEE_GRANULAR_POOLS.some((p) => pools.has(p))) pools.add("MELEE")
 }
 
 /** Strip the Coda / Kuva / Tenet prefix from a variant name to recover the


### PR DESCRIPTION
## What

Introduces a `MELEE_GRANULAR_POOLS = ["Melee"]` constant and routes the melee branch of `addSlotWidePools` through the same `.some((p) => pools.has(p))` pattern already used for `PRIMARY_GRANULAR_POOLS` and `SECONDARY_GRANULAR_POOLS`.

## Why

Pure consistency refactor — all three slot checks are now symmetric, so melee can pick up additional granular pool names later without touching the control flow. Behaviorally identical to the previous `pools.has("Melee")`.

## Notes

Follows up on the merged #258 / #259 work. `just check` (typecheck across web/api/shared + `scripts/tsconfig.json`, lint, format) passes clean.