### PR TITLE
Fix verified toggle reverting: don't refetch through Hyperdrive's stale cache

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { Compass, Hammer, LayoutGrid, ScrollText, User } from "lucide-react"
+import {
+  Bug,
+  Compass,
+  Hammer,
+  LayoutGrid,
+  ScrollText,
+  User,
+} from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 
 import {
@@ -22,6 +29,7 @@ import {
 import { authClient } from "@/lib/auth-client"
 import { fuzzyRank } from "@/lib/fuzzy"
 import { itemsIndexQuery } from "@/lib/queries/items-index-query"
+import { EXTERNAL_LINKS } from "@/lib/util/constants"
 import { CATEGORIES, getImageUrl, type BrowseItem } from "@/lib/warframe"
 
 const SEARCH_DEBOUNCE_MS = 200
@@ -166,6 +174,21 @@ export function CommandPalette({
                   <ScrollText />
                   <span>Changelog</span>
                   <CommandShortcut>what's new</CommandShortcut>
+                </CommandItem>
+                <CommandItem
+                  onSelect={() =>
+                    go(() =>
+                      window.open(
+                        EXTERNAL_LINKS.reportIssue,
+                        "_blank",
+                        "noopener,noreferrer",
+                      ),
+                    )
+                  }
+                >
+                  <Bug />
+                  <span>Report an issue</span>
+                  <CommandShortcut>GitHub</CommandShortcut>
                 </CommandItem>
               </CommandGroup>
             )}

--- a/apps/web/src/lib/queries/admin-actions.ts
+++ b/apps/web/src/lib/queries/admin-actions.ts
@@ -221,10 +221,13 @@ export function useAdminSetOrgVerified() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (input: { slug: string; verified: boolean }) =>
-      adminCall(`/admin/orgs/${encodeURIComponent(input.slug)}`, {
-        method: "PATCH",
-        json: { verified: input.verified },
-      }),
+      adminCall<{ id: string; slug: string; verified: boolean }>(
+        `/admin/orgs/${encodeURIComponent(input.slug)}`,
+        {
+          method: "PATCH",
+          json: { verified: input.verified },
+        },
+      ),
     // Flip the admin list optimistically: the PATCH + list refetch round trip
     // takes seconds on a cold Worker, and with no immediate feedback the
     // toggle reads as broken (and invites mis-clicks on other rows).
@@ -254,13 +257,36 @@ export function useAdminSetOrgVerified() {
         qc.setQueryData(key, data)
       }
     },
-    onSettled: (_data, _err, input) => {
-      qc.invalidateQueries({ queryKey: ["admin", "orgs"] })
+    // Deliberately NO immediate refetch of the admin list: API reads go
+    // through Hyperdrive, whose query cache can serve a pre-write SELECT for
+    // ~a minute — an eager refetch stomps the optimistic flip with stale data
+    // and the toggle visibly reverts. The PATCH response is authoritative, so
+    // confirm the cache from it instead.
+    onSuccess: (data, input) => {
+      qc.setQueriesData<AdminOrgsResponse>(
+        { queryKey: ["admin", "orgs"] },
+        (old) =>
+          old
+            ? {
+                ...old,
+                orgs: old.orgs.map((o) =>
+                  o.slug === input.slug ? { ...o, verified: data.verified } : o,
+                ),
+              }
+            : old,
+      )
       // Verified drives the purple-vs-muted org rendering on the org page,
-      // the directory, and build cards — refresh them all.
-      qc.invalidateQueries({ queryKey: ["org", input.slug.toLowerCase()] })
-      qc.invalidateQueries({ queryKey: ["orgs"] })
-      qc.invalidateQueries({ queryKey: ["builds"] })
+      // the directory, and build cards — mark them stale so they refetch on
+      // next visit (by which point the Hyperdrive cache has usually turned
+      // over). refetchType "none" avoids an instant stale-read refetch for
+      // anything currently mounted.
+      const opts = { refetchType: "none" as const }
+      qc.invalidateQueries({
+        queryKey: ["org", input.slug.toLowerCase()],
+        ...opts,
+      })
+      qc.invalidateQueries({ queryKey: ["orgs"], ...opts })
+      qc.invalidateQueries({ queryKey: ["builds"], ...opts })
     },
   })
 }

--- a/apps/web/src/lib/util/constants.ts
+++ b/apps/web/src/lib/util/constants.ts
@@ -37,6 +37,7 @@ export const API_URL =
 // External links
 export const EXTERNAL_LINKS = {
   github: "https://github.com/Reuzehagel/arsenyx",
+  reportIssue: "https://github.com/Reuzehagel/arsenyx/issues/new/choose",
   wiki: "https://wiki.warframe.com",
   apiBase: "https://api.arsenyx.com",
   // Donation destination surfaced by the footer + post-publish nudge.
@@ -61,6 +62,11 @@ export const FOOTER_LINKS = {
     { label: "Documentation", href: ROUTES.docs },
     { label: "Changelog", href: ROUTES.changelog },
     { label: "GitHub", href: EXTERNAL_LINKS.github, external: true },
+    {
+      label: "Report an Issue",
+      href: EXTERNAL_LINKS.reportIssue,
+      external: true,
+    },
   ],
   legal: [
     { label: "Privacy Policy", href: ROUTES.privacy },


### PR DESCRIPTION
Follow-up to #279. The toggle flipped optimistically, then visibly reverted: the eager `invalidateQueries` refetch of `/admin/orgs` was served a pre-write result by **Hyperdrive's query cache** (enabled by default: `max_age` 60s + 15s stale-while-revalidate), which stomped the optimistic value. Minutes later the cache turned over and the value 'arrived'. Same mechanism explains the public /orgs page needing repeated refreshes after toggling.

- `useAdminSetOrgVerified` no longer refetches the admin list after the PATCH — it confirms the react-query cache from the PATCH response, which is authoritative.
- The org page / directory / build-list invalidations now use `refetchType: 'none'` so mounted queries don't immediately re-read through the stale window; they refetch on next visit.

Verified locally: after the click, the only network call is the PATCH itself, and the row state sticks.

## Note for the underlying issue

This works around Hyperdrive read-after-write staleness for this one path, but every read-after-write on the site sits behind the same ~60-75s window (org settings edits, admin user flags, etc.). Worth considering disabling query caching on the Hyperdrive config (`wrangler hyperdrive update <id> --caching-disabled true`) — connection pooling is retained, and the site's own edge cache already covers the hot public reads.