### PR TITLE
docs(changelog): note arcane icon repair

### DIFF
--- a/apps/web/src/data/changelog.ts
+++ b/apps/web/src/data/changelog.ts
@@ -11,6 +11,16 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-06-30",
+    changes: [
+      {
+        type: "fix",
+        description:
+          "Arcanes Crepuscular, Sculptor, and Steadfast now show their correct art. Crepuscular used to come up as a blank blue glyph, and Sculptor and Steadfast were showing the wrong icons.",
+      },
+    ],
+  },
+  {
     date: "2026-06-28",
     changes: [
       {


### PR DESCRIPTION
## What & why

Adds a user-facing changelog entry (dated 2026-06-30) for the arcane icon repair that shipped in #266. That PR's substantive change — Crepuscular, Sculptor, and Steadfast now rendering their correct framed art — wasn't reflected in the public `/changelog`. The data-pipeline cleanup from #266 is intentionally left out; it's internal and not something visitors see.

## Entry

> **fix** — Arcanes Crepuscular, Sculptor, and Steadfast now show their correct art. Crepuscular used to come up as a blank blue glyph, and Sculptor and Steadfast were showing the wrong icons.

Phrasing run through the human-writing pass to match the changelog's existing plain, concrete voice (no "showcase"/"key improvement"/inflated-significance filler).

## Notes

- Single-file change to [apps/web/src/data/changelog.ts](apps/web/src/data/changelog.ts).
- `apps/web` typecheck, oxlint, and oxfmt all pass on the touched file.
- Heads-up unrelated to this PR: `bun run typecheck` currently fails in `apps/api` (`_build-list.ts`, `builds.ts` — `TS2322` "string not assignable to never"). Those errors are pre-existing on `main`, not introduced here.
