### PR TITLE
docs(changelog): add July 3 entry for orgs, editor, and UX fixes

### DIFF
--- a/apps/web/src/data/changelog.ts
+++ b/apps/web/src/data/changelog.ts
@@ -11,6 +11,41 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-07-03",
+    changes: [
+      {
+        type: "feat",
+        description:
+          "Organizations can now be marked verified by an admin. Verified orgs render in purple across build cards, the build viewer header, org pages, and the directory, and sort first in the directory. Everyone else now renders in a muted gray instead.",
+      },
+      {
+        type: "fix",
+        description:
+          "Org members can now see their org's private and unlisted builds on the org page — they used to see only public builds, same as a logged-out visitor.",
+      },
+      {
+        type: "feat",
+        description:
+          "Ctrl+K and the footer now have a Report an Issue shortcut that jumps straight to a GitHub issue template.",
+      },
+      {
+        type: "fix",
+        description:
+          "Ability tooltips now render damage-type icons and line breaks correctly instead of showing raw tags like <br> and DT_SENTIENT_COLOR.",
+      },
+      {
+        type: "fix",
+        description:
+          "Elements now combine in slot order instead of equip order, so modding elements out of sequence no longer shows the wrong combined element until you reload the build.",
+      },
+      {
+        type: "fix",
+        description:
+          "Directory cards line up their member and build counts at the bottom of the card, even when one card has a longer description than its neighbors.",
+      },
+    ],
+  },
+  {
     date: "2026-07-01",
     changes: [
       {


### PR DESCRIPTION
## Summary
- Adds a July 3, 2026 changelog entry covering the user-facing PRs merged since the last entry (#277–#281)
- Org verification badges, private/unlisted build visibility for org members, ability-tooltip rendering, slot-order element combination, directory card alignment, and the report-an-issue shortcut

## Test plan
- [x] Verified the new entry renders correctly on `/changelog` in the local preview