### PR TITLE
Verified org badges, org-member build visibility (#274), pt-guide embed whitelist

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -110,6 +110,9 @@ model Organization {
   slug        String  @unique
   image       String?
   description String?
+  // Manually granted via the admin panel to real communities (WFCD, Endo
+  // Flood, …). Verified orgs render purple (--color-wf-org); the rest muted.
+  verified    Boolean @default(false)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/apps/api/scripts/migrations/2026-07-03_org_verified.sql
+++ b/apps/api/scripts/migrations/2026-07-03_org_verified.sql
@@ -1,0 +1,9 @@
+-- Adds the admin-granted verified flag for organizations. Verified orgs
+-- render purple (--color-wf-org) across the site; unverified render muted.
+--
+-- Apply to prod (PlanetScale) BEFORE merging the API change (from apps/api/,
+-- with DATABASE_URL pointed at the prod direct string):
+--   bunx prisma db execute --file scripts/migrations/2026-07-03_org_verified.sql
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS "verified" boolean NOT NULL DEFAULT false;

--- a/apps/api/src/routes/_build-list.ts
+++ b/apps/api/src/routes/_build-list.ts
@@ -38,7 +38,7 @@ export const LIST_SELECT = {
     },
   },
   organization: {
-    select: { id: true, name: true, slug: true, image: true },
+    select: { id: true, name: true, slug: true, image: true, verified: true },
   },
 } as const
 
@@ -55,7 +55,7 @@ export const DETAIL_INCLUDE = {
     },
   },
   organization: {
-    select: { id: true, name: true, slug: true, image: true },
+    select: { id: true, name: true, slug: true, image: true, verified: true },
   },
   buildGuide: {
     select: { summary: true, description: true, updatedAt: true },

--- a/apps/api/src/routes/_build-visibility.ts
+++ b/apps/api/src/routes/_build-visibility.ts
@@ -84,6 +84,17 @@ export function orgPublicScope(organizationId: string): ListScope {
   }
 }
 
+/** Every Build published under an Organization, at any Visibility — the org
+ *  page as seen by the org's own members (`GET /orgs/:slug/builds` when the
+ *  viewer is a member). Mirrors the per-Build rule in builds.ts, where org
+ *  membership grants view access to the org's PRIVATE Builds (#274). */
+export function orgMemberScope(organizationId: string): ListScope {
+  return {
+    baseWhere: { organizationId },
+    baseFilter: Prisma.sql`"organizationId" = ${organizationId}`,
+  }
+}
+
 /** No Visibility filter at all — the admin moderation list sees every Build
  *  regardless of Visibility (`GET /admin/builds`). Guarded by requireAdmin at
  *  the route; the scope itself is deliberately unfiltered. */

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -266,6 +266,7 @@ admin.get("/orgs", adminSearchLimit, async (c) => {
         slug: true,
         image: true,
         description: true,
+        verified: true,
         createdAt: true,
         _count: { select: { members: true, builds: true } },
       },
@@ -280,6 +281,7 @@ admin.get("/orgs", adminSearchLimit, async (c) => {
       slug: o.slug,
       image: o.image,
       description: o.description,
+      verified: o.verified,
       createdAt: o.createdAt.toISOString(),
       memberCount: o._count.members,
       buildCount: o._count.builds,
@@ -288,6 +290,31 @@ admin.get("/orgs", adminSearchLimit, async (c) => {
     page,
     limit: LIST_PAGE,
   })
+})
+
+admin.patch("/orgs/:slug", adminMutateLimit, async (c) => {
+  const actor = await requireAdmin(c)
+  if (actor instanceof Response) return actor
+
+  const parsed = await parseJsonBody(c, { maxBytes: 1024 })
+  if (!parsed.ok) return parsed.response
+  const verified = parsed.value.verified
+  if (typeof verified !== "boolean") {
+    return c.json({ error: "invalid_verified" }, 400)
+  }
+
+  const slug = c.req.param("slug").toLowerCase()
+  try {
+    const updated = await prisma.organization.update({
+      where: { slug },
+      data: { verified },
+      select: { id: true, slug: true, verified: true },
+    })
+    return c.json(updated)
+  } catch (err) {
+    if (isPrismaNotFound(err)) return c.json({ error: "not_found" }, 404)
+    throw err
+  }
 })
 
 admin.delete("/orgs/:slug", adminMutateLimit, async (c) => {

--- a/apps/api/src/routes/builds.ts
+++ b/apps/api/src/routes/builds.ts
@@ -863,7 +863,7 @@ builds.get("/:slug", edgeCache({ maxAge: 60 }), async (c) => {
         itemUniqueName: true,
         itemImageName: true,
         user: { select: { name: true, username: true, displayUsername: true } },
-        organization: { select: { name: true } },
+        organization: { select: { name: true, verified: true } },
         buildGuide: { select: { summary: true } },
       },
     })

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -12,7 +12,7 @@ import {
 } from "../lib/validate"
 import { rateLimitUser } from "../middleware/rate-limit"
 import { parseListQuery, runList } from "./_build-list"
-import { orgPublicScope } from "./_build-visibility"
+import { orgMemberScope, orgPublicScope } from "./_build-visibility"
 import { parsePage, trimQ } from "./_query"
 
 export const orgs = new Hono()
@@ -75,6 +75,7 @@ orgs.get("/", async (c) => {
           slug: true,
           image: true,
           description: true,
+          verified: true,
         },
       },
     },
@@ -162,7 +163,9 @@ orgs.get("/public", async (c) => {
   const [rows, total] = await Promise.all([
     prisma.organization.findMany({
       where,
-      orderBy: { createdAt: "desc" },
+      // Verified (trusted) orgs lead the directory; within each group, newest
+      // first.
+      orderBy: [{ verified: "desc" }, { createdAt: "desc" }],
       skip,
       take: DIRECTORY_PAGE,
       select: {
@@ -171,6 +174,7 @@ orgs.get("/public", async (c) => {
         slug: true,
         image: true,
         description: true,
+        verified: true,
         createdAt: true,
         _count: {
           select: {
@@ -190,6 +194,7 @@ orgs.get("/public", async (c) => {
       slug: o.slug,
       image: o.image,
       description: o.description,
+      verified: o.verified,
       createdAt: o.createdAt.toISOString(),
       memberCount: o._count.members,
       buildCount: o._count.builds,
@@ -213,6 +218,7 @@ orgs.get("/:slug", async (c) => {
         slug: true,
         image: true,
         description: true,
+        verified: true,
         createdAt: true,
         members: {
           orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
@@ -253,6 +259,7 @@ orgs.get("/:slug", async (c) => {
     slug: org.slug,
     image: org.image,
     description: org.description,
+    verified: org.verified,
     createdAt: org.createdAt.toISOString(),
     members: org.members.map((m) => ({
       role: m.role,
@@ -269,15 +276,31 @@ orgs.get("/:slug", async (c) => {
 
 orgs.get("/:slug/builds", async (c) => {
   const slug = c.req.param("slug").toLowerCase()
-  const org = await prisma.organization.findUnique({
-    where: { slug },
-    select: { id: true },
-  })
+  const [session, org] = await Promise.all([
+    getSession(c),
+    prisma.organization.findUnique({
+      where: { slug },
+      select: { id: true },
+    }),
+  ])
   if (!org) return c.json({ error: "not_found" }, 404)
+
+  // Org members see every Build published under the org (PRIVATE and UNLISTED
+  // included), matching the per-Build rule in builds.ts; everyone else sees
+  // only PUBLIC (#274).
+  const viewerId = session?.user.id
+  const membership = viewerId
+    ? await prisma.organizationMember.findUnique({
+        where: {
+          organizationId_userId: { organizationId: org.id, userId: viewerId },
+        },
+        select: { userId: true },
+      })
+    : null
 
   const result = await runList({
     filters: parseListQuery(c),
-    ...orgPublicScope(org.id),
+    ...(membership ? orgMemberScope(org.id) : orgPublicScope(org.id)),
     defaultSort: "newest",
   })
   return c.json(result)

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -2,7 +2,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: frame-ancestors 'self' https://profit-taker.com https://*.profit-taker.com
+  Content-Security-Policy: frame-ancestors 'self' https://profit-taker.com https://*.profit-taker.com https://pt-guide.pages.dev https://*.pt-guide.pages.dev
   Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 /index.html

--- a/apps/web/src/components/build-viewer/viewer-header.tsx
+++ b/apps/web/src/components/build-viewer/viewer-header.tsx
@@ -85,7 +85,11 @@ export function ViewerHeader({
                   <RouterLink
                     to="/org/$slug"
                     params={{ slug: build.organization.slug }}
-                    className="text-[#a78bfa] hover:underline"
+                    className={
+                      build.organization.verified
+                        ? "text-wf-org hover:underline"
+                        : "hover:text-foreground hover:underline"
+                    }
                   >
                     {build.organization.name}
                   </RouterLink>

--- a/apps/web/src/components/builds/build-card.tsx
+++ b/apps/web/src/components/builds/build-card.tsx
@@ -43,7 +43,9 @@ function BuildByline({
       <>
         <p className="text-muted-foreground line-clamp-1 text-xs">
           {build.organization ? (
-            <span className="text-wf-org">{build.organization.name}</span>
+            <span className={build.organization.verified ? "text-wf-org" : ""}>
+              {build.organization.name}
+            </span>
           ) : (
             <>by {author}</>
           )}
@@ -64,7 +66,9 @@ function BuildByline({
 
   return build.organization ? (
     <>
-      <span className="text-wf-org line-clamp-1">
+      <span
+        className={`line-clamp-1 ${build.organization.verified ? "text-wf-org" : ""}`}
+      >
         {build.organization.name}
       </span>
       {!build.hideAuthor && (

--- a/apps/web/src/lib/queries/admin-actions.ts
+++ b/apps/web/src/lib/queries/admin-actions.ts
@@ -197,6 +197,7 @@ export type AdminOrg = {
   slug: string
   image: string | null
   description: string | null
+  verified: boolean
   createdAt: string
   memberCount: number
   buildCount: number
@@ -215,6 +216,25 @@ export const adminOrgsQuery = (params: { page: number; q: string }) =>
     queryFn: () =>
       adminCall<AdminOrgsResponse>(`/admin/orgs${listQuery(params)}`),
   })
+
+export function useAdminSetOrgVerified() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { slug: string; verified: boolean }) =>
+      adminCall(`/admin/orgs/${encodeURIComponent(input.slug)}`, {
+        method: "PATCH",
+        json: { verified: input.verified },
+      }),
+    onSuccess: (_data, input) => {
+      qc.invalidateQueries({ queryKey: ["admin", "orgs"] })
+      // Verified drives the purple-vs-muted org rendering on the org page,
+      // the directory, and build cards — refresh them all.
+      qc.invalidateQueries({ queryKey: ["org", input.slug.toLowerCase()] })
+      qc.invalidateQueries({ queryKey: ["orgs"] })
+      qc.invalidateQueries({ queryKey: ["builds"] })
+    },
+  })
+}
 
 export function useAdminDeleteOrg() {
   const qc = useQueryClient()

--- a/apps/web/src/lib/queries/org-query.ts
+++ b/apps/web/src/lib/queries/org-query.ts
@@ -28,6 +28,7 @@ export type OrgProfile = {
   slug: string
   image: string | null
   description: string | null
+  verified: boolean
   createdAt: string
   members: OrgMember[]
   buildCount: number
@@ -43,6 +44,7 @@ export type OrgSummary = {
   slug: string
   image: string | null
   description: string | null
+  verified: boolean
 }
 
 export type MyOrgsResponse = {
@@ -58,6 +60,7 @@ export type OrgDirectoryItem = {
   slug: string
   image: string | null
   description: string | null
+  verified: boolean
   createdAt: string
   memberCount: number
   buildCount: number

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -35,6 +35,7 @@ import {
   type AdminUserFlag,
   useAdminDeleteBuild,
   useAdminDeleteOrg,
+  useAdminSetOrgVerified,
   useAdminDeleteUser,
   useAdminPatchUser,
 } from "@/lib/queries/admin-actions"
@@ -471,6 +472,7 @@ function OrgsTab({ page, q }: { page: number; q: string }) {
 
 function OrgRow({ org }: { org: AdminOrg }) {
   const del = useAdminDeleteOrg()
+  const setVerified = useAdminSetOrgVerified()
   return (
     <div className="flex items-center gap-3 rounded-lg border p-3">
       <UserAvatar
@@ -482,7 +484,9 @@ function OrgRow({ org }: { org: AdminOrg }) {
       <div className="flex min-w-0 flex-1 flex-col">
         <Link
           href={`/org/${org.slug}`}
-          className="truncate text-sm font-medium hover:underline"
+          className={`truncate text-sm font-medium hover:underline ${
+            org.verified ? "text-wf-org" : ""
+          }`}
         >
           {org.name}
         </Link>
@@ -490,6 +494,14 @@ function OrgRow({ org }: { org: AdminOrg }) {
           /{org.slug} · {org.memberCount} members · {org.buildCount} builds
         </span>
       </div>
+      <FlagButton
+        label="Verified"
+        active={org.verified}
+        disabled={setVerified.isPending}
+        onClick={() =>
+          setVerified.mutate({ slug: org.slug, verified: !org.verified })
+        }
+      />
       <ConfirmDeleteDialog
         title="Delete organization"
         description={

--- a/apps/web/src/routes/org.$slug.tsx
+++ b/apps/web/src/routes/org.$slug.tsx
@@ -121,7 +121,14 @@ function OrgHeader({ org }: { org: OrgProfile }) {
           <h1 className="truncate text-2xl font-bold tracking-tight">
             {org.name}
           </h1>
-          <span className="shrink-0 rounded bg-[#7c3aed] px-[5px] py-[1px] text-[10px] font-semibold text-white">
+          <span
+            className={`shrink-0 rounded px-[5px] py-[1px] text-[10px] font-semibold ${
+              org.verified
+                ? "bg-[#7c3aed] text-white"
+                : "bg-muted text-muted-foreground"
+            }`}
+            title={org.verified ? "Verified organization" : undefined}
+          >
             ORG
           </span>
           <span className="text-muted-foreground text-sm">@{org.slug}</span>

--- a/apps/web/src/routes/orgs.tsx
+++ b/apps/web/src/routes/orgs.tsx
@@ -107,7 +107,12 @@ function OrgsDirectoryContent() {
                     shape="square"
                   />
                   <div className="flex min-w-0 flex-col gap-0.5">
-                    <CardTitle className="truncate">{org.name}</CardTitle>
+                    <CardTitle
+                      className={`truncate ${org.verified ? "text-wf-org" : ""}`}
+                      title={org.verified ? "Verified organization" : undefined}
+                    >
+                      {org.name}
+                    </CardTitle>
                     <CardDescription className="truncate text-xs">
                       @{org.slug}
                     </CardDescription>

--- a/packages/shared/src/api/build-dto.ts
+++ b/packages/shared/src/api/build-dto.ts
@@ -25,6 +25,8 @@ export type BuildOrganizationSummary = {
   name: string
   slug: string
   image: string | null
+  /** Admin-granted trust flag — verified orgs render purple, others muted. */
+  verified: boolean
 }
 
 export type BuildItemSummary = {


### PR DESCRIPTION
## What

Three related changes from today's org discussion:

### Verified organization badges
Org creation was always open to every signed-in user, but the purple org styling made every org look equally "official". Purple is now an admin-granted trust signal:

- New `verified` flag on `Organization` (default `false`), toggled from the admin panel's Orgs tab (`PATCH /admin/orgs/:slug`).
- Verified orgs render purple (`--color-wf-org`) on build cards, the build viewer header, the org page `ORG` chip, and the directory; unverified orgs render muted/gray.
- Verified orgs sort first in `/orgs` (then newest-first).
- `verified` flows through all org/build payloads (`BuildOrganizationSummary` in `@arsenyx/shared`).

### Fix #274 — private org builds invisible to members
`GET /orgs/:slug/builds` always used the PUBLIC-only scope. It now resolves the viewer's membership: members get the new `orgMemberScope` (all builds under the org, any visibility — mirroring the per-build rule in `builds.ts`), everyone else keeps PUBLIC-only. Route was never edge-cached, and `edgeCache` skips cookied requests, so no cache-leak surface.

Closes #274.

### Embed whitelist for Profit-Taker Guide previews
Adds `https://pt-guide.pages.dev` + `https://*.pt-guide.pages.dev` to `frame-ancestors` (requested by Kalaay). Wildcarded on their Pages project so per-commit preview hashes work too, matching the existing `*.profit-taker.com` pattern.

## ⚠️ Deploy order

Apply the migration to prod **before** merging (CI deploys the API on push to main; the new selects 500 without the column):

```
bunx prisma db execute --file scripts/migrations/2026-07-03_org_verified.sql
```

(from `apps/api/` with `DATABASE_URL` pointed at prod)

## Verified

- `bun run typecheck`, oxlint, oxfmt clean; all 56 API vitest tests pass
- Dev-DB smoke test: verified org sorts first with `verified: true` in directory/detail/build-list payloads; PRIVATE org build hidden from the anonymous org list
- Headless screenshots confirm purple-vs-gray rendering on directory, org page, and build cards
- Not exercised end-to-end: the member-visibility path (needs a signed-in member session) and the admin toggle UI — worth one manual click after deploy