### PR TITLE
fix(editor): combine elements in slot order, not equip order

### DIFF
--- a/apps/web/src/components/build-editor/item-sidebar.tsx
+++ b/apps/web/src/components/build-editor/item-sidebar.tsx
@@ -68,7 +68,11 @@ import {
   WeaponStatsPanel,
 } from "./stats-panels"
 import type { PlacedArcane } from "./use-arcane-slots"
-import type { PlacedMod, SlotId } from "./use-build-slots"
+import {
+  placedModsInSlotOrder,
+  type PlacedMod,
+  type SlotId,
+} from "./use-build-slots"
 import { ZawComponentSelector } from "./zaw-component-selector"
 
 const SHARD_SLOTS = 5
@@ -209,11 +213,8 @@ export function ItemSidebar({
     ? (deploymentContext ?? DEFAULT_DEPLOYMENT_CONTEXT)
     : "archwing"
 
-  const modList = useMemo(
-    () =>
-      Object.values(placedMods).filter((p): p is PlacedMod => p !== undefined),
-    [placedMods],
-  )
+  // Slot reading order, not equip order — elemental combination depends on it.
+  const modList = useMemo(() => placedModsInSlotOrder(placedMods), [placedMods])
   const arcaneList = useMemo(
     () => placedArcanes.filter((a): a is PlacedArcane => !!a),
     [placedArcanes],

--- a/apps/web/src/components/build-editor/use-build-slots.test.ts
+++ b/apps/web/src/components/build-editor/use-build-slots.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   dropOrphanSlots,
+  placedModsInSlotOrder,
   type PlacedMod,
   type SlotId,
   type SlotLayout,
@@ -32,6 +33,41 @@ const COMPANION_WEAPON: SlotLayout = {
   showExilus: false,
   showStance: false,
 }
+
+describe("placedModsInSlotOrder", () => {
+  it("orders by slot position, not equip order (#272)", () => {
+    // Repro from the issue: Toxin in slot 1, Heat in slot 3, THEN Cold in
+    // slot 2. Insertion order (Toxin, Heat, Cold) would combine Toxin+Heat
+    // into Gas; slot order (Toxin, Cold, Heat) gives Viral + Heat.
+    const placed: Partial<Record<SlotId, PlacedMod>> = {}
+    placed["normal-0"] = mod("Infected Clip")
+    placed["normal-2"] = mod("Hellfire")
+    placed["normal-1"] = mod("Deep Freeze")
+    expect(placedModsInSlotOrder(placed).map((p) => p.mod.name)).toEqual([
+      "Infected Clip",
+      "Deep Freeze",
+      "Hellfire",
+    ])
+  })
+
+  it("puts aura/stance/exilus before normal slots in reading order", () => {
+    const placed: Partial<Record<SlotId, PlacedMod>> = {}
+    placed["normal-7"] = mod("D")
+    placed["exilus"] = mod("C")
+    placed["aura-1"] = mod("B2")
+    placed["stance"] = mod("B1")
+    placed["normal-0"] = mod("E")
+    placed["aura-0"] = mod("A")
+    expect(placedModsInSlotOrder(placed).map((p) => p.mod.name)).toEqual([
+      "A",
+      "B1",
+      "C",
+      "B2",
+      "E",
+      "D",
+    ])
+  })
+})
 
 describe("dropOrphanSlots", () => {
   it("drops a mod sitting in a slot the layout doesn't have", () => {

--- a/apps/web/src/components/build-editor/use-build-slots.ts
+++ b/apps/web/src/components/build-editor/use-build-slots.ts
@@ -127,6 +127,32 @@ export function getVisibleSlots(layout: SlotLayout): SlotId[] {
   return out
 }
 
+/** Reading-order rank for a slot id, matching getVisibleSlots. */
+function slotOrderIndex(id: SlotId): number {
+  if (id === "stance") return 1
+  if (id === "exilus") return 2
+  if (id.startsWith("aura-")) {
+    const n = Number(id.slice("aura-".length))
+    return n === 0 ? 0 : 2 + n
+  }
+  return 1000 + Number(id.slice("normal-".length))
+}
+
+/**
+ * Placed mods in slot reading order, regardless of the order they were
+ * equipped. `placed` is a string-keyed object, so `Object.values` yields
+ * insertion order — but elemental combination is slot-order-sensitive, so
+ * stat math must never see equip order (#272).
+ */
+export function placedModsInSlotOrder(
+  placed: Partial<Record<SlotId, PlacedMod>>,
+): PlacedMod[] {
+  return (Object.entries(placed) as [SlotId, PlacedMod | undefined][])
+    .filter((e): e is [SlotId, PlacedMod] => e[1] !== undefined)
+    .sort(([a], [b]) => slotOrderIndex(a) - slotOrderIndex(b))
+    .map(([, p]) => p)
+}
+
 /**
  * Drop seeded slot entries whose slot doesn't exist in this layout. A
  * legacy or imported build can carry a mod (or forma) in a slot the current


### PR DESCRIPTION
## Summary
- Fixes #272: while editing, elemental mods combined in the order they were equipped rather than left-right top-down slot order, showing wrong combined elements (e.g. Gas + Cold instead of Viral + Heat) until the build was saved.
- Root cause: `ItemSidebar` built its mod list with `Object.values(placedMods)` — the slot map is string-keyed, so values come back in insertion (equip) order.
- Adds `placedModsInSlotOrder()` in `use-build-slots.ts` that sorts placed mods into slot reading order (matching `getVisibleSlots`) and uses it for stat calculation. Covers both the editor and the read-only viewer, which share `ItemSidebar`.

## Test plan
- [x] New unit tests for `placedModsInSlotOrder` including the exact repro from the issue (Toxin slot 1, Heat slot 3, then Cold slot 2 → Toxin, Cold, Heat order)
- [x] `bun run typecheck` passes
- [x] Manually verified in the editor: Infected Clip + Hellfire shows Gas; adding Cryo Rounds between them now shows Viral + Heat instead of Gas + Cold