### PR TITLE
fix(data): fixed incorrect Umbral scaling bonuses

### DIFF
--- a/apps/web/src/lib/stats/warframe.ts
+++ b/apps/web/src/lib/stats/warframe.ts
@@ -23,7 +23,7 @@ const UMBRAL_MODS = new Set([
   "Umbral Intensify",
   "Umbral Fiber",
 ])
-const UMBRAL_SET_BONUSES: Record<number, number> = { 1: 1.0, 2: 1.25, 3: 1.75 }
+const UMBRAL_SET_BONUSES: Record<number, number> = { 1: 1.0, 2: 1.3, 3: 1.8 }
 
 type RankUp = { health: number; shield: number; armor: number; energy: number }
 


### PR DESCRIPTION
This fixes the discrepancy between the data files and actual in-game Umbral mod values
Fixed Umbral set bonuses to match in-game values:
- 1x / 1.3x / 1.8x

instead of the previous:
- 1x / 1.25x / 1.75x