### PR TITLE
Admin org toggle UX + directory card alignment

### DIFF
--- a/apps/web/src/lib/queries/admin-actions.ts
+++ b/apps/web/src/lib/queries/admin-actions.ts
@@ -225,7 +225,36 @@ export function useAdminSetOrgVerified() {
         method: "PATCH",
         json: { verified: input.verified },
       }),
-    onSuccess: (_data, input) => {
+    // Flip the admin list optimistically: the PATCH + list refetch round trip
+    // takes seconds on a cold Worker, and with no immediate feedback the
+    // toggle reads as broken (and invites mis-clicks on other rows).
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: ["admin", "orgs"] })
+      const snapshots = qc.getQueriesData<AdminOrgsResponse>({
+        queryKey: ["admin", "orgs"],
+      })
+      qc.setQueriesData<AdminOrgsResponse>(
+        { queryKey: ["admin", "orgs"] },
+        (old) =>
+          old
+            ? {
+                ...old,
+                orgs: old.orgs.map((o) =>
+                  o.slug === input.slug
+                    ? { ...o, verified: input.verified }
+                    : o,
+                ),
+              }
+            : old,
+      )
+      return { snapshots }
+    },
+    onError: (_err, _input, ctx) => {
+      for (const [key, data] of ctx?.snapshots ?? []) {
+        qc.setQueryData(key, data)
+      }
+    },
+    onSettled: (_data, _err, input) => {
       qc.invalidateQueries({ queryKey: ["admin", "orgs"] })
       // Verified drives the purple-vs-muted org rendering on the org page,
       // the directory, and build cards — refresh them all.

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -473,6 +473,7 @@ function OrgsTab({ page, q }: { page: number; q: string }) {
 function OrgRow({ org }: { org: AdminOrg }) {
   const del = useAdminDeleteOrg()
   const setVerified = useAdminSetOrgVerified()
+  const error = setVerified.error instanceof Error ? setVerified.error : null
   return (
     <div className="flex items-center gap-3 rounded-lg border p-3">
       <UserAvatar
@@ -493,11 +494,11 @@ function OrgRow({ org }: { org: AdminOrg }) {
         <span className="text-muted-foreground truncate text-xs">
           /{org.slug} · {org.memberCount} members · {org.buildCount} builds
         </span>
+        {error ? <FieldError>{error.message}</FieldError> : null}
       </div>
       <FlagButton
         label="Verified"
         active={org.verified}
-        disabled={setVerified.isPending}
         onClick={() =>
           setVerified.mutate({ slug: org.slug, verified: !org.verified })
         }

--- a/apps/web/src/routes/orgs.tsx
+++ b/apps/web/src/routes/orgs.tsx
@@ -125,7 +125,9 @@ function OrgsDirectoryContent() {
                     </p>
                   </CardContent>
                 ) : null}
-                <CardFooter className="text-muted-foreground justify-between text-xs">
+                {/* mt-auto pins the stats row to the card bottom so rows align
+                    across cards with and without a description. */}
+                <CardFooter className="text-muted-foreground mt-auto justify-between text-xs">
                   <span>
                     <span className="text-foreground font-semibold tabular-nums">
                       {org.memberCount.toLocaleString()}


### PR DESCRIPTION
Follow-up to #278, two small orgs UI fixes.

## Optimistic Verified toggle

The admin Verified toggle gave no feedback until the PATCH **and** a full org-list refetch completed — several seconds of nothing on a cold Worker, which reads as broken (and is how two orgs got verified by accident).

- `useAdminSetOrgVerified` now updates the cached admin org list optimistically in `onMutate` (button state + purple name flip instantly), rolls back from snapshots on error, and invalidates on settle as before.
- Mutation errors now render in the org row (previously swallowed silently).
- Dropped the `isPending` disable on the button — with optimistic state it only added flicker.

Verified locally with a seeded dev admin session: the row flips within ~100ms of the click (was multi-second), and the background refetch confirms the server state.

## Org directory card alignment

Cards with a description pushed their member/build stats row lower than description-less neighbours in the same grid row. `mt-auto` on the CardFooter pins the stats row to the card bottom so the rows align. Verified by DOM measurement: footer tops equal across cards with and without descriptions.