### PR TITLE
feat(web): report-an-issue shortcuts in footer and command palette

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { Compass, Hammer, LayoutGrid, ScrollText, User } from "lucide-react"
+import {
+  Bug,
+  Compass,
+  Hammer,
+  LayoutGrid,
+  ScrollText,
+  User,
+} from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 
 import {
@@ -22,6 +29,7 @@ import {
 import { authClient } from "@/lib/auth-client"
 import { fuzzyRank } from "@/lib/fuzzy"
 import { itemsIndexQuery } from "@/lib/queries/items-index-query"
+import { EXTERNAL_LINKS } from "@/lib/util/constants"
 import { CATEGORIES, getImageUrl, type BrowseItem } from "@/lib/warframe"
 
 const SEARCH_DEBOUNCE_MS = 200
@@ -166,6 +174,21 @@ export function CommandPalette({
                   <ScrollText />
                   <span>Changelog</span>
                   <CommandShortcut>what's new</CommandShortcut>
+                </CommandItem>
+                <CommandItem
+                  onSelect={() =>
+                    go(() =>
+                      window.open(
+                        EXTERNAL_LINKS.reportIssue,
+                        "_blank",
+                        "noopener,noreferrer",
+                      ),
+                    )
+                  }
+                >
+                  <Bug />
+                  <span>Report an issue</span>
+                  <CommandShortcut>GitHub</CommandShortcut>
                 </CommandItem>
               </CommandGroup>
             )}

--- a/apps/web/src/lib/util/constants.ts
+++ b/apps/web/src/lib/util/constants.ts
@@ -37,6 +37,7 @@ export const API_URL =
 // External links
 export const EXTERNAL_LINKS = {
   github: "https://github.com/Reuzehagel/arsenyx",
+  reportIssue: "https://github.com/Reuzehagel/arsenyx/issues/new/choose",
   wiki: "https://wiki.warframe.com",
   apiBase: "https://api.arsenyx.com",
   // Donation destination surfaced by the footer + post-publish nudge.
@@ -61,6 +62,11 @@ export const FOOTER_LINKS = {
     { label: "Documentation", href: ROUTES.docs },
     { label: "Changelog", href: ROUTES.changelog },
     { label: "GitHub", href: EXTERNAL_LINKS.github, external: true },
+    {
+      label: "Report an Issue",
+      href: EXTERNAL_LINKS.reportIssue,
+      external: true,
+    },
   ],
   legal: [
     { label: "Privacy Policy", href: ROUTES.privacy },


### PR DESCRIPTION
## What

- New `EXTERNAL_LINKS.reportIssue` constant pointing to https://github.com/Reuzehagel/arsenyx/issues/new/choose
- Footer: "Report an Issue" external link in the Community section
- Command palette (Ctrl+K): "Report an issue" entry in the Navigation group, opens GitHub in a new tab

## Why

Community request from Kalaay on Discord — there was no in-app path to report bugs. The `/issues/new/choose` chooser works because the repo already ships issue templates (bug report, game data, UI/UX, feature request).

## Notes for review

- Verified in local preview: footer link renders with correct href/target/rel, palette entry renders and the group behaves as before.
- `bun run typecheck` and `just check` pass.