### PR TITLE
chore(data): empty arcane InternalName override (wiki fixed upstream)

### DIFF
--- a/data/curated/arcane-internalname-fixes.ts
+++ b/data/curated/arcane-internalname-fixes.ts
@@ -12,19 +12,16 @@
  * This map corrects the join key at ingestion, keyed by the wiki row's stable
  * `Name` field → the *correct* DE uniqueName (verified against
  * ExportRelicArcane). It's a gap-stop for upstream data errors, same spirit as
- * WIKI_ALIASES. Remove an entry once the wiki row carries the right
- * `InternalName` again (the wiki stays authoritative when its data is correct).
+ * WIKI_ALIASES. Add an entry when a row is mislabeled; remove it once the wiki
+ * row carries the right `InternalName` again (the wiki stays authoritative when
+ * its data is correct). The map is empty when the wiki is accurate.
  *
- * Observed 2026-06-28 (#262 refresh): Crepuscular/Sculptor rows carried each
- * other's / Steadfast's id, so Crepuscular went frameless, Sculptor showed
- * Crepuscular's art, and Steadfast showed Sculptor's. Steadfast's own row is
- * correct; fixing the two below resolves the whole chain.
+ * History — Crepuscular/Sculptor (#266, observed in the 2026-06-28 #262
+ * refresh): their rows carried each other's / Steadfast's id, so Crepuscular
+ * went frameless, Sculptor showed Crepuscular's art, and Steadfast showed
+ * Sculptor's. Corrected upstream on 2026-06-30 (all three rows verified against
+ * `Module:Arcane/data`), so the entries were removed.
  */
 
-/** Wiki `Name` → correct DE uniqueName. */
-export const ARCANE_INTERNALNAME_FIXES: Record<string, string> = {
-  "Arcane Crepuscular":
-    "/Lotus/Upgrades/CosmeticEnhancers/Utility/AbilityStrengthAndCritDamageWhenInvisible",
-  "Arcane Sculptor":
-    "/Lotus/Upgrades/CosmeticEnhancers/Utility/AbilityEfficiencyOnAbilityObjectCreation",
-}
+/** Wiki `Name` → correct DE uniqueName. Empty when the wiki is accurate. */
+export const ARCANE_INTERNALNAME_FIXES: Record<string, string> = {}


### PR DESCRIPTION
## What & why

`Module:Arcane/data`'s shifted-`InternalName` bug — the root cause behind the mis-iconed arcanes fixed in #266 — has been corrected upstream. As of 2026-06-30, all three affected rows carry their own `InternalName` (verified against the raw Lua at `Module:Arcane/data`):

| Arcane | Wiki `InternalName` | Wiki `Image` |
|---|---|---|
| Crepuscular | `…/AbilityStrengthAndCritDamageWhenInvisible` | `ArcaneCrepuscular.png` ✓ |
| Sculptor | `…/AbilityEfficiencyOnAbilityObjectCreation` | `ArcaneSculptor.png` ✓ |
| Steadfast | `…/NoCostCastChanceOnCast` | `ArcaneSteadfast.png` ✓ |

So `ARCANE_INTERNALNAME_FIXES` is now redundant — this is the follow-up #266 flagged ("once that lands, the override file can be emptied").

## Change

- Empty the override map. **Kept** the file, its doc comment (now with a History note recording the #266 incident and the upstream fix), and the `resolve-images.ts` join branch — so the next mislabel is a one-line data add, not a re-plumb.

## Notes

- **Safe with no rebuild**: with the wiki now correct, the join produces the right art with or without the override, and the committed catalog under `apps/web/public/data/` is already correct (hand-patched in #266). Emptying this build-config file doesn't touch the catalog, so no `data:stamp` and no `check:data-version` trip.
- `typecheck:scripts`, oxlint, and oxfmt pass on the touched file.
