### PR TITLE
Fix embed theme gaps and ability element text

### DIFF
--- a/apps/web/src/components/build-editor/ability-icon.tsx
+++ b/apps/web/src/components/build-editor/ability-icon.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query"
 import { Undo2, Zap } from "lucide-react"
 import { Suspense, useMemo, useState } from "react"
 
+import { StatText } from "@/components/stat-text"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -64,7 +65,7 @@ export function AbilityIcon({
         <TooltipContent side="bottom" className="max-w-xs">
           <p className="font-semibold">{ability.name}</p>
           <p className="text-muted-foreground mt-0.5 whitespace-pre-line">
-            {ability.description}
+            <StatText text={ability.description} />
           </p>
         </TooltipContent>
       </Tooltip>
@@ -92,7 +93,7 @@ export function AbilityIcon({
               <p className="text-destructive text-xs">(Helminth)</p>
             )}
             <p className="text-muted-foreground text-xs whitespace-pre-line">
-              {ability.description}
+              <StatText text={ability.description} />
             </p>
           </div>
         )}

--- a/apps/web/src/components/build-viewer/embed-shell.tsx
+++ b/apps/web/src/components/build-viewer/embed-shell.tsx
@@ -3,7 +3,10 @@ import { useEffect, useRef, useState } from "react"
 /**
  * Embed wrapper for /builds/$slug?embed=1. Fires postMessage so host pages
  * can auto-resize the iframe to the exact content height. The `bg` param
- * sets body background to blend the embed with the host page.
+ * paints only the outer host-blending layer; the measured inner layer stays
+ * on Arsenyx's card color so gaps between rounded embed panels don't expose a
+ * stale host background after the host site changes theme without reloading the
+ * iframe.
  *
  * `scale` applies CSS `zoom` globally (e.g. 0.9 = 90%). Because `zoom`
  * affects layout, wrap-query responsive reflow still works — mods wrap
@@ -47,14 +50,20 @@ export function EmbedShell({
 
   return (
     <div
-      ref={innerRef}
       className="bg-background w-full"
       style={{
-        ...(zoom !== 1 && { zoom }),
         ...(bgColor && { backgroundColor: bgColor }),
       }}
     >
-      {children}
+      <div
+        ref={innerRef}
+        className="bg-card w-full"
+        style={{
+          ...(zoom !== 1 && { zoom }),
+        }}
+      >
+        {children}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/build-viewer/embed-strips.tsx
+++ b/apps/web/src/components/build-viewer/embed-strips.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, Zap } from "lucide-react"
 import { type ReactNode, Suspense, useState } from "react"
 
 import { ShardSlot } from "@/components/build-editor/shard-controls"
+import { StatText } from "@/components/stat-text"
 import {
   Popover,
   PopoverContent,
@@ -311,7 +312,7 @@ function EmbedAbilityIcon({
         )}
       </p>
       <p className="text-muted-foreground mt-0.5 text-xs">
-        {ability.description}
+        <StatText text={ability.description} />
       </p>
     </>
   )


### PR DESCRIPTION
## Summary
- keep embed host background separate from the Arsenyx content background so rounded panel gaps do not expose stale host theme colors
- render Warframe ability descriptions through StatText in normal and embed popovers so element tags show icons/colors

## Tests
- bun run fmt:check
- bun --filter=arsenyx-web run typecheck
- bun --filter=arsenyx-web run test src/components/stat-text.test.ts